### PR TITLE
add bulk parameter

### DIFF
--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -50,6 +50,7 @@ module Recurly
       tax_in_cents
       tax_type
       tax_rate
+      bulk
     )
     alias to_param uuid
 

--- a/spec/fixtures/subscriptions/serialize-with-bulk.xml
+++ b/spec/fixtures/subscriptions/serialize-with-bulk.xml
@@ -1,0 +1,1 @@
+<subscription><account><account_code>1</account_code><billing_info><month>1</month><number>4111-1111-1111-1111</number><year>2014</year></billing_info><email>verena@example.com</email><first_name>Verena</first_name><last_name>Example</last_name></account><bulk>true</bulk><currency>EUR</currency><plan_code>gold</plan_code></subscription>

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -28,7 +28,8 @@ describe Subscription do
                                 tax_type
                                 tax_rate
                                 total_billing_cycles
-                                remaining_billing_cycles}
+                                remaining_billing_cycles
+                                bulk}
 
         subject.attribute_names.sort.must_equal expected_attributes.sort
       end
@@ -88,6 +89,12 @@ describe Subscription do
       subscription = Subscription.find 'abc1234'
       subscription.tax_type.must_equal('usst')
       subscription.tax_in_cents.must_equal(0)
+    end
+
+    it "properly serializes bulk attribute" do
+      attributes[:bulk] = true
+      subscription = Subscription.new attributes
+      subscription.to_xml.must_equal get_raw_xml("subscriptions/serialize-with-bulk.xml")
     end
   end
 


### PR DESCRIPTION
We have recently added this parameter to the Subscription model to allow bulk creation of subscriptions (bypassing the 60 second check).
