### PR TITLE
Expose API headers

### DIFF
--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -22,8 +22,21 @@ module Recurly
     )
 
     class << self
-      # @return [String]
-      attr_accessor :accept_language
+      # Additional HTTP headers sent with each API call
+      # @return [Hash{String => String}]
+      def headers
+        @headers ||= { 'Accept' => accept, 'User-Agent' => user_agent }
+      end
+
+      # @return [String, nil] Accept-Language header value
+      def accept_language
+        headers['Accept-Language']
+      end
+
+      # @param [String] language Accept-Language header value
+      def accept_language=(language)
+        headers['Accept-Language'] = language
+      end
 
       # @return [Net::HTTPOK, Net::HTTPResponse]
       # @raise [ResponseError] With a non-2xx status code.

--- a/lib/recurly/api/net_http_adapter.rb
+++ b/lib/recurly/api/net_http_adapter.rb
@@ -32,8 +32,7 @@ module Recurly
         }
 
         def request method, uri, options = {}
-          head = { 'Accept' => accept, 'User-Agent' => user_agent }
-          accept_language and head['Accept-Language'] ||= accept_language
+          head = headers.dup
           head.update options[:head] if options[:head]
           uri = base_uri + uri
           if options[:params] && !options[:params].empty?


### PR DESCRIPTION
Allows callers to globally set custom headers on Recurly API calls. Motivated by testing flexibility.

See recurly/recurly-client-ruby#57
