### PR TITLE
Added cgi require to js.rb

### DIFF
--- a/lib/recurly/js.rb
+++ b/lib/recurly/js.rb
@@ -1,5 +1,6 @@
 require 'openssl'
 require 'base64'
+require 'cgi'
 
 module Recurly
   # A collection of helper methods to use to verify


### PR DESCRIPTION
I'm making a demo app in sinatra to test this out, and js.rb wasn't requiring "cgi", but CGI.encode/decode are used. How has this not broken every recurly.js use? Does some Rails thing make CGI global?
