### PR TITLE
Rails 2.x does not have ::ActiveResource::VERSION, revert to ::Rails::VE...

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -1,4 +1,5 @@
 require 'active_resource'
+require 'active_resource/version'
 require 'active_support/deprecation'
 require 'cgi'
 require 'openssl'


### PR DESCRIPTION
Rails 2.x (at least 2.3.15) does not have ::ActiveResource::VERSION, so revert to the original Rails version check
