### PR TITLE
Fixed exception when assigned empty value to verification_value

### DIFF
--- a/lib/recurly/xml.rb
+++ b/lib/recurly/xml.rb
@@ -42,7 +42,7 @@ module Recurly
             last = text[-4, 4]
             el.text = "#{text[0, text.length - 4].to_s.gsub(/\d/, '*')}#{last}"
           when "verification_value"
-            el.text = el.text.gsub(/\d/, '*')
+            el.text = el.text.to_s.gsub(/\d/, '*')
           end
         end
         xml.to_s

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -80,6 +80,12 @@ describe Account do
 XML
     end
 
+    it 'handle empty values for embedded billing info' do
+      stub_api_request :post, 'accounts', 'accounts/create-201'
+      @account.billing_info = { :verification_value => '' }
+      @account.save.must_equal true
+    end
+
     describe "persisted accounts" do
       before do
         @account.persist!


### PR DESCRIPTION
This fixes following issue :

``` ruby
Recurly::Account.create billing_info: { verification_value: '' }
# => NoMethodError: undefined method `gsub' for 0:Fixnum
```

Added also a test case for this.
