### PR TITLE
fix path for BillingInfo.find

### DIFF
--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -48,6 +48,21 @@ module Recurly
       super attributes
     end
 
+    class << self
+      # Overrides the inherited member_path method to allow for billing info's
+      # irregular URL structure.
+      #
+      # @return [String] The relative path to an account's billing info from the
+      #   API's base URI.
+      # @param uuid [String]
+      # @example
+      #   Recurly::BillingInfo.member_path "code"
+      #   # => "accounts/code/billing_info"
+      def member_path uuid
+        "accounts/#{uuid}/billing_info"
+      end
+    end
+
     # Billing info is only writeable through an {Account} instance.
     embedded!
   end

--- a/spec/recurly/billing_info_spec.rb
+++ b/spec/recurly/billing_info_spec.rb
@@ -1,4 +1,28 @@
 require 'spec_helper'
 
 describe BillingInfo do
+
+  describe ".find" do
+    it "must return an account's billing info when available" do
+      stub_api_request(
+        :get, 'accounts/abcdef1234567890/billing_info', 'billing_info/show-200'
+      )
+      billing_info = BillingInfo.find 'abcdef1234567890'
+      billing_info.must_be_instance_of BillingInfo
+      billing_info.first_name.must_equal 'Larry'
+      billing_info.last_name.must_equal 'David'
+      billing_info.card_type.must_equal 'Visa'
+      billing_info.last_four.must_equal '1111'
+      billing_info.city.must_equal 'Los Angeles'
+      billing_info.state.must_equal 'CA'
+    end
+
+    it "must raise an exception when unavailable" do
+      stub_api_request(
+        :get, 'accounts/abcdef1234567890/billing_info', 'accounts/show-404'
+      )
+      proc { BillingInfo.find 'abcdef1234567890' }.must_raise Resource::NotFound
+    end
+  end
+
 end


### PR DESCRIPTION
Right now this raises a `Recurly::Resource::NotFound` exception:

```
Recurly::BillingInfo.find('code')
```

But this returns the correct BillingInfo resource:

```
Recurly::BillingInfo.find(
  'https://api.recurly.com/v2/accounts/code/billing_info'
)
```

This commit fixes the first example.
