### PR TITLE
Fix for incorrect nested resource lookups in Rails 3.0 and before

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -12,7 +12,8 @@ if defined?(::Rails::VERSION::MAJOR)
     require 'patches/rails2/active_resource/connection'
   end
 
-  unless ::Rails::VERSION::MAJOR == 3 and ::Rails::VERSION::MINOR > 0
+  if ::Rails::VERSION::MAJOR == 2 or
+    (::Rails::VERSION::MAJOR == 3 and ::Rails::VERSION::MINOR == 0)
     # was fixed in Rails 3.1... see comments
     require 'patches/rails2/active_resource/base'
   end


### PR DESCRIPTION
This issue was unintentially fixed in Rails 3.1 by rails/rails@a962bfe47232200c20dce02047201247d24d77f7, but this patch will allow for model names matching nested Recurly resources (CreditCard, etc) in Rails 3.0 and before as well.

All unit tests pass.
## Explanation:

ActiveResource::Base#find_or_create_resource_for() is called for when loading
attributes containing a Hash (serialized object). In Rails 3.0 and before,
it would start by looking in the ancestors of the current class. This meant
that loading the "credit_card" attribute into a Recurly::BillingInfo record,
for instance, would cause it to look first in Recurly for the CreditCard
class. Because ActiveResource::Base also contains constants for all
ActiveRecord::Base classes (true, oddly enough), any model called CreditCard
would be instantiated instead of Recurly::BillingInfo::CreditCard.

To solve this, I've patched ActiveResource::Base#find_or_create_resource_for()
to match the behavior of Rails 3.1, looking first in the current class for
the constant before checking ancestors.
