### PR TITLE
Fix API inconsistency of Subscription#plan_code.

### DIFF
--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -20,6 +20,13 @@ module Recurly
       super
     end
 
+    # API inconsistency workaround: Pull plan_code into subscription to conform to known_attributes
+    def load(attributes, remove_root = false)
+      attributes = attributes.with_indifferent_access
+      attributes[:plan_code] ||= attributes[:plan][:plan_code] if attributes.include?(:plan)
+      super
+    end
+    
     def self.refund(account_code, refund_type = :partial)
       raise "Refund type must be :full, :partial, or :none." unless [:full, :partial, :none].include?(refund_type)
       Subscription.delete(nil, {:account_code => account_code, :refund => refund_type})

--- a/spec/integration/subscription_spec.rb
+++ b/spec/integration/subscription_spec.rb
@@ -21,6 +21,7 @@ module Recurly
         subscription = Subscription.find(account.account_code)
         subscription.state.should == "active"
         subscription.plan.plan_code.should == "paid"
+        subscription.plan_code.should == "paid"
       end
     end
 


### PR DESCRIPTION
Hi,

plan_code is listed as a known attribute of Subscription, however when looking up an existing Subscription (GET), plan_code is supplied as a nested value inside of a Plan resource. This change overrides Subscription#find and populates plan_code before returning the Subscription to the user.
