### PR TITLE
Make hashmaps compatible with Ruby 1.8.7

### DIFF
--- a/lib/recurly/verification.rb
+++ b/lib/recurly/verification.rb
@@ -48,15 +48,15 @@ module Recurly
 
     def sign_billing_info_update(account_code)
       generate_signature('billinginfoupdate', {
-        account_code: account_code
+        :account_code => account_code
       })
     end
 
     def sign_transaction(account_code, currency, amount_in_cents)
       generate_signature('transactioncreate', {
-        account_code: account_code,
-        currency: currency,
-        amount_in_cents: amount_in_cents
+        :account_code => account_code,
+        :currency => currency,
+        :amount_in_cents => amount_in_cents
       }) 
     end
 


### PR DESCRIPTION
With this simple change you can support poor Ruby 1.8.7 users. Thx a lot :-)
