### PR TITLE
Ensures Recurly::Resource::Pager#find encodes uuids

### DIFF
--- a/lib/recurly/resource/pager.rb
+++ b/lib/recurly/resource/pager.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module Recurly
   class Resource
     # Pages through an index resource, yielding records as it goes. It's rare
@@ -169,11 +171,10 @@ module Recurly
 
       def find uuid
         if resource_class.respond_to? :find
-          raise NoMethodError,
-            "#find must be called on #{resource_class} directly"
+          raise NoMethodError, "#find must be called on #{resource_class} directly"
         end
 
-        resource_class.from_response API.get("#{uri}/#{uuid}")
+        resource_class.from_response API.get("#{uri}/#{ERB::Util.url_encode(uuid)}")
       end
 
       # @return [true, false]

--- a/spec/recurly/resource/pager_spec.rb
+++ b/spec/recurly/resource/pager_spec.rb
@@ -144,5 +144,18 @@ XML
         active.load!
       end
     end
+
+    describe "#find" do
+      describe "with a resource class lacking a finder" do
+        let(:resource) { Class.new(Resource) { def self.name() 'Resource' end; private_class_method(:find) } }
+
+        it "must find resources with uuids containing spaces" do
+          stub_api_request(:get, 'resources/code%20with%20space') {
+            XML[200][:show]
+          }
+          resource = pager.find 'code with space'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
- Applies to paged resource find methods for resources not using Recurly::Resource#find (add_ons)
- Fixes #174

/cc @austinheap 