### PR TITLE
Bank accounts (ACH feature)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 * Fix paged resource loading when the uuid needs to be escaped, fixes [174](https://github.com/recurly/recurly-client-ruby/issues/174), [PR](https://github.com/recurly/recurly-client-ruby/pull/177)
 * Add `tax_type`, `tax_rate`, `tax_region` to `Adjustment` [PR](https://github.com/recurly/recurly-client-ruby/pull/180)
 * Add `net_terms` and `collection_method` to `Invoice` [PR](https://github.com/recurly/recurly-client-ruby/pull/186)
+* Added `bank_account` attributes to `BillingInfo`:
+  * `name_on_account`
+  * `account_type` (`checking` or `savings`)
+  * `last_four`
+  * `routing_number`
 
 <a name="v2.4.1"></a>
 ## v2.4.1 (2015-1-23)

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -1,5 +1,10 @@
 module Recurly
   class BillingInfo < Resource
+    BANK_ACCOUNT_ATTRIBUTES = %w(name_on_account account_type last_four routing_number).freeze
+    CREDIT_CARD_ATTRIBUTES = %w(number verification_value card_type year month first_six last_four).freeze
+    AMAZON_ATTRIBUTES = %w(amazon_billing_agreement_id).freeze
+    PAYPAL_ATTRIBUTES = %w(paypal_billing_agreement_id).freeze
+
     # @return [Account]
     belongs_to :account
 
@@ -17,22 +22,10 @@ module Recurly
       vat_number
       ip_address
       ip_address_country
-      card_type
-      year
-      month
-      start_year
-      start_month
-      issue_number
-      first_six
-      last_four
-      paypal_billing_agreement_id
-      amazon_billing_agreement_id
-      number
-      verification_value
       token_id
-    )
+    ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES
 
-    # @return ["credit_card", "paypal", "amazon", nil] The type of billing info.
+    # @return ["credit_card", "paypal", "amazon", "bank_account", nil] The type of billing info.
     attr_reader :type
 
     # @return [String]
@@ -40,12 +33,15 @@ module Recurly
       attributes = self.class.attribute_names
       case type
       when 'credit_card'
-        attributes -= %w(paypal_billing_agreement_id amazon_billing_agreement_id)
+        attributes -= (AMAZON_ATTRIBUTES + PAYPAL_ATTRIBUTES + BANK_ACCOUNT_ATTRIBUTES)
+        attributes |= CREDIT_CARD_ATTRIBUTES
       when 'paypal'
-        attributes -= %w(
-          card_type year month start_year start_month issue_number
-          first_six last_four
-        )
+        attributes -= (CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES + AMAZON_ATTRIBUTES)
+      when 'amazon'
+        attributes -= (CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES + PAYPAL_ATTRIBUTES)
+      when 'bank_account'
+        attributes -= (CREDIT_CARD_ATTRIBUTES + PAYPAL_ATTRIBUTES + AMAZON_ATTRIBUTES)
+        attributes |= BANK_ACCOUNT_ATTRIBUTES
       end
       super attributes
     end

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -1,6 +1,5 @@
 require 'date'
 require 'erb'
-require 'recurly/resource/association'
 
 module Recurly
   # The base class for all Recurly resources (e.g. {Account}, {Subscription},
@@ -117,6 +116,7 @@ module Recurly
   class Resource
     autoload :Errors, 'recurly/resource/errors'
     autoload :Pager,  'recurly/resource/pager'
+    autoload :Association,  'recurly/resource/association'
 
     # Raised when a record cannot be found.
     #
@@ -388,7 +388,6 @@ module Recurly
           record = {}
         end
         klass ||= self
-        associations = klass.associations
 
         xml.root.attributes.each do |name, value|
           record.instance_variable_set "@#{name}", value.to_s

--- a/spec/fixtures/billing_info/show-200-bank-account.xml
+++ b/spec/fixtures/billing_info/show-200-bank-account.xml
@@ -4,8 +4,9 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info">
   <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
-  <first_name>Larry</first_name>
-  <last_name>David</last_name>
+  <name_on_account>Larry David</name_on_account>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
   <company nil="nil"></company>
   <address1>123 Pretty Pretty Good St.</address1>
   <address2 nil="nil"></address2>
@@ -17,9 +18,7 @@ Content-Type: application/xml; charset=utf-8
   <vat_number>2000</vat_number>
   <ip_address>127.0.0.1</ip_address>
   <ip_address_country nil="nil"></ip_address_country>
-  <card_type>Visa</card_type>
-  <year type="integer">2015</year>
-  <month type="integer">1</month>
-  <first_six>411111</first_six>
-  <last_four>1111</last_four>
+  <account_type>checking</account_type>
+  <last_four>3123</last_four>
+  <routing_number>12309812</routing_number>
 </billing_info>

--- a/spec/recurly/billing_info_spec.rb
+++ b/spec/recurly/billing_info_spec.rb
@@ -17,6 +17,17 @@ describe BillingInfo do
       billing_info.state.must_equal 'CA'
     end
 
+    it "must return an accounts billing info as a bank account when available" do
+      stub_api_request(
+        :get, 'accounts/abcdef1234567890/billing_info', 'billing_info/show-200-bank-account'
+      )
+      billing_info = BillingInfo.find 'abcdef1234567890'
+      billing_info.name_on_account.must_equal 'Larry David'
+      billing_info.account_type.must_equal 'checking'
+      billing_info.last_four.must_equal '3123'
+      billing_info.routing_number.must_equal '12309812'
+    end
+
     it "must raise an exception when unavailable" do
       stub_api_request(
         :get, 'accounts/abcdef1234567890/billing_info', 'accounts/show-404'


### PR DESCRIPTION
Adds ACH support for Billing Infos

cc/ @bhelx 

tests:

```ruby
account = Recurly::Account.find('<account-code>')
account.billing_info = {
  name_on_account: 'John Doe',
  routing_number: '125200057',
  account_number: '0123456789',
  address1: '123 Fake St',
  city: 'San Francisco',
  state: 'CA',
  country: 'US',
  zip: '94107'
}
account.billing_info.save
```
  - check the billing info to see that it reflects that info
  