### PR TITLE
Add tax_code to plan, add on and adjustment

### DIFF
--- a/lib/recurly/add_on.rb
+++ b/lib/recurly/add_on.rb
@@ -9,6 +9,7 @@ module Recurly
       default_quantity
       unit_amount_in_cents
       display_quantity_on_hosted_page
+      tax_code
       created_at
     )
     alias to_param add_on_code

--- a/lib/recurly/adjustment.rb
+++ b/lib/recurly/adjustment.rb
@@ -29,6 +29,7 @@ module Recurly
       total_in_cents
       currency
       tax_exempt
+      tax_code
       tax_details
       product_code
       start_date

--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -25,6 +25,7 @@ module Recurly
       total_billing_cycles
       accounting_code
       tax_exempt
+      tax_code
       created_at
     )
     alias to_param plan_code


### PR DESCRIPTION
Used in tax calculations for VAT 2015 and Avalara integration taxes only.

Valid tax_code values for VAT 2015 taxes are unknown, digital and physical. Valid tax_code values for Avalara integration taxes can be found in the Avalara documentation.

Approvers: @cbarton

Tests:
On a site with VAT 2015 and Avalara integration taxes enabled:
- Create/Update a plan, add_on and adjustment with a valid tax_code and verify there isn't an error
- Get the created/updated plan, add_on and adjustment and verify that the tax_code is returned in the results
- Attempt to create/update a plan, add_on and adjustment with an invalid tax_code and verify that an error is returned in the results
  On a site without VAT 2015 and Avalara integration taxes enabled:
- Get a plan, add_on and adjustment and verify that the tax_code is not returned in the results
- Attempt to create/update a plan, add_on and adjustment with a tax_code and verify that an error is returned in the results
