### PR TITLE
backend support for optional signed parameters

### DIFF
--- a/spec/recurly/js_spec.rb
+++ b/spec/recurly/js_spec.rb
@@ -31,7 +31,7 @@ describe Recurly.js do
 
     it "must encode nested arrays and hashes" do
       digest.call(
-        { :a => [1, 2, 3], :b => { :c => '123', :d => '456' } }
+        :a => [1, 2, 3], :b => { :c => '123', :d => '456' }
       ).must_equal '[a:[1,2,3],b:[c:123,d:456]]'
     end
 
@@ -56,7 +56,6 @@ describe Recurly.js do
     let(:private_key) { '0123456789abcdef0123456789abcdef' }
     let(:timestamp) { 1312806801 }
     let(:signature) { "fb5194a51aa97996cdb995a89064764c5c1bfd93-#{timestamp}" }
-    let(:signature_extras) { "3fee8f858431b233ca835ce4750670163b57a397-#{timestamp}+account.first_name" }
 
     class MockTime
       class << self
@@ -76,25 +75,26 @@ describe Recurly.js do
     end
 
     it "must generate proper signatures" do
-      signed = sign.call 'update', :a => 'foo', :b => 'bar'
-      signed.must_equal signature
+      sig = sign.call 'update', :a => 'foo', :b => 'bar'
+      sig.must_equal signature
     end
 
     it "must sign subscription" do
-      sig = js.method(:sign_subscription).call 'acc', {:a => {:a1 => 'v'}}
+      sig = js.method(:sign_subscription).call 'acc', :a => { :a1 => 'v' }
       sig.must_equal 'f85e8ea59232af127ff417773027da927fcd15d0-1312806801+a.a1'
     end
 
     it "must sign billing_info" do
-      sig = js.method(:sign_billing_info).call 'acc', {:a => {:a1 => 'v'}}
+      sig = js.method(:sign_billing_info).call 'acc', :a => {:a1 => 'v'}
       sig.must_equal '796e4f02e24ee5fc8a248f8ff123749e08a033da-1312806801+a.a1'
     end
 
     it "must sign transaction" do
-      sig = js.method(:sign_transaction).call 50_00, 'USD', 'acc', {:a => {:a1 => 'v'}}
+      sig = js.method(:sign_transaction).call(
+        50_00, 'USD', 'acc', :a => {:a1 => 'v'}
+      )
       sig.must_equal '16754dea33128cb3a83bcd7ca937ca45742739e7-1312806801+a.a1'
     end
-
 
     it "must validate proper signatures" do
       verify.call 'update', :a => 'foo', :b => 'bar', :signature => signature
@@ -107,10 +107,12 @@ describe Recurly.js do
     end
 
     it "must merge extras into hmac and append their keys to the signature" do
-      signed = sign.call('update', {:a => 'foo', :b => 'bar'},
-        {:account => {:first_name => 'joe'}}
+      signed = sign.call('update', { :a => 'foo', :b => 'bar' },
+        { :acct => { :name => 'joe' } }
       )
-      signed.must_equal signature_extras
+      signed.must_equal(
+        "1b85c19394eaea131a8d43eaada91634625d8f18-#{timestamp}+acct.name"
+      )
     end
 
     it "must reject a stale signature" do


### PR DESCRIPTION
Would you review this Stephen?

Recurly.js needs to support optional params, the approach I've taken here is that all "extra" params given in a hashmap, that hashmap is recursed to its endpoints, creating a list of "keypaths" basically like paths in a filesystem structure.

The extra params are then merge!'d directly into the signature digest arguments. Later, the backend knows to add the associated parameters into its signed parameters by extracting the keypaths from the signature.
