### PR TITLE
remove deprecated ActiveSupport Memoizable in favor of plain ruby memoization

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -70,45 +70,39 @@ module Recurly
     end
 
     def charges(status = :all)
-      Charge.list(account_code, status)
+      @_charges ||= Charge.list(account_code, status)
     end
-    memoize :charges
 
     def lookup_charge(id)
       Charge.lookup(account_code, id)
     end
 
     def credits
-      Credit.list(account_code)
+      @_credits ||= Credit.list(account_code)
     end
-    memoize :credits
 
     def lookup_credit(id)
       Credit.lookup(account_code, id)
     end
 
     def transactions(status)
-      Transaction.list_for_account(account_code, status)
+      @_transactions ||= Transaction.list_for_account(account_code, status)
     end
-    memoize :transactions
 
     def lookup_transaction(id)
       Transaction.lookup(account_code, id)
     end
 
     def invoices
-      Invoice.list(account_code)
+      @_invoices ||= Invoice.list(account_code)
     end
-    memoize :invoices
 
     def lookup_invoice(id)
       Invoice.lookup(account_code, id)
     end
 
     def coupon
-      Coupon.find(account_code)
+      @_coupons ||= Coupon.find(account_code)
     end
-    memoize :coupon
-
   end
 end

--- a/lib/recurly/base.rb
+++ b/lib/recurly/base.rb
@@ -1,10 +1,6 @@
-require 'active_support/memoizable'
-
 module Recurly
 
   class Base < ActiveResource::Base
-    extend ActiveSupport::Memoizable
-
     self.format = Recurly::Formats::XmlWithErrorsFormat.new
 
     def update_only
@@ -104,7 +100,7 @@ module Recurly
         errors.from_xml xml
         raise
       end
-      
+
       # Patched to read errors with field information
       def load_errors_from_array(new_errors, save_cache = false)
         errors.clear unless save_cache


### PR DESCRIPTION
As of 3.2.13, ActiveSupport has deprecated the Memoizable mixin in favor of plain ruby memoization.  This updates the 0.4.16 Recurly gem to remove the deprecation warnings on startup.
