### PR TITLE
Add Invoice#invoice_number_prefix and Invoice#invoice_number_with_prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 * Add `vat_location_valid` to `Account` [PR](https://github.com/recurly/recurly-client-ruby/pull/171)
+* Add `Invoice#invoice_number_prefix` and `Invoice#invoice_number_with_prefix` to make use of the new
+  Country Invoice Sequencing feature [PR](https://github.com/recurly/recurly-client-ruby/pull/173)
 
 <a name="v2.4.0"></a>
 ## v2.4.0 (2015-1-7)

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -23,10 +23,15 @@ module Recurly
     # @return [Redemption]
     has_one :redemption
 
+    def invoice_number_with_prefix
+      "#{invoice_number_prefix}#{invoice_number}"
+    end
+
     define_attribute_methods %w(
       uuid
       state
       invoice_number
+      invoice_number_prefix
       po_number
       vat_number
       subtotal_in_cents
@@ -45,7 +50,7 @@ module Recurly
       customer_notes
       address
     )
-    alias to_param invoice_number
+    alias to_param invoice_number_with_prefix
 
     def self.to_xml(attrs)
       invoice = new attrs

--- a/spec/fixtures/invoices/create-201-prefix.xml
+++ b/spec/fixtures/invoices/create-201-prefix.xml
@@ -1,38 +1,38 @@
 HTTP/1.1 201 Created
 Content-Type: application/xml; charset=utf-8
-Location: https://api.recurly.com/v2/invoices/refund-invoice
+Location: https://api.recurly.com/v2/invoices/create-201-prefix
 
 <?xml version="1.0" encoding="UTF-8"?>
-<invoice href="https://api.recurly.com/v2/invoices/refund-invoice">
+<invoice href="https://api.recurly.com/v2/invoices/create-201-prefix">
   <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
-  <original_invoice href="https://api.recurly.com/v2/invoices/refundable-invoice"/>
-  <uuid>refund-invoice</uuid>
+  <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
+  <uuid>create-201-prefix</uuid>
   <state>open</state>
   <invoice_number type="integer">1001</invoice_number>
-  <invoice_number_prefix></invoice_number_prefix>
+  <invoice_number_prefix>GB</invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
-  <subtotal_in_cents type="integer">-550</subtotal_in_cents>
+  <subtotal_in_cents type="integer">300</subtotal_in_cents>
   <tax_in_cents type="integer">0</tax_in_cents>
-  <total_in_cents type="integer">0</total_in_cents>
+  <total_in_cents type="integer">300</total_in_cents>
   <currency>USD</currency>
   <created_at type="datetime">2011-04-30T08:00:00Z</created_at>
   <line_items>
     <adjustment href="https://api.recurly.com/v2/adjustments/charge" type="charge">
       <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
-      <invoice href="https://api.recurly.com/v2/invoices/refund-invoice"/>
+      <invoice href="https://api.recurly.com/v2/invoices/create-201-prefix"/>
+      <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
       <uuid>charge</uuid>
       <state>invoiced</state>
-      <description>Refund for Special charge 1</description>
+      <description>Special charge</description>
       <origin>one_time</origin>
-      <unit_amount_in_cents type="integer">275</unit_amount_in_cents>
-      <quantity type="integer">-1</quantity>
-      <quantity_remaining type="integer">1</quantity_remaining>
+      <unit_amount_in_cents type="integer">100</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
       <discount_in_cents type="integer">0</discount_in_cents>
       <tax_in_cents type="integer">0</tax_in_cents>
-      <total_in_cents type="integer">-275</total_in_cents>
+      <total_in_cents type="integer">100</total_in_cents>
       <currency>USD</currency>
-      <taxable type="boolean">true</taxable>
+      <taxable type="boolean">false</taxable>
       <start_date nil="nil"></start_date>
       <end_date nil="nil"></end_date>
       <created_at type="datetime">2011-04-30T08:00:00Z</created_at>
@@ -41,10 +41,11 @@ Location: https://api.recurly.com/v2/invoices/refund-invoice
   <transactions>
     <transaction href="https://api.recurly.com/v2/transactions/transaction" type="credit_card">
       <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
-      <invoice href="https://api.recurly.com/v2/invoices/refund-invoice"/>
+      <invoice href="https://api.recurly.com/v2/invoices/create-201-prefix"/>
+      <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
       <uuid>transaction</uuid>
-      <action>refund</action>
-      <amount_in_cents type="integer">550</amount_in_cents>
+      <action>purchase</action>
+      <amount_in_cents type="integer">300</amount_in_cents>
       <tax_in_cents type="integer">0</tax_in_cents>
       <currency>USD</currency>
       <status>success</status>

--- a/spec/fixtures/invoices/create-201.xml
+++ b/spec/fixtures/invoices/create-201.xml
@@ -9,6 +9,7 @@ Location: https://api.recurly.com/v2/invoices/created-invoice
   <uuid>created-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">300</subtotal_in_cents>

--- a/spec/fixtures/invoices/create-with-optionals-201.xml
+++ b/spec/fixtures/invoices/create-with-optionals-201.xml
@@ -9,6 +9,7 @@ Location: https://api.recurly.com/v2/invoices/created-invoice
   <uuid>created-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">300</subtotal_in_cents>

--- a/spec/fixtures/invoices/preview-200.xml
+++ b/spec/fixtures/invoices/preview-200.xml
@@ -14,6 +14,7 @@ Content-Type: application/xml; charset=utf-8
   <uuid>previewed-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">300</subtotal_in_cents>

--- a/spec/fixtures/invoices/refund_amount-201.xml
+++ b/spec/fixtures/invoices/refund_amount-201.xml
@@ -9,6 +9,7 @@ Location: https://api.recurly.com/v2/invoices/refund-invoice
   <uuid>refund-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1001</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">-1000</subtotal_in_cents>

--- a/spec/fixtures/invoices/show-200-nosub.xml
+++ b/spec/fixtures/invoices/show-200-nosub.xml
@@ -7,6 +7,7 @@ Content-Type: application/xml; charset=utf-8
   <uuid>created-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">300</subtotal_in_cents>

--- a/spec/fixtures/invoices/show-200-refundable.xml
+++ b/spec/fixtures/invoices/show-200-refundable.xml
@@ -7,6 +7,7 @@ Content-Type: application/xml; charset=utf-8
   <uuid>refundable-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">1100</subtotal_in_cents>

--- a/spec/fixtures/invoices/show-200-taxed.xml
+++ b/spec/fixtures/invoices/show-200-taxed.xml
@@ -7,6 +7,7 @@ Content-Type: application/xml; charset=utf-8
   <uuid>created-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">300</subtotal_in_cents>

--- a/spec/fixtures/invoices/show-200-with-notes.xml
+++ b/spec/fixtures/invoices/show-200-with-notes.xml
@@ -7,6 +7,7 @@ Content-Type: application/xml; charset=utf-8
   <uuid>created-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">300</subtotal_in_cents>

--- a/spec/fixtures/subscriptions/preview-200-change.xml
+++ b/spec/fixtures/subscriptions/preview-200-change.xml
@@ -31,6 +31,7 @@ Content-Type: application/xml; charset=utf-8
     <uuid>abcdefg123</uuid>
     <state>open</state>
     <invoice_number nil="nil"></invoice_number>
+    <invoice_number_prefix></invoice_number_prefix>
     <po_number nil="nil"></po_number>
     <vat_number></vat_number>
     <subtotal_in_cents type="integer">5000</subtotal_in_cents>

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -19,6 +19,15 @@ describe Invoice do
   end
 
   describe 'attributes' do
+    it 'includes the invoice number prefix' do
+      stub_api_request :get, 'invoices/invoice-with-prefix', 'invoices/create-201-prefix'
+
+      invoice = Invoice.find('invoice-with-prefix')
+      invoice.invoice_number.must_equal 1001
+      invoice.invoice_number_prefix.must_equal 'GB'
+      invoice.invoice_number_with_prefix.must_equal 'GB1001'
+    end
+
     it 'has a tax type if taxed' do
       stub_api_request :get, 'invoices/taxed-invoice', 'invoices/show-200-taxed'
 


### PR DESCRIPTION
cc/ @judith 

tests:

  - Turn on the Country Invoice Sequencing feature with VAT taxes
  - Create a VAT taxed invoice 
  - `Recurly::Invoice.find(<invoice_number_with_prefix>).invoice_number_with_prefix` should find the correct invoice and return its full invoice number.