### PR TITLE
don't traverse ancestors when using const_defined?/const_get

### DIFF
--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -369,8 +369,8 @@ module Recurly
         xml = XML.new xml
         if xml.name == member_name
           record = new
-        elsif Recurly.const_defined?(class_name = Helper.classify(xml.name))
-          klass = Recurly.const_get class_name
+        elsif Recurly.const_defined?(class_name = Helper.classify(xml.name), false)
+          klass = Recurly.const_get(class_name, false)
           record = klass.send :new
         elsif root = xml.root and root.elements.empty?
           return XML.cast root
@@ -398,7 +398,7 @@ module Recurly
 
           if el.children.empty? && href = el.attribute('href')
             resource_class = Recurly.const_get(
-              Helper.classify(el.attribute('type') || el.name)
+              Helper.classify(el.attribute('type') || el.name), false
             )
             record[el.name] = case el.name
             when *associations[:has_many]
@@ -464,7 +464,7 @@ module Recurly
         self::Associations.module_eval {
           define_method(member_name) { self[member_name] }
           if options.key?(:readonly) && options[:readonly] == false
-            associated = Recurly.const_get Helper.classify(member_name)
+            associated = Recurly.const_get Helper.classify(member_name), false
             define_method("#{member_name}=") { |member|
               associated_uri = "#{path}/#{member_name}"
               self[member_name] = case member
@@ -946,7 +946,7 @@ module Recurly
       when Array
         value.map { |each| fetch_association Helper.singularize(name), each }
       when Hash
-        Recurly.const_get(Helper.classify(name)).send :new, value
+        Recurly.const_get(Helper.classify(name), false).send :new, value
       when Proc, Resource, Resource::Pager, nil
         value
       else

--- a/lib/recurly/xml.rb
+++ b/lib/recurly/xml.rb
@@ -18,8 +18,8 @@ module Recurly
         else
           # FIXME: Move some of this logic to Resource.from_xml?
           if type and resource_name = Helper.classify(type)
-            if Recurly.const_defined? resource_name
-              resource_class = Recurly.const_get(Helper.classify(type))
+            if Recurly.const_defined? resource_name, false
+              resource_class = Recurly.const_get(Helper.classify(type), false)
               return resource_class.new resource_class.from_xml(el)
             end
           end


### PR DESCRIPTION
We have a CreditCard model defined (from our previous payment solution) in the global namespace. Recurly is accidentally trying to instantiate one of these when loading invoices, because of a "type=credit_card" attribute on transactions. So we got strange crashes regarding CreditCard.from_xml when pulling invoices from the API, that we traced down to the use of const_defined?/const_get with inheritance. 
