### PR TITLE
Threadsafe Recurly.api_key?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * `last_four`
   * `routing_number`
   * [PR](https://github.com/recurly/recurly-client-ruby/pull/188)
+* Added config to Recurly to allow for per thread configuration of Recurly client. [PR](https://github.com/recurly/recurly-client-ruby/pull/190)
 
 <a name="v2.4.1"></a>
 ## v2.4.1 (2015-1-23)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ Recurly::API.net_http = {
 }
 ```
 
+## Multi-Threaded Configuration
+If you are using the client in a multi-threaded environment and require a different configuration per thread you can use the following within the threads context:
+
+``` ruby
+Recurly.config({
+  subdomain: ENV['RECURLY_SUBDOMAIN']
+  api_key: ENV['RECURLY_API_KEY'],
+  default_currency: "US",
+  private_key:  ENV['RECURLY_PUBLIC_API_KEY']
+})
+```
+
+The any configuration items you do not include in the above config call will be defaulted to the standard configuration items.   For example if you do not define default_currency then
+Recurly.default_currency will be used.
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Recurly::API.net_http = {
 ```
 
 ## Multi-Threaded Configuration
-If you are using the client in a multi-threaded environment and require a different configuration per thread you can use the following within the threads context:
+If you are using the client in a multi-threaded environment and require a different configuration per thread you can use the following within the thread's context:
 
 ``` ruby
 Recurly.config({
@@ -81,7 +81,7 @@ Recurly.config({
 })
 ```
 
-The any configuration items you do not include in the above config call will be defaulted to the standard configuration items.   For example if you do not define default_currency then
+Any configuration items you do not include in the above config call will be defaulted to the standard configuration items.   For example if you do not define default_currency then
 Recurly.default_currency will be used.
 
 

--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -50,8 +50,8 @@ module Recurly
 
     # @return [String] A subdomain.
     def subdomain
-      if Thread.current[:recurly_config]
-        return Thread.current[:recurly_config][:subdomain] if Thread.current[:recurly_config][:subdomain]
+      if Thread.current[:recurly_config] && Thread.current[:recurly_config][:subdomain]
+        return Thread.current[:recurly_config][:subdomain]
       end
       @subdomain || 'api'
     end
@@ -60,8 +60,8 @@ module Recurly
     # @return [String] An API key.
     # @raise [ConfigurationError] If not configured.
     def api_key
-      if Thread.current[:recurly_config]
-        return Thread.current[:recurly_config][:api_key] if Thread.current[:recurly_config][:api_key]
+      if Thread.current[:recurly_config] && Thread.current[:recurly_config][:api_key]
+        return Thread.current[:recurly_config][:api_key]
       end
 
       defined? @api_key and @api_key or raise(
@@ -72,8 +72,8 @@ module Recurly
 
     # @return [String, nil] A default currency.
     def default_currency
-      if Thread.current[:recurly_config]
-        return Thread.current[:recurly_config][:default_currency] if Thread.current[:recurly_config][:default_currency]
+      if Thread.current[:recurly_config] &&  Thread.current[:recurly_config][:default_currency]
+        return Thread.current[:recurly_config][:default_currency]
       end
 
       return  @default_currency if defined? @default_currency

--- a/lib/recurly/js.rb
+++ b/lib/recurly/js.rb
@@ -18,6 +18,10 @@ module Recurly
       # @return [String] A private key for Recurly.js.
       # @raise [ConfigurationError] No private key has been set.
       def private_key
+        if Thread.current[:recurly_config] && Thread.current[:recurly_config][:private_key]
+          return Thread.current[:recurly_config][:private_key]
+        end
+
         defined? @private_key and @private_key or raise(
           ConfigurationError, "private_key not configured"
         )

--- a/spec/recurly/js_spec.rb
+++ b/spec/recurly/js_spec.rb
@@ -20,6 +20,24 @@ describe Recurly.js do
       Recurly.js.private_key = nil
       proc { Recurly.js.private_key }.must_raise ConfigurationError
     end
+
+    it "must use defaults set if not sent in new thread" do
+      Recurly.js.private_key = 'testprivate'
+
+      Thread.new {
+        Recurly.js.private_key.must_equal 'testprivate'
+      }
+
+    end
+
+    it "must use new values set in thread context" do
+      Recurly.js.private_key = 'testprivate'
+      Thread.new {
+        Recurly.config(private_key: "newprivate")
+        Recurly.js.private_key.must_equal 'newprivate'
+      }
+      Recurly.js.private_key.must_equal 'testprivate'
+    end
   end
 
   describe "public_key" do

--- a/spec/recurly_spec.rb
+++ b/spec/recurly_spec.rb
@@ -21,5 +21,35 @@ describe Recurly do
       Recurly.api_key = nil
       proc { Recurly.api_key }.must_raise ConfigurationError
     end
+
+    it "must use defaults set if not sent in new thread" do
+      Recurly.api_key = 'old_key'
+      Recurly.subdomain = 'olddomain'
+      Recurly.default_currency = 'US'
+      Thread.new {
+        Recurly.api_key.must_equal 'old_key'
+        Recurly.subdomain.must_equal 'olddomain'
+        Recurly.default_currency.must_equal 'US'
+      }
+      Recurly.api_key.must_equal 'old_key'
+      Recurly.subdomain.must_equal 'olddomain'
+      Recurly.default_currency.must_equal 'US'
+
+    end
+
+    it "must use new values set in thread context" do
+      Recurly.api_key = 'old_key'
+      Recurly.subdomain = 'olddomain'
+      Recurly.default_currency = 'US'
+      Thread.new {
+          Recurly.config(api_key: "test", subdomain: "testsub", default_currency: "IR")
+          Recurly.api_key.must_equal 'test'
+          Recurly.subdomain.must_equal 'testsub'
+          Recurly.default_currency.must_equal 'IR'
+      }
+      Recurly.api_key.must_equal 'old_key'
+      Recurly.subdomain.must_equal 'olddomain'
+      Recurly.default_currency.must_equal 'US'
+    end
   end
 end

--- a/spec/recurly_spec.rb
+++ b/spec/recurly_spec.rb
@@ -31,10 +31,6 @@ describe Recurly do
         Recurly.subdomain.must_equal 'olddomain'
         Recurly.default_currency.must_equal 'US'
       }
-      Recurly.api_key.must_equal 'old_key'
-      Recurly.subdomain.must_equal 'olddomain'
-      Recurly.default_currency.must_equal 'US'
-
     end
 
     it "must use new values set in thread context" do


### PR DESCRIPTION
Resolves issue #159 Threadsafe Recurly.api_key?  by adding a new method that will allow developers to optionally override keys on a per thread context.

I know this is a lot like the current pull request for this issue. But this takes it a step further and allows any of the static config variable to be overridden.  Also it will only have any impact if the developer calls the Recurly.config() method.  Otherwise the normal code path stays in place.
