### PR TITLE
Corrected Readme Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,11 @@ In Rails 2.x, this code should be in config/initializers/recurly.rb
 In Sinatra, it should be within a `configure` block.
 
 
-Manual Setup via YAML
+Manual Setup via YAML or JSON
 --------------
-
 You can also configure Recurly via a YAML file by using:
 
-    Recurly.configure_via_yaml("./config/recurly.yml")
-
+    Recurly.configure_from_yaml("./config/recurly.yml")
 
 The Recurly Configuration YAML is in the format of:
 
@@ -63,6 +61,8 @@ The Recurly Configuration YAML is in the format of:
     password: myrecurlypassword
     site: https://myrecurlysite.recurly.com
 
+
+The same format could be applied in JSON instead of YAML using: Recurly.configure_from_json('path/to/file.json')
 
 Clearing test data (Rails3)
 ----------------


### PR DESCRIPTION
The Readme Docs indicate that "Recurly.config_via_yaml()" will load a yaml config file, but in fact the method is "Recurly.config_from_yaml()". I have corrected this in the readme, and noted that Recurly.config_from_json is also available.
