### PR TITLE
Remove usage of deprecated URI.escape

### DIFF
--- a/lib/recurly/api/net_http_adapter.rb
+++ b/lib/recurly/api/net_http_adapter.rb
@@ -36,7 +36,7 @@ module Recurly
           head = headers.dup
           head.update options[:head] if options[:head]
           head.delete_if { |_, value| value.nil? }
-          uri = base_uri + URI.escape(uri)
+          uri = base_uri + uri
           if options[:params] && !options[:params].empty?
             pairs = options[:params].map { |key, value|
               "#{CGI.escape key.to_s}=#{CGI.escape value.to_s}"

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -184,7 +184,12 @@ module Recurly
       #   Recurly::Account.member_path "code" # => "accounts/code"
       #   Recurly::Account.member_path nil    # => "accounts"
       def member_path uuid
-        [collection_path, uuid].compact.join '/'
+        escaped_uuid = CGI.escape(uuid.to_s)
+        if escaped_uuid.empty?
+          collection_path
+        else
+          "#{collection_path}/#{escaped_uuid}"
+        end
       end
 
       # @return [Array] Per attribute, defines readers, writers, boolean and


### PR DESCRIPTION
URI.escape is considered harmful and deprecated. It also raises many
warnings when running specs. This commit removes URI.escape and uses
CGI.escape on the uuid of resources.
