### PR TITLE
make Pager#each work more sensibly

### DIFF
--- a/lib/recurly/resource/pager.rb
+++ b/lib/recurly/resource/pager.rb
@@ -2,7 +2,7 @@ module Recurly
   class Resource
     # Pages through an index resource, yielding records as it goes. It's rare
     # to instantiate one on its own: use {Resource.paginate},
-    # {Resource.find_each}, and <tt>Resource#{has_many_association}</tt>
+    # {Resource.each}, and <tt>Resource#{has_many_association}</tt>
     # instead.
     #
     # Because pagers handle +has_many+ associations, pagers can also build and
@@ -11,7 +11,7 @@ module Recurly
     # @example Through a resource class:
     #   Recurly::Account.paginate # => #<Recurly::Resource::Pager...>
     #
-    #   Recurly::Account.find_each { |a| p a }
+    #   Recurly::Account.each { |a| p a }
     # @example Through an resource instance:
     #   account.transactions
     #   # => #<Recurly::Resource::Pager...>
@@ -64,24 +64,27 @@ module Recurly
         @count ||= API.head(uri, @options)['X-Records'].to_i
       end
 
-      # @return [Array] Iterates through the current page of records.
+      # @return [Array,Enumerator] Iterates through the current page of records.
       # @yield [record]
-      def each
-        return enum_for :each unless block_given?
+      # Yields each record of the current page.
+      def each_current_page
+        return enum_for :each_current_page unless block_given?
         load! unless @collection
         @collection.each { |record| yield record }
       end
 
-      # @return [nil]
-      # @see Resource.find_each
+      # @return [Enumerator] Iterates through the current page of records.
       # @yield [record]
-      def find_each
-        return enum_for :find_each unless block_given?
+      # Yields each record of the collection, iterating over each page if there are multiple. 
+      def each
+        return enum_for :each unless block_given?
         # if links['prev'] exists, we are not on the first page; if not, we're on the first page or no page yet. 
         @collection = nil if links && links['prev']
         begin
-          each { |record| yield record }
+          each_current_page { |record| yield record }
         end while self.next
+        # we didn't collect the records array to return, so just return an enumerator 
+        enum_for :each
       end
 
       # @return [Array, nil] Refreshes the pager's collection of records with

--- a/lib/recurly/resource/pager.rb
+++ b/lib/recurly/resource/pager.rb
@@ -77,6 +77,8 @@ module Recurly
       # @yield [record]
       def find_each
         return enum_for :find_each unless block_given?
+        # if links['prev'] exists, we are not on the first page; if not, we're on the first page or no page yet. 
+        @collection = nil if links && links['prev']
         begin
           each { |record| yield record }
         end while self.next

--- a/lib/recurly/resource/pager.rb
+++ b/lib/recurly/resource/pager.rb
@@ -87,6 +87,9 @@ module Recurly
         enum_for :each
       end
 
+      # legacy method name; #each used to behave differently and find_each had each's behavior. 
+      alias find_each each
+
       # @return [Array, nil] Refreshes the pager's collection of records with
       #   the next page.
       def next

--- a/spec/recurly/resource/pager_spec.rb
+++ b/spec/recurly/resource/pager_spec.rb
@@ -15,9 +15,9 @@ describe Resource::Pager do
       )
     end
 
-    it "must iterate over a collection" do
+    it "must iterate over a page" do
       stub_api_request(:get, 'resources') { XML[200][:index] }
-      records = pager.each { |r|
+      records = pager.each_current_page { |r|
         r.must_be_instance_of pager.resource_class
       }
       records.must_be_instance_of Array
@@ -29,7 +29,14 @@ describe Resource::Pager do
       stub_api_request(:get, 'resources?cursor=1234567890&per_page=2') {
         XML[200][:index][1]
       }
-      pager.find_each { |r| r.must_be_instance_of pager.resource_class }
+      pager.each { |r| r.must_be_instance_of pager.resource_class }
+    end
+
+    it "must yield all records across pages" do
+      stub_api_request(:get, 'resources') { XML[200][:index] }
+      i=0
+      pager.each { |r| i += 1 }
+      i.must_equal 3
     end
 
     describe "#find_each" do

--- a/spec/recurly/resource/pager_spec.rb
+++ b/spec/recurly/resource/pager_spec.rb
@@ -25,11 +25,26 @@ describe Resource::Pager do
     end
 
     it "must iterate across pages" do
-      stub_api_request(:get, 'resources') { XML[200][:index] }
+      stub_api_request(:get, 'resources') { XML[200][:index][0] }
       stub_api_request(:get, 'resources?cursor=1234567890&per_page=2') {
-        XML[200][:index]
+        XML[200][:index][1]
       }
       pager.find_each { |r| r.must_be_instance_of pager.resource_class }
+    end
+
+    describe "#find_each" do
+      it "must restart from the beginning each time" do
+        stub_api_request(:get, 'resources') { XML[200][:index][0] }
+        stub_api_request(:get, 'resources?cursor=1234567890&per_page=2') {
+          XML[200][:index][1]
+        }
+        count1 = 0
+        count2 = 0
+        pager.find_each { |r| count1 += 1 }
+        pager.find_each { |r| count2 += 1 }
+        count1.must_equal 3
+        count2.must_equal count1
+      end
     end
 
     describe "#count" do

--- a/spec/recurly/resource/pager_spec.rb
+++ b/spec/recurly/resource/pager_spec.rb
@@ -33,7 +33,10 @@ describe Resource::Pager do
     end
 
     it "must yield all records across pages" do
-      stub_api_request(:get, 'resources') { XML[200][:index] }
+      stub_api_request(:get, 'resources') { XML[200][:index][0] }
+      stub_api_request(:get, 'resources?cursor=1234567890&per_page=2') {
+        XML[200][:index][1]
+      }
       i=0
       pager.each { |r| i += 1 }
       i.must_equal 3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ EOR
       <<EOR
 HTTP/1.1 200 OK
 Link: \
-<https://api.recurly.com/v2/resources?per_page=2>; rel="start"
+<https://api.recurly.com/v2/resources?per_page=2>; rel="start", <https://api.recurly.com/v2/resources?per_page=2&cursor=-11306277>; rel="prev"
 X-Records: 3
 
 <resources>


### PR DESCRIPTION
I've changed Pager#each, and thereby all other Enumerable methods of Pager, to behave the way that #find_each used to behave - that being the way <i>every other enumerable in ruby behaves</i>. 

when I do, say, `plan.add_ons.each`, I want to iterate over each add-on. not the first 50 add-ons, or any other first _n_ add-ons. I cannot imagine where I would want 50 add-ons but not the 51st. thus the former, page-specific behavior of #each is relegate to #each_current_page. 

I was bitten by records not being returned from #each - i.e., #each not behaving in a sensible and predictable manner, and hope to save others from this. 

this incidentally includes a fix for #find_each being broken and not yielding the same records each time it is called. as I do not know if this will prove too API-breaking, I will make a separate pull request for only that fix, but I am hoping the whole thing will be merged. 
