### PR TITLE
Adding vat_location_valid field to Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <a name="unreleased"></a>
 ## Unreleased
+* Add `vat_location_valid` to `Account` [PR](https://github.com/recurly/recurly-client-ruby/pull/171)
 
 <a name="v2.4.0"></a>
 ## v2.4.0 (2015-1-7)

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -38,6 +38,7 @@ module Recurly
       tax_exempt
       entity_use_code
       created_at
+      vat_location_valid
     )
     alias to_param account_code
 

--- a/spec/fixtures/accounts/show-200.xml
+++ b/spec/fixtures/accounts/show-200.xml
@@ -29,4 +29,5 @@ Content-Type: application/xml; charset=utf-8
     <country>US</country>
     <phone>8015551234</phone>
   </address>
+  <vat_location_valid type="boolean">true</vat_location_valid>
 </account>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -83,6 +83,7 @@ describe Account do
       account.address.zip.must_equal '94105'
       account.address.phone.must_equal '8015551234'
       account.address.country.must_equal 'US'
+      account.vat_location_valid.must_equal true
     end
 
     it 'must return an account with tax state' do


### PR DESCRIPTION
This field will show up when the account is elligible and has been
location verified according to the VAT rules. It will be true when
passed and false when failed.
