### PR TITLE
Fix XML serialization in ActiveResource to support YAML security patch

### DIFF
--- a/lib/patches/rails3/active_model/serializers/xml.rb
+++ b/lib/patches/rails3/active_model/serializers/xml.rb
@@ -1,0 +1,28 @@
+module ActiveModel
+  module Serializers
+    module Xml
+
+      # Patch for Rails 3.0 to properly serialize nil values (without type="yaml")
+      #
+      #   This issue was fixed in Rails 3.0.20 by this pull request:
+      #     https://github.com/rails/rails/pull/8853
+
+      class Serializer
+        class Attribute
+
+        protected
+
+          def compute_type
+            return if value.nil?
+            type = ActiveSupport::XmlMini::TYPE_NAMES[value.class.name]
+            type ||= :string if value.respond_to?(:to_str)
+            type ||= :yaml
+            type
+          end
+
+        end
+      end
+
+    end
+  end
+end

--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -5,20 +5,21 @@ require 'openssl'
 require 'addressable/uri'
 
 # load ActiveResource patches
-if defined?(::Rails::VERSION::MAJOR)
-  if ::Rails::VERSION::MAJOR == 3
-    require 'patches/rails3/active_resource/connection'
-  elsif ::Rails::VERSION::MAJOR == 2
-    require 'patches/rails2/active_resource/connection'
+if ::ActiveResource::VERSION::MAJOR == 3
+  if ::ActiveResource::VERSION::MINOR == 0 &&
+     ::ActiveResource::VERSION::TINY < 20
+    require 'patches/rails3/active_model/serializers/xml'
   end
-
-  if ::Rails::VERSION::MAJOR == 2 or
-    (::Rails::VERSION::MAJOR == 3 and ::Rails::VERSION::MINOR == 0)
-    # was fixed in Rails 3.1... see comments
-    require 'patches/rails2/active_resource/base'
-  end
+  require 'patches/rails3/active_resource/connection'
+elsif ::ActiveResource::VERSION::MAJOR == 2
+  require 'patches/rails2/active_resource/connection'
 end
 
+if ::ActiveResource::VERSION::MAJOR == 2 ||
+    (::ActiveResource::VERSION::MAJOR == 3 &&
+     ::ActiveResource::VERSION::MINOR == 0)
+  require 'patches/rails2/active_resource/base'
+end
 
 require 'recurly/version'
 require 'recurly/exceptions'
@@ -29,7 +30,7 @@ require 'recurly/rails3/railtie' if defined?(::Rails::Railtie)
 require 'recurly/base'
 
 # load rails2 fixes
-if defined?(::Rails::VERSION::MAJOR) and ::Rails::VERSION::MAJOR == 2
+if ::ActiveResource::VERSION::MAJOR == 2
   require 'recurly/rails2/compatibility'
 end
 
@@ -98,7 +99,7 @@ module Recurly
         end
       end
     end
-    
+
     def site_for_environment(environment)
       if environment == :development
         "http://api.lvh.me:3000"


### PR DESCRIPTION
With Rails <= 3.0.19, serializing nil values would result in an XML element with a 'type="yaml"' attribute. Because of the recent security patch, this causes an error to be raised on the consumer end.

This commit applies the same fix that is going into Rails 3.0.20, but hasn't been released yet:
  https://github.com/rails/rails/pull/8853

Signed-off-by: Stephen Celis stephen@recurly.com
Signed-off-by: Andrew Morton andrew@recurly.com
