### PR TITLE
Threadsafe Recurly.api_key

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -49,13 +49,17 @@ module Recurly
     # @return [String] An API key.
     # @raise [ConfigurationError] If not configured.
     def api_key
-      Thread.current[:recurly_api_key] or raise(
-          ConfigurationError, "Recurly.api_key not configured"
-      )
+      Thread.current[:recurly_api_key] or (defined? @api_key and @api_key) or raise(
+            ConfigurationError, "Recurly.api_key not configured"
+        )
     end
 
     def api_key=(api_key)
-      Thread.current[:recurly_api_key] = api_key
+      if Thread.main == Thread.current
+        @api_key = api_key
+      else
+        Thread.current[:recurly_api_key] = api_key
+      end
     end
 
     # @return [String, nil] A default currency.

--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -49,11 +49,14 @@ module Recurly
     # @return [String] An API key.
     # @raise [ConfigurationError] If not configured.
     def api_key
-      defined? @api_key and @api_key or raise(
-        ConfigurationError, "Recurly.api_key not configured"
+      Thread.current[:recurly_api_key] or raise(
+          ConfigurationError, "Recurly.api_key not configured"
       )
     end
-    attr_writer :api_key
+
+    def api_key=(api_key)
+      Thread.current[:recurly_api_key] = api_key
+    end
 
     # @return [String, nil] A default currency.
     def default_currency

--- a/spec/recurly_spec.rb
+++ b/spec/recurly_spec.rb
@@ -11,6 +11,9 @@ describe Recurly do
     end
 
     it "must raise an exception when not set" do
+      if Recurly.instance_variable_defined? :@api_key
+        Recurly.send :remove_instance_variable, :@api_key
+      end
       Thread.new {
         proc { Recurly.api_key }.must_raise ConfigurationError
       }.join
@@ -19,6 +22,12 @@ describe Recurly do
     it "must raise an exception when set to nil" do
       Recurly.api_key = nil
       proc { Recurly.api_key }.must_raise ConfigurationError
+    end
+
+    it "has different api keys for different threads" do
+      Recurly.api_key = "123"
+      Thread.new { Recurly.api_key = "456" }.join
+      Recurly.api_key.must_equal "123"
     end
   end
 end

--- a/spec/recurly_spec.rb
+++ b/spec/recurly_spec.rb
@@ -11,10 +11,9 @@ describe Recurly do
     end
 
     it "must raise an exception when not set" do
-      if Recurly.instance_variable_defined? :@api_key
-        Recurly.send :remove_instance_variable, :@api_key
-      end
-      proc { Recurly.api_key }.must_raise ConfigurationError
+      Thread.new {
+        proc { Recurly.api_key }.must_raise ConfigurationError
+      }.join
     end
 
     it "must raise an exception when set to nil" do


### PR DESCRIPTION
Very straightforward solution, which brings a undesired behaviour - code, that relies on Recurly.api_key being set by some other thread,  will fail.
So, second commit to fix this issue, but for a main thread only - if you set Recurly.api_key in the main thread, it will be avail to all threads run afterwards. 
But if any of these threads sets its own key - it will use its own key.