### PR TITLE
Add 'tax_type', 'tax_region', 'tax_rate' to Adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 <a name="unreleased"></a>
 ## Unreleased
 * Fix paged resource loading when the uuid needs to be escaped, fixes [174](https://github.com/recurly/recurly-client-ruby/issues/174), [PR](https://github.com/recurly/recurly-client-ruby/pull/177)
+* Add `tax_type`, `tax_rate`, `tax_region` to `Adjustment` [PR](https://github.com/recurly/recurly-client-ruby/pull/180)
 
 <a name="v2.4.1"></a>
 ## v2.4.1 (2015-1-23)

--- a/lib/recurly/adjustment.rb
+++ b/lib/recurly/adjustment.rb
@@ -25,17 +25,21 @@ module Recurly
       unit_amount_in_cents
       quantity
       discount_in_cents
-      tax_in_cents
       total_in_cents
       currency
-      tax_exempt
-      tax_code
-      tax_details
       product_code
       start_date
       end_date
       created_at
       quantity_remaining
+
+      tax_in_cents
+      tax_type
+      tax_region
+      tax_rate
+      tax_exempt
+      tax_code
+      tax_details
     )
     alias to_param uuid
 

--- a/spec/fixtures/adjustments/show-200.xml
+++ b/spec/fixtures/adjustments/show-200.xml
@@ -15,6 +15,9 @@ Content-Type: application/xml; charset=utf-8
   <quantity type="integer">1</quantity>
   <discount_in_cents type="integer">0</discount_in_cents>
   <tax_in_cents type="integer">5000</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <tax_region>CA</tax_region>
+  <tax_rate type="float">0.0875</tax_rate>
   <total_in_cents type="integer">1200</total_in_cents>
   <currency>USD</currency>
   <product_code>basic</product_code>

--- a/spec/fixtures/invoices/show-200-taxed.xml
+++ b/spec/fixtures/invoices/show-200-taxed.xml
@@ -16,6 +16,8 @@ Content-Type: application/xml; charset=utf-8
   <currency>USD</currency>
   <created_at type="datetime">2011-04-30T08:00:00Z</created_at>
   <tax_type>usst</tax_type>
+  <tax_region>CA</tax_region>
+  <tax_rate type="float">0.0875</tax_rate>
   <line_items>
     <adjustment href="https://api.recurly.com/v2/adjustments/charge" type="charge">
       <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>

--- a/spec/recurly/adjustment_spec.rb
+++ b/spec/recurly/adjustment_spec.rb
@@ -19,6 +19,9 @@ describe Adjustment do
       adjustment.start_date.must_be_kind_of DateTime
       adjustment.end_date.must_be_kind_of DateTime
       adjustment.created_at.must_be_kind_of DateTime
+      adjustment.tax_type.must_equal 'usst'
+      adjustment.tax_region.must_equal 'CA'
+      adjustment.tax_rate.must_equal 0.0875
 
       tax_details = adjustment.tax_details
       tax_details.length.must_equal 2


### PR DESCRIPTION
The tax information has been brought down to from the Invoice level to the Adjustment level. This unlocks those fields.

cc/ @bhelx 

```ruby
adj = Recurly::Adjustment.find('<uuid>')
puts adj.tax_type
puts adj.tax_rate
puts adj.tax_region
```