### PR TITLE
Ip address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 * Add `bank_account_authorized_at` to `Subscription` [PR](https://github.com/recurly/recurly-client-ruby/pull/191)
+* Add `ip_address` to `Transaction` [PR](https://github.com/recurly/recurly-client-ruby/pull/192)
 
 <a name="v2.4.2"></a>
 ## v2.4.2 (2015-4-28)

--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -40,6 +40,7 @@ module Recurly
       details
       transaction_error
       source
+      ip_address
     )
     alias to_param uuid
 

--- a/spec/fixtures/transactions/show-200.xml
+++ b/spec/fixtures/transactions/show-200.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
   <avs_result_street nil="nil"></avs_result_street>
   <avs_result_postal nil="nil"></avs_result_postal>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <ip_address>127.0.0.1</ip_address>
   <details>
     <account>
       <account_code>gob</account_code>


### PR DESCRIPTION
Adding `ip_address` to transactions now that it's exposed
https://docs.recurly.com/api/transactions#create-transaction

cc: @cbarton 

Test:
`transaction = Recurly::Transaction.find('<uuid>')`
`print transaction.ip_address`
