### PR TITLE
adds accounting_code to Plan attributes

### DIFF
--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -24,6 +24,7 @@ module Recurly
       trial_interval_unit
       total_billing_cycles
       created_at
+      accounting_code
     )
     alias to_param plan_code
   end


### PR DESCRIPTION
The accounting_code attribute of Plan objects was not exposed.
