### PR TITLE
Fixes issue with broken association lookups

### DIFF
--- a/lib/recurly/api/net_http_adapter.rb
+++ b/lib/recurly/api/net_http_adapter.rb
@@ -36,7 +36,7 @@ module Recurly
           head = headers.dup
           head.update options[:head] if options[:head]
           head.delete_if { |_, value| value.nil? }
-          uri = base_uri + URI.escape(uri)
+          uri = base_uri + uri
           if options[:params] && !options[:params].empty?
             pairs = options[:params].map { |key, value|
               "#{CGI.escape key.to_s}=#{CGI.escape value.to_s}"

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -1,4 +1,5 @@
 require 'date'
+require 'erb'
 
 module Recurly
   # The base class for all Recurly resources (e.g. {Account}, {Subscription},
@@ -184,6 +185,7 @@ module Recurly
       #   Recurly::Account.member_path "code" # => "accounts/code"
       #   Recurly::Account.member_path nil    # => "accounts"
       def member_path uuid
+        uuid = ERB::Util.url_encode(uuid) if uuid
         [collection_path, uuid].compact.join '/'
       end
 

--- a/spec/fixtures/accounts/show-200-space.xml
+++ b/spec/fixtures/accounts/show-200-space.xml
@@ -1,0 +1,31 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/my%20account">
+  <adjustments href="https://api.recurly.com/v2/accounts/my%20account/adjustments" />
+  <billing_info href="https://api.recurly.com/v2/accounts/my%20account/billing_info" />
+  <invoices href="https://api.recurly.com/v2/accounts/my%20account/invoices" />
+  <subscriptions href="https://api.recurly.com/v2/accounts/my%20account/subscriptions" />
+  <transactions href="https://api.recurly.com/v2/accounts/my%20account/transactions" />
+  <account_code>my account</account_code>
+  <state>active</state>
+  <username>my account</username>
+  <email />
+  <first_name />
+  <last_name />
+  <company_name />
+  <vat_number />
+  <address>
+    <address1 />
+    <address2 />
+    <city />
+    <state />
+    <zip />
+    <country />
+    <phone />
+  </address>
+  <accept_language nil="nil" />
+  <hosted_login_token>d75e6a51189ca6ffe19d519d5da0aaa7</hosted_login_token>
+  <created_at type="datetime">2014-08-04T23:18:21Z</created_at>
+</account>

--- a/spec/fixtures/accounts/subscriptions/index-200-space.xml
+++ b/spec/fixtures/accounts/subscriptions/index-200-space.xml
@@ -1,0 +1,33 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/my%20account/subscriptions.xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscriptions type="array">
+  <subscription href="https://api.recurly.com/v2/subscriptions/2ad6a72fd96eaee2b26f1542819a4206">
+    <account href="https://api.recurly.com/v2/accounts/my%20account" />
+    <invoice href="https://api.recurly.com/v2/invoices/1000" />
+    <plan href="https://api.recurly.com/v2/plans/basic">
+    <plan_code>basic</plan_code>
+      <name>Basic Plan</name>
+    </plan>
+    <uuid>2ad6a72fd96eaee2b26f1542819a4206</uuid>
+    <state>active</state>
+    <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+    <currency>USD</currency>
+    <quantity type="integer">1</quantity>
+    <activated_at type="datetime">2014-10-31T20:18:27Z</activated_at>
+    <canceled_at nil="nil" />
+    <expires_at nil="nil" />
+    <total_billing_cycles nil="nil" />
+    <remaining_billing_cycles nil="nil" />
+    <current_period_started_at type="datetime">2014-10-31T20:18:27Z</current_period_started_at>
+    <current_period_ends_at type="datetime">2014-11-30T20:18:27Z</current_period_ends_at>
+    <trial_started_at nil="nil" />
+    <trial_ends_at nil="nil" />
+    <subscription_add_ons type="array"></subscription_add_ons>
+    <a name="cancel" href="https://api.recurly.com/v2/subscriptions/2ad6a72fd96eaee2b26f1542819a4206/cancel" method="put" />
+    <a name="terminate" href="https://api.recurly.com/v2/subscriptions/2ad6a72fd96eaee2b26f1542819a4206/terminate" method="put" />
+    <a name="postpone" href="https://api.recurly.com/v2/subscriptions/2ad6a72fd96eaee2b26f1542819a4206/postpone" method="put" />
+  </subscription>
+</subscriptions>

--- a/spec/fixtures/accounts/subscriptions/index-200.xml
+++ b/spec/fixtures/accounts/subscriptions/index-200.xml
@@ -1,0 +1,33 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions.xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscriptions type="array">
+  <subscription href="https://api.recurly.com/v2/subscriptions/2ad6a72fd96eaee2b26f1542819a4206">
+    <account href="https://api.recurly.com/v2/accounts/abcdef1234567890" />
+    <invoice href="https://api.recurly.com/v2/invoices/1000" />
+    <plan href="https://api.recurly.com/v2/plans/basic">
+    <plan_code>basic</plan_code>
+      <name>Basic Plan</name>
+    </plan>
+    <uuid>2ad6a72fd96eaee2b26f1542819a4206</uuid>
+    <state>active</state>
+    <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+    <currency>USD</currency>
+    <quantity type="integer">1</quantity>
+    <activated_at type="datetime">2014-10-31T20:18:27Z</activated_at>
+    <canceled_at nil="nil" />
+    <expires_at nil="nil" />
+    <total_billing_cycles nil="nil" />
+    <remaining_billing_cycles nil="nil" />
+    <current_period_started_at type="datetime">2014-10-31T20:18:27Z</current_period_started_at>
+    <current_period_ends_at type="datetime">2014-11-30T20:18:27Z</current_period_ends_at>
+    <trial_started_at nil="nil" />
+    <trial_ends_at nil="nil" />
+    <subscription_add_ons type="array"></subscription_add_ons>
+    <a name="cancel" href="https://api.recurly.com/v2/subscriptions/2ad6a72fd96eaee2b26f1542819a4206/cancel" method="put" />
+    <a name="terminate" href="https://api.recurly.com/v2/subscriptions/2ad6a72fd96eaee2b26f1542819a4206/terminate" method="put" />
+    <a name="postpone" href="https://api.recurly.com/v2/subscriptions/2ad6a72fd96eaee2b26f1542819a4206/postpone" method="put" />
+  </subscription>
+</subscriptions>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -165,4 +165,27 @@ XML
       )
     end
   end
+
+  describe "associations" do
+    let(:account) {
+      stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-200'
+      stub_api_request :get, 'accounts/abcdef1234567890/subscriptions', 'accounts/subscriptions/index-200'
+      Account.find 'abcdef1234567890'
+    }
+
+    it "retrieves associations" do
+      account.subscriptions.first.must_be_instance_of Subscription
+    end
+
+    describe "when an account_code contains spaces" do
+      let(:account) {
+        stub_api_request :get, 'accounts/my%20account', 'accounts/show-200-space'
+        stub_api_request :get, 'accounts/my%20account/subscriptions', 'accounts/subscriptions/index-200-space'
+        Account.find 'my account'
+      }
+      it "retrieves associations" do
+        account.subscriptions.first.must_be_instance_of Subscription
+      end
+    end
+  end
 end


### PR DESCRIPTION
##### Summary
- Associations where the parent resource URI contained an encoded character resulted in double-encoding the dependent association collection path
- URI escaping is removed from the HTTP adapter, and escaping now occurs only when building a resource member path
- Association urls are returned properly encoded by the api
- Fixes #110 
