### PR TITLE
Add bank_account_authorized_at to subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+* Add `bank_account_authorized_at` to `Subscription` [PR](https://github.com/recurly/recurly-client-ruby/pull/191)
+
 <a name="v2.4.2"></a>
 ## v2.4.2 (2015-4-28)
 * Fix paged resource loading when the uuid needs to be escaped, fixes [174](https://github.com/recurly/recurly-client-ruby/issues/174), [PR](https://github.com/recurly/recurly-client-ruby/pull/177)

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -52,6 +52,7 @@ module Recurly
       tax_region
       tax_rate
       bulk
+      bank_account_authorized_at
       terms_and_conditions
       customer_notes
       vat_reverse_charge_notes

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -35,6 +35,7 @@ describe Subscription do
                                 customer_notes
                                 address
                                 vat_reverse_charge_notes
+                                bank_account_authorized_at
                               }
 
         subject.attribute_names.sort.must_equal expected_attributes.sort


### PR DESCRIPTION
For back dating bank account authorization when importing subscriptions, the API user can specify a `bank_account_authorized_at` timestamp of when that authorization occurred.

cc/ @bhelx 

tests:

```ruby
sub = Recurly::Subscription.create(
  plan_code: '<plan_code>',
  currency: 'USD',
  bank_account_authorized_at: Time.parse('2015-02-15').iso8601,
  account: {
    account_code: '<account_code>'
  }
)

sub = Recurly::Subscription.find(sub.uuid)
puts sub.bank_account_authorized_at #> 2015-02-15T08:00:00+00:00
```