### PR TITLE
Allow erb scriptlets in yaml config file

### DIFF
--- a/lib/recurly/config_parser.rb
+++ b/lib/recurly/config_parser.rb
@@ -7,7 +7,7 @@ module Recurly
         path ||= Recurly.settings_path
         settings = {}
         if File.exists?(path)
-          settings = YAML.load_file(path) || {}
+          settings = YAML::load(ERB.new(File.read(path)).result) || {}
         else
           puts "\n#{path} file not found. Run rake recurly:setup to create one\n\n"
         end


### PR DESCRIPTION
Here's my recurly.yml

```

---
username:    <%= ENV['RECURLY_USERNAME'] %>
subdomain:   <%= ENV['RECURLY_SUBDOMAIN'] %>
environment: :<%= Rails.env.production?? 'production' : 'sandbox' %>
password:    <%= ENV['RECURLY_API_PASSWORD'] %>
private_key: <%= ENV['RECURLY_PRIVATE_KEY'] %>
```

This tiny patch makes that work.
