### PR TITLE
Make transaction_error.error_code available

### DIFF
--- a/lib/recurly/api/errors.rb
+++ b/lib/recurly/api/errors.rb
@@ -26,6 +26,10 @@ module Recurly
         ]
       end
 
+      def transaction_error_code
+        xml and xml.root and xml.text '//error_code'
+      end
+
       def symbol
         xml and xml.root and xml.text '/error/symbol'
       end

--- a/spec/recurly/transaction_spec.rb
+++ b/spec/recurly/transaction_spec.rb
@@ -21,6 +21,7 @@ describe Transaction do
         } 
       }
       error = proc { transaction.save }.must_raise Transaction::DeclinedError
+      error.transaction_error_code.must_equal("invalid_card_number")
       error.message.must_equal(
         "Your card number is not valid. Please update your card number."
       )


### PR DESCRIPTION
This makes the error_code available publicly.

``` xml
<errors>
  <transaction_error>
    <error_code>fraud_security_code</error_code>
    ...
```

Currently the only way to retrieve this is using private methods:

``` rb
error.send(:xml).text '//error_code'
```

I wasn't sure on the method name of `Error#transaction_error_code`. `#error_code` is already taken, but IMO that should probably be called `#http_status_code` or something similar.
