### PR TITLE
adds ability to enter offline payment on an invoice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+* Added ability to enter offline payment [PR](https://github.com/recurly/recurly-client-ruby/pull/189/)
+
 <a name="v2.4.4"></a>
 ## v2.4.4 (2015-6-25)
 

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -78,6 +78,12 @@ module Recurly
       reload follow_link :mark_failed
       true
     end
+    
+    def enter_offline_payment(attrs={})
+      Transaction.from_response API.post("#{uri}/transactions", attrs.empty? ? nil : Transaction.to_xml(attrs))
+    rescue Recurly::API::UnprocessableEntity => e
+      raise Invalid, e.message
+    end
 
     def pdf
       self.class.find to_param, :format => 'pdf'

--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -41,8 +41,15 @@ module Recurly
       transaction_error
       source
       ip_address
+      collected_at
+      description
     )
     alias to_param uuid
+    
+    def self.to_xml(attrs)
+      transaction = new attrs
+      transaction.to_xml
+    end
 
     # @return ["credit", "charge", nil] The type of transaction.
     attr_reader :type

--- a/spec/fixtures/transactions/show-200.xml
+++ b/spec/fixtures/transactions/show-200.xml
@@ -10,6 +10,7 @@ Content-Type: application/xml; charset=utf-8
   <tax_in_cents type="integer">0</tax_in_cents>
   <currency>USD</currency>
   <status>success</status>
+  <payment_method>credit_card</payment_method>
   <source>subscription</source>
   <reference nil="nil"></reference>
   <recurring type="boolean">true</recurring>


### PR DESCRIPTION
Implements [this API call](https://docs.recurly.com/api/invoices#offline-manual-payment) in Ruby.

### Testing

```ruby
invoice = Recurly::Invoice.find('9543')
invoice.enter_offline_payment(
  :payment_method => 'check',
  :amount_in_cents => 1000,
  :description => 'Paid with check',
  :collected_at => Time.utc(2012, 12, 31)
)
```