### PR TITLE
Define collection_method attribute in invoice

### DIFF
--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -49,6 +49,7 @@ module Recurly
       terms_and_conditions
       customer_notes
       address
+      collection_method
     )
     alias to_param invoice_number_with_prefix
 

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -49,6 +49,7 @@ module Recurly
       terms_and_conditions
       customer_notes
       address
+      net_terms
       collection_method
     )
     alias to_param invoice_number_with_prefix

--- a/spec/fixtures/invoices/show-200.xml
+++ b/spec/fixtures/invoices/show-200.xml
@@ -19,6 +19,7 @@ Content-Type: application/xml; charset=utf-8
   <tax_type>usst</tax_type>
   <customer_notes>Some Customer Notes</customer_notes>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <net_terms type="integer">0</net_terms>
   <collection_method>automatic</collection_method>
   <line_items>
     <adjustment href="https://api.recurly.com/v2/adjustments/charge" type="charge">

--- a/spec/fixtures/invoices/show-200.xml
+++ b/spec/fixtures/invoices/show-200.xml
@@ -4,6 +4,7 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <invoice href="https://api.recurly.com/v2/invoices/created-invoice">
   <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
   <uuid>created-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
@@ -18,10 +19,12 @@ Content-Type: application/xml; charset=utf-8
   <tax_type>usst</tax_type>
   <customer_notes>Some Customer Notes</customer_notes>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <collection_method>automatic</collection_method>
   <line_items>
     <adjustment href="https://api.recurly.com/v2/adjustments/charge" type="charge">
       <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
       <invoice href="https://api.recurly.com/v2/invoices/created-invoice"/>
+      <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
       <uuid>charge</uuid>
       <state>invoiced</state>
       <description>Special charge</description>
@@ -42,6 +45,7 @@ Content-Type: application/xml; charset=utf-8
     <transaction href="https://api.recurly.com/v2/transactions/transaction" type="credit_card">
       <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
       <invoice href="https://api.recurly.com/v2/invoices/created-invoice"/>
+      <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
       <uuid>transaction</uuid>
       <action>purchase</action>
       <amount_in_cents type="integer">300</amount_in_cents>

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -35,12 +35,13 @@ describe Invoice do
       invoice.tax_type.must_equal 'usst'
     end
 
-    it 'can access notes if there' do
-      stub_api_request :get, 'invoices/created-invoice', 'invoices/show-200-with-notes'
+    it 'can access notes and collection method if there' do
+      stub_api_request :get, 'invoices/show-invoice', 'invoices/show-200'
 
-      invoice = Invoice.find 'created-invoice'
+      invoice = Invoice.find 'show-invoice'
       invoice.customer_notes.must_equal 'Some Customer Notes'
       invoice.terms_and_conditions.must_equal 'Some Terms and Conditions'
+      invoice.collection_method.must_equal 'automatic'
     end
   end
 

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -35,12 +35,13 @@ describe Invoice do
       invoice.tax_type.must_equal 'usst'
     end
 
-    it 'can access notes and collection method if there' do
+    it 'can access notes, net_terms and collection method if there' do
       stub_api_request :get, 'invoices/show-invoice', 'invoices/show-200'
 
       invoice = Invoice.find 'show-invoice'
       invoice.customer_notes.must_equal 'Some Customer Notes'
       invoice.terms_and_conditions.must_equal 'Some Terms and Conditions'
+      invoice.net_terms.must_equal 0
       invoice.collection_method.must_equal 'automatic'
     end
   end


### PR DESCRIPTION
As defined in the docs at https://docs.recurly.com/api/invoices, adding collection_method attr to invoice resource.