### PR TITLE
Remove headers with nil values

### DIFF
--- a/lib/recurly/api/net_http_adapter.rb
+++ b/lib/recurly/api/net_http_adapter.rb
@@ -34,6 +34,7 @@ module Recurly
         def request method, uri, options = {}
           head = headers.dup
           head.update options[:head] if options[:head]
+          head.delete_if { |_, value| value.nil? }
           uri = base_uri + uri
           if options[:params] && !options[:params].empty?
             uri += "?#{options[:params].map { |k, v| "#{k}=#{v}" }.join '&' }"


### PR DESCRIPTION
The change I previously contributed, #62, contains a bug.

In allowing clients to specify HTTP request headers, it allows header values to be set to `nil`. This was discovered because `Recurly::Railtie` sets the `Accept-Language` header to `request.env['HTTP_ACCEPT_LANGUAGE']`, but in a test environment this value is `nil` and causes an exception later within `Net::HTTP`.

This fix cleans the headers hash just prior to passing it to `Net::HTTP`.
