### PR TITLE
Add subscription change preview endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="unreleased"></a>
+## Unreleased
+
+### Features
+
+* Added subscription change preview: `subscription.preview` [57a69d3](https://github.com/recurly/recurly-client-ruby/commit/57a69d3301497774e7d34dfe9095908ed2210de7)
+* Added subscription estimated cost for new and change previews: `subscription.cost_in_cents` [57a69d3](https://github.com/recurly/recurly-client-ruby/commit/57a69d3301497774e7d34dfe9095908ed2210de7)
+
 <a name="v2.3.0"></a>
 ## v2.3.0 (2014-5-14)
 

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -2,8 +2,6 @@ module Recurly
   class Subscription < Resource
     autoload :AddOns, 'recurly/subscription/add_ons'
 
-    class NotPreviewableError < StandardError; end
-
     # @macro [attach] scope
     #   @scope class
     #   @return [Pager<Subscription>] A pager that yields +$1+ subscriptions.
@@ -31,6 +29,7 @@ module Recurly
       uuid
       state
       unit_amount_in_cents
+      cost_in_cents
       currency
       quantity
       activated_at
@@ -58,8 +57,6 @@ module Recurly
     end
 
     def preview
-      raise NotPreviewableError.new('Cannot preview an existing subscription') unless new_record?
-
       clear_errors
       @response = API.send(:post, "#{path}/preview", to_xml)
       reload response

--- a/spec/fixtures/subscriptions/preview-200-change.xml
+++ b/spec/fixtures/subscriptions/preview-200-change.xml
@@ -1,0 +1,68 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890">
+  <account href="https://api.recurly.com/v2/accounts/account_code"/>
+  <plan href="https://api.recurly.com/v2/plans/plan_code">
+    <plan_code>plan_code</plan_code>
+    <name>A Man, a Plan, a Canal: Panama</name>
+  </plan>
+  <uuid>abcdef1234567890</uuid>
+  <state>active</state>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <currency>USD</currency>
+  <quantity type="integer">5</quantity>
+  <activated_at type="datetime">2014-05-20T16:29:59Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <total_billing_cycles nil="nil"></total_billing_cycles>
+  <remaining_billing_cycles nil="nil"></remaining_billing_cycles>
+  <current_period_started_at type="datetime">2014-05-20T16:29:59Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2014-06-20T16:29:59Z</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <cost_in_cents type="integer">5000</cost_in_cents>
+  <subscription_add_ons type="array">
+  </subscription_add_ons>
+  <invoice href="">
+    <account href="https://api.recurly.com/v2/accounts/account_code"/>
+    <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
+    <uuid>abcdefg123</uuid>
+    <state>open</state>
+    <invoice_number nil="nil"></invoice_number>
+    <po_number nil="nil"></po_number>
+    <vat_number></vat_number>
+    <subtotal_in_cents type="integer">5000</subtotal_in_cents>
+    <tax_in_cents type="integer">0</tax_in_cents>
+    <total_in_cents type="integer">5000</total_in_cents>
+    <currency>USD</currency>
+    <created_at nil="nil"></created_at>
+    <closed_at nil="nil"></closed_at>
+    <line_items type="array">
+      <adjustment href="https://api.recurly.com/v2/adjustments/abcdefg111" type="charge">
+        <account href="https://api.recurly.com/v2/accounts/account_code"/>
+        <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
+        <uuid>abcdefg111</uuid>
+        <state>pending</state>
+        <description>plan_code</description>
+        <accounting_code></accounting_code>
+        <product_code>plan_code</product_code>
+        <origin>plan</origin>
+        <unit_amount_in_cents type="integer">5000</unit_amount_in_cents>
+        <quantity type="integer">5</quantity>
+        <discount_in_cents type="integer">0</discount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <total_in_cents type="integer">5000</total_in_cents>
+        <currency>USD</currency>
+        <taxable type="boolean">false</taxable>
+        <tax_exempt type="boolean">false</tax_exempt>
+        <start_date type="datetime">2014-05-20T18:14:08Z</start_date>
+        <end_date type="datetime">2014-06-20T16:29:59Z</end_date>
+        <created_at nil="nil"></created_at>
+      </adjustment>
+    </line_items>
+    <transactions type="array">
+    </transactions>
+  </invoice>
+</subscription>

--- a/spec/fixtures/subscriptions/preview-200-new.xml
+++ b/spec/fixtures/subscriptions/preview-200-new.xml
@@ -1,0 +1,28 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription href="">
+  <account href="https://api.recurly.com/v2/accounts/account_code"/>
+  <plan href="https://api.recurly.com/v2/plans/plan_code">
+    <plan_code>plan_code</plan_code>
+    <name>A Man, a Plan, a Canal: Panama</name>
+  </plan>
+  <uuid>abcdef1234567890</uuid>
+  <state>pending</state>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <currency>USD</currency>
+  <quantity type="integer">1</quantity>
+  <activated_at nil="nil"></activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <total_billing_cycles nil="nil"></total_billing_cycles>
+  <remaining_billing_cycles nil="nil"></remaining_billing_cycles>
+  <current_period_started_at type="datetime">2014-05-20T18:20:01Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2014-05-20T18:20:01Z</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <cost_in_cents type="integer">1000</cost_in_cents>
+  <subscription_add_ons type="array">
+  </subscription_add_ons>
+</subscription>

--- a/spec/fixtures/subscriptions/show-200-noinvoice.xml
+++ b/spec/fixtures/subscriptions/show-200-noinvoice.xml
@@ -14,7 +14,7 @@ Content-Type: application/xml; charset=utf-8
   <net_terms type="integer">10</net_terms>
   <collection_method>manual</collection_method>
   <po_number>1000</po_number>
-  <total_amount_in_cents type="integer">1000</total_amount_in_cents>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
   <activated_at type="datetime">2011-04-30T07:00:00Z</activated_at>
   <canceled_at nil="nil"></canceled_at>
   <expires_at nil="nil"></expires_at>
@@ -24,6 +24,6 @@ Content-Type: application/xml; charset=utf-8
   <trial_ends_at nil="nil"></trial_ends_at>
   <subscription_add_ons type="array">
   </subscription_add_ons>
-  <a name="cancel" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/cancel" method="put"/> 
+  <a name="cancel" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/cancel" method="put"/>
   <a name="terminate" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/terminate" method="put"/>
 </subscription>

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -8,6 +8,7 @@ describe Subscription do
       expected_attributes = %w{ uuid
                                 state
                                 unit_amount_in_cents
+                                cost_in_cents
                                 currency
                                 quantity
                                 activated_at
@@ -254,13 +255,30 @@ describe Subscription do
   end
 
   describe 'previewing' do
-    it 'cannot preview an existing subscription' do
+    it 'previews new subscriptions' do
+      stub_api_request :post, 'subscriptions/preview', 'subscriptions/preview-200-new'
+
+      subscription = Subscription.preview(
+        plan_code: 'plan_code',
+        currency: 'USD',
+        account: {
+          account_code: 'account_code',
+        }
+      )
+
+      subscription.plan.plan_code.must_equal 'plan_code'
+    end
+
+    it 'previews subscription changes' do
       stub_api_request :get, 'subscriptions/abcdef1234567890', 'subscriptions/show-200-noinvoice'
+      stub_api_request :post, 'subscriptions/abcdef1234567890/preview', 'subscriptions/preview-200-change'
 
       subscription = Subscription.find 'abcdef1234567890'
-      assert_raises Subscription::NotPreviewableError do
-        subscription.preview
-      end
+      subscription.quantity = 5
+      subscription.preview
+
+      subscription.cost_in_cents.must_equal subscription.unit_amount_in_cents * 5
+      subscription.invoice.must_be_instance_of Invoice
     end
   end
 end


### PR DESCRIPTION
This adds support for Subscription Change Preview http://docs.recurly.com/api/subscriptions#sub-change-preview.

Remember that previews and saving is mutually exclusive, so you cannot do a call chain like:

`subscription.preview.save`

And expect it to save the subscription.

cc/ @drewish @chrissrogers 
