### PR TITLE
Add support for original_invoice link on refund invoices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <a name="unreleased"></a>
 ## Unreleased
+* Add `Invoice#original_invoice` for refund invoices [PR](https://github.com/recurly/recurly-client-ruby/pull/169)
 
 <a name="v2.3.8"></a>
 ## v2.3.8 (2014-12-22)

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -17,6 +17,8 @@ module Recurly
     belongs_to :account
     # @return [Subscription]
     belongs_to :subscription
+    # @return [Invoice]
+    belongs_to :original_invoice, class_name: 'Invoice'
 
     # @return [Redemption]
     has_one :redemption

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -1,5 +1,6 @@
 require 'date'
 require 'erb'
+require 'recurly/resource/association'
 
 module Recurly
   # The base class for all Recurly resources (e.g. {Account}, {Subscription},
@@ -404,14 +405,15 @@ module Recurly
 
           if el.children.empty? && href = el.attribute('href')
             resource_class = Recurly.const_get(
-              Helper.classify(el.attribute('type') || el.name), false
+              Helper.classify(association_class_name(el.name) ||
+                el.attribute('type') || el.name), false
             )
             case el.name
-            when *associations[:has_many]
+            when *associations_for_relation(:has_many)
               record[el.name] = Pager.new(
                 resource_class, :uri => href.value, :parent => record
               )
-            when *(associations[:has_one] + associations[:belongs_to])
+            when *(associations_for_relation(:has_one) + associations_for_relation(:belongs_to))
               record.links[el.name] = {
                 :resource_class => resource_class,
                 :method => :get,
@@ -432,11 +434,29 @@ module Recurly
         record
       end
 
-      # @return [Hash] A list of association names for the current class.
+      # @return [Array] A list of associations for the current class.
       def associations
-        @associations ||= {
-          :has_many => [], :has_one => [], :belongs_to => []
-        }
+        @associations ||= []
+      end
+
+      # @return [Array] A list of associated resource classes with
+      # the relation [:has_many, :has_one, :belongs_to] for the current class.
+      def associations_for_relation(relation)
+        associations.select{ |a| a.relation == relation }.map(&:resource_class)
+      end
+
+      # @return [String, nil] The actual associated resource class name
+      # for the current class if the resource class does not match the
+      # actual class.
+      def association_class_name(resource_class)
+        association = find_association(resource_class)
+        association.class_name if association
+      end
+
+      # @return [Association, nil] Find association for the current class
+      #                            with resource class name.
+      def find_association(resource_class)
+        associations.find{ |a| a.resource_class == resource_class }
       end
 
       def associations_helper
@@ -449,8 +469,10 @@ module Recurly
       # @param collection_name [Symbol] Association name.
       # @param options [Hash] A hash of association options.
       # @option options [true, false] :readonly Don't define a setter.
+      #                 [String] :class_name Actual associated resource class name
+      #                                      if not same as collection_name.
       def has_many collection_name, options = {}
-        associations[:has_many] << collection_name.to_s
+        associations << Association.new(:has_many, collection_name.to_s, options)
         associations_helper.module_eval do
           define_method collection_name do
             self[collection_name] ||= []
@@ -469,8 +491,10 @@ module Recurly
       # @param member_name [Symbol] Association name.
       # @param options [Hash] A hash of association options.
       # @option options [true, false] :readonly Don't define a setter.
+      #                 [String] :class_name Actual associated resource class name
+      #                                      if not same as member_name.
       def has_one member_name, options = {}
-        associations[:has_one] << member_name.to_s
+        associations << Association.new(:has_one, member_name.to_s, options)
         associations_helper.module_eval do
           define_method(member_name) { self[member_name] }
           if options.key?(:readonly) && options[:readonly] == false
@@ -502,8 +526,13 @@ module Recurly
       # Establishes a belongs_to association.
       #
       # @return [Proc]
+      # @param parent_name [Symbol] Association name.
+      # @param options [Hash] A hash of association options.
+      # @option options [true, false] :readonly Don't define a setter.
+      #                 [String] :class_name Actual associated resource class name
+      #                                      if not same as parent_name.
       def belongs_to parent_name, options = {}
-        associations[:belongs_to] << parent_name.to_s
+        associations << Association.new(:belongs_to, parent_name.to_s, options)
         associations_helper.module_eval do
           define_method(parent_name) { self[parent_name] }
           if options.key?(:readonly) && options[:readonly] == false
@@ -516,7 +545,8 @@ module Recurly
 
       # @return [:has_many, :has_one, :belongs_to, nil] An association type.
       def reflect_on_association name
-        a = associations.find { |k, v| v.include? name.to_s } and a.first
+        a = find_association name.to_s
+        a.relation if a
       end
 
       def embedded! root_index = false
@@ -661,7 +691,7 @@ module Recurly
         changed_attributes[key] = self[key]
       end
 
-      if self.class.associations.values.flatten.include? key
+      if self.class.find_association key
         value = fetch_association key, value
       # FIXME: More explicit; less magic.
       elsif value && key.end_with?('_in_cents') && !respond_to?(:currency)
@@ -958,12 +988,10 @@ module Recurly
 
     def clear_errors
       errors.clear
-      self.class.associations.each_value do |associations|
-        associations.each do |association|
-          next unless respond_to? "#{association}=" # Clear writable only.
-          [*self[association]].each do |associated|
-            associated.clear_errors if associated.respond_to? :clear_errors
-          end
+      self.class.associations do |association|
+        next unless respond_to? "#{association}=" # Clear writable only.
+        [*self[association]].each do |associated|
+          associated.clear_errors if associated.respond_to? :clear_errors
         end
       end
     end

--- a/lib/recurly/resource/association.rb
+++ b/lib/recurly/resource/association.rb
@@ -1,0 +1,16 @@
+module Recurly
+  class Resource
+    class Association
+      attr_reader :relation, :resource_class
+
+      def initialize relation, resource_class, options = {}
+        @relation, @resource_class, @options = relation, resource_class, options
+      end
+
+      def class_name
+        return @class_name if defined? @class_name
+        @class_name = @options[:class_name]
+      end
+    end
+  end
+end

--- a/spec/fixtures/invoices/refund-201.xml
+++ b/spec/fixtures/invoices/refund-201.xml
@@ -5,6 +5,7 @@ Location: https://api.recurly.com/v2/invoices/refund-invoice
 <?xml version="1.0" encoding="UTF-8"?>
 <invoice href="https://api.recurly.com/v2/invoices/refund-invoice">
   <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <original_invoice href="https://api.recurly.com/v2/invoices/refundable-invoice"/>
   <uuid>refund-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1001</invoice_number>

--- a/spec/fixtures/invoices/refund_amount-201.xml
+++ b/spec/fixtures/invoices/refund_amount-201.xml
@@ -5,6 +5,7 @@ Location: https://api.recurly.com/v2/invoices/refund-invoice
 <?xml version="1.0" encoding="UTF-8"?>
 <invoice href="https://api.recurly.com/v2/invoices/refund-invoice">
   <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <original_invoice href="https://api.recurly.com/v2/invoices/refundable-invoice"/>
   <uuid>refund-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1001</invoice_number>

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -51,6 +51,8 @@ describe Invoice do
       it "creates a refund invoice for the line items refunded" do
         refund_invoice = @invoice.refund @line_items
         refund_invoice.must_be_instance_of Invoice
+        refund_invoice.original_invoice.must_be_instance_of Invoice
+        refund_invoice.original_invoice.must_equal @invoice
         refund_invoice.line_items.each do |key, adjustment|
           adjustment.quantity_remaining.must_equal 1
         end
@@ -78,6 +80,8 @@ describe Invoice do
       it "creates a refund invoice for the line items refunded" do
         refund_invoice = @invoice.refund_amount 1000
         refund_invoice.must_be_instance_of Invoice
+        refund_invoice.original_invoice.must_be_instance_of Invoice
+        refund_invoice.original_invoice.must_equal @invoice
         refund_invoice.amount_remaining_in_cents.must_equal 100
       end
     end

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -158,8 +158,8 @@ XML
 
     describe ".associations" do
       it "must be empty without any associations defined" do
-        resource.associations[:has_many].must_be_empty
-        resource.associations[:has_one].must_be_empty
+        resource.associations_for_relation(:has_many).must_be_empty
+        resource.associations_for_relation(:has_one).must_be_empty
       end
     end
 
@@ -174,7 +174,7 @@ XML
       end
 
       it "must define an association" do
-        resource.associations[:has_many].must_include 'reasons'
+        resource.associations_for_relation(:has_many).must_include 'reasons'
         resource.reflect_on_association(:reasons).must_equal :has_many
       end
 
@@ -195,9 +195,9 @@ XML
       end
 
       it "must define an association" do
-        resource.associations[:has_one].must_include 'day'
+        resource.associations_for_relation(:has_one).must_include 'day'
         resource.reflect_on_association(:day).must_equal :has_one
-        Day.associations[:belongs_to].must_include 'resource'
+        Day.associations_for_relation(:belongs_to).must_include 'resource'
         Day.reflect_on_association(:resource).must_equal :belongs_to
       end
 


### PR DESCRIPTION
Refactor how associations are created in order to support the ```class_name``` option for the ```original_invoice``` ```belongs_to``` association. Instead of being an array of resource class names for each type of relation, making it an array of ```Association``` objects containing a relation type, resource class name, and an options hash for other settings like ```class_name``` if the resource class of the object does not match the resource class name of the association.

Approvers: @cbarton 

Tests:
For a site with ```line_item_refunds``` enabled:
- Find a refund invoice
- Verify that the ```original_invoice``` method on the invoice returns an invoice object for the invoice refunded
- Find a invoice that is not a refund
- Verify that the ```original_invoice``` method on the invoice returns ```nil```