### PR TITLE
Broken Invoice#pdf method

### DIFF
--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -53,7 +53,7 @@ module Recurly
     end
 
     def pdf
-      find to_param, :format => 'pdf'
+      self.class.find to_param, :format => 'pdf'
     end
 
     private


### PR DESCRIPTION
Calling `#pdf` on an invoice raises `NoMethodError: undefined method 'find' for #<Recurly::Invoice:...>` because it calls `find` on an instance, not the Invoice class.

I'm not sure the best way to test this with MiniTest::Spec, but in RSpec, or Mocha I would just set an expectation that the class method `Invoice.find` would be called with the invoice number and `:format => 'pdf'`.
