### PR TITLE
fix broken Pager#find_each

### DIFF
--- a/lib/recurly/resource/pager.rb
+++ b/lib/recurly/resource/pager.rb
@@ -77,6 +77,8 @@ module Recurly
       # @yield [record]
       def find_each
         return enum_for :find_each unless block_given?
+        # if links['prev'] exists, we are not on the first page; if not, we're on the first page or no page yet. 
+        @collection = nil if links && links['prev']
         begin
           each { |record| yield record }
         end while self.next

--- a/spec/recurly/resource/pager_spec.rb
+++ b/spec/recurly/resource/pager_spec.rb
@@ -25,11 +25,26 @@ describe Resource::Pager do
     end
 
     it "must iterate across pages" do
-      stub_api_request(:get, 'resources') { XML[200][:index] }
+      stub_api_request(:get, 'resources') { XML[200][:index][0] }
       stub_api_request(:get, 'resources?cursor=1234567890&per_page=2') {
-        XML[200][:index]
+        XML[200][:index][1]
       }
       pager.find_each { |r| r.must_be_instance_of pager.resource_class }
+    end
+
+    describe "#find_each" do
+      it "must restart from the beginning each time" do
+        stub_api_request(:get, 'resources') { XML[200][:index][0] }
+        stub_api_request(:get, 'resources?cursor=1234567890&per_page=2') {
+          XML[200][:index][1]
+        }
+        count1 = 0
+        count2 = 0
+        pager.find_each { |r| count1 += 1 }
+        pager.find_each { |r| count2 += 1 }
+        count1.must_equal 3
+        count2.must_equal count1
+      end
     end
 
     describe "#count" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ EOR
       <<EOR
 HTTP/1.1 200 OK
 Link: \
-<https://api.recurly.com/v2/resources?per_page=2>; rel="start"
+<https://api.recurly.com/v2/resources?per_page=2>; rel="start", <https://api.recurly.com/v2/resources?per_page=2&cursor=-11306277>; rel="prev"
 X-Records: 3
 
 <resources>


### PR DESCRIPTION
this makes Pager#find_each return a consistent set of records each time it is called. it is included as part of #106 and can be ignored if that one is merged, but if that one does not make it, this one at least should. 
