### PR TITLE
Add entity_use_code to account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="unreleased"></a>
+## Unreleased
+
+### Features
+
+* Added account `entity_use_code` when the site is integrated with Avalara [PR](https://github.com/recurly/recurly-client-ruby/pull/147)
+
 <a name="v2.3.1"></a>
 ## v2.3.1 (2104-5-23)
 

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -36,6 +36,7 @@ module Recurly
       vat_number
       address
       tax_exempt
+      entity_use_code
       created_at
     )
     alias to_param account_code

--- a/spec/fixtures/accounts/show-200.xml
+++ b/spec/fixtures/accounts/show-200.xml
@@ -19,6 +19,7 @@ Content-Type: application/xml; charset=utf-8
   <hosted_login_token>18d935f06b0547ddad8cdf2490ac802e</hosted_login_token>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
   <vat_number>12345-67</vat_number>
+  <entity_use_code>I</entity_use_code>
   <address>
     <address1>123 Main St.</address1>
     <address2 nil="nil"></address2>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -36,6 +36,7 @@ describe Account do
       account.first_name.must_equal 'Larry'
       account.last_name.must_equal 'David'
       account.accept_language.must_equal 'en-US'
+      account.entity_use_code.must_equal 'I'
       account.vat_number.must_equal '12345-67'
       account.address.address1.must_equal '123 Main St.'
       account.address.city.must_equal 'San Francisco'


### PR DESCRIPTION
From our recent integration with Avalara, we now give merchants the ability to set their account tax use code.

cc/ @chrissrogers 
