### PR TITLE
Add support for refund_apply_order when refunding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+* Add `refund_apply_order` to `Invoice` [PR](https://github.com/recurly/recurly-client-ruby/pull/193)
+
 <a name="v2.4.3"></a>
 ## v2.4.3 (2015-5-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <a name="unreleased"></a>
 ## Unreleased
 
-* Add `refund_apply_order` to `Invoice` [PR](https://github.com/recurly/recurly-client-ruby/pull/193)
+* Add `refund_apply_order` to `Invoice` when creating a refund [PR](https://github.com/recurly/recurly-client-ruby/pull/193)
 
 <a name="v2.4.3"></a>
 ## v2.4.3 (2015-5-26)

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -51,7 +51,6 @@ module Recurly
       address
       net_terms
       collection_method
-      refund_apply_order
     )
     alias to_param invoice_number_with_prefix
 
@@ -90,10 +89,10 @@ module Recurly
     # refundable.
     # @raise [Error] If the refund fails.
     # @param line_items [Array, nil] An array of line items to refund.
-    def refund line_items = nil
+    def refund line_items = nil, refund_apply_order = 'credit'
       return false unless link? :refund
       refund = self.class.from_response(
-        follow_link :refund, :body => refund_line_items_to_xml(line_items)
+        follow_link :refund, :body => refund_line_items_to_xml(line_items, refund_apply_order)
       )
       refund
     end
@@ -104,10 +103,10 @@ module Recurly
     # refundable.
     # @raise [Error] If the refund fails.
     # @param amount_in_cents [Integer, nil] The amount (in cents) to refund.
-    def refund_amount amount_in_cents = nil
+    def refund_amount amount_in_cents = nil, refund_apply_order = 'credit'
       return false unless link? :refund
       refund = self.class.from_response(
-        follow_link :refund, :body => refund_amount_to_xml(amount_in_cents)
+        follow_link :refund, :body => refund_amount_to_xml(amount_in_cents, refund_apply_order)
       )
       refund
     end
@@ -122,14 +121,17 @@ module Recurly
       super({ :currency => Recurly.default_currency }.merge attributes)
     end
 
-    def refund_amount_to_xml amount_in_cents=nil
+    def refund_amount_to_xml amount_in_cents = nil, refund_apply_order
       builder = XML.new("<invoice/>")
+      builder.add_element 'refund_apply_order', refund_apply_order
       builder.add_element 'amount_in_cents', amount_in_cents
       builder.to_s
     end
 
-    def refund_line_items_to_xml line_items = []
+    def refund_line_items_to_xml line_items = [], refund_apply_order
       builder = XML.new("<invoice/>")
+      builder.add_element 'refund_apply_order', refund_apply_order
+
       node = builder.add_element 'line_items'
       line_items.each do |line_item|
         adj_node = node.add_element 'adjustment'

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -51,6 +51,7 @@ module Recurly
       address
       net_terms
       collection_method
+      refund_apply_order
     )
     alias to_param invoice_number_with_prefix
 

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -72,8 +72,8 @@ describe Invoice do
 
     describe "#refund_to_xml" do
       it "must serialize line_items" do
-        @invoice.send(:refund_line_items_to_xml, @line_items).must_equal(
-          '<invoice><line_items><adjustment><uuid>charge1</uuid><quantity>1</quantity><prorate>false</prorate></adjustment></line_items></invoice>'
+        @invoice.send(:refund_line_items_to_xml, @line_items, 'credit').must_equal(
+          '<invoice><refund_apply_order>credit</refund_apply_order><line_items><adjustment><uuid>charge1</uuid><quantity>1</quantity><prorate>false</prorate></adjustment></line_items></invoice>'
         )
       end
     end
@@ -99,8 +99,8 @@ describe Invoice do
 
     describe "#refund_to_xml" do
       it "must serialize amount_in_cents" do
-        @invoice.send(:refund_amount_to_xml, 1000).must_equal(
-          '<invoice><amount_in_cents>1000</amount_in_cents></invoice>'
+        @invoice.send(:refund_amount_to_xml, 1000, 'credit').must_equal(
+          '<invoice><refund_apply_order>credit</refund_apply_order><amount_in_cents>1000</amount_in_cents></invoice>'
         )
       end
     end


### PR DESCRIPTION
cc/ @bhelx 

tests:

- Create a new invoice and make sure it is paid
- Attempt a transaction first line item refund:

```ruby
inv = Recurly::Invoice.find(<invoice_number>)
ref_inv = inv.refund([{ adjustment: inv.line_items.first, quantity: 1, prorate: false}], 'transaction')
puts ref_inv.invoice_number
```

- Create another invoice and make sure it is paid
- Attempt a transaction first open amount refund:

```ruby
inv = Recurly::Invoice.find(<invoice_number>)
ref_inv = inv.refund_amount(5_00, 'transaction')
puts ref_inv.invoice_number
```