### PR TITLE
Fixed exception when sending empty credit card number

### DIFF
--- a/lib/recurly/xml.rb
+++ b/lib/recurly/xml.rb
@@ -38,7 +38,7 @@ module Recurly
           el = XML.new el
           case el.name
           when "number"
-            text = el.text
+            text = el.text.to_s
             last = text[-4, 4]
             el.text = "#{text[0, text.length - 4].to_s.gsub(/\d/, '*')}#{last}"
           when "verification_value"

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -80,6 +80,13 @@ describe Account do
 XML
     end
 
+    it 'handle empty values for embedded billing info' do
+      stub_api_request :post, 'accounts', 'accounts/create-201'
+      @account.billing_info = { :number => '' }
+      @account.save.must_equal true
+    end
+
+
     describe "persisted accounts" do
       before do
         @account.persist!


### PR DESCRIPTION
This fixes issue with exception being raised when sending empty credit card number.

``` ruby
Recurly::Account.create billing_info: { number: '' }
ArgumentError: wrong number of arguments(2 for 1)
        from /var/proj/own-dev3/vendor/gems/ruby/1.9.1/gems/recurly-2.1.5/lib/recurly/xml.rb:39:in `[]'
```
