### PR TITLE
exposes the subscription relationship of a transaction

### DIFF
--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -17,6 +17,8 @@ module Recurly
     belongs_to :account
 		# @return [Invoice, nil]
 		belongs_to :invoice
+		# @return [Subscription, nil]
+		belongs_to :subscription
 
     define_attribute_methods %w(
       uuid


### PR DESCRIPTION
Returns nil for transactions that are not associated with a subscription.
