### PR TITLE
Support new coupon duration attributes

### DIFF
--- a/lib/recurly/coupon.rb
+++ b/lib/recurly/coupon.rb
@@ -20,6 +20,9 @@ module Recurly
       redeem_by_date
       single_use
       applies_for_months
+      duration
+      temporal_unit
+      temporal_amount
       max_redemptions
       applies_to_all_plans
       created_at

--- a/spec/fixtures/coupons/show-200.xml
+++ b/spec/fixtures/coupons/show-200.xml
@@ -17,6 +17,9 @@ Content-Type: application/xml; charset=utf-8
   <max_redemptions type="integer">100</max_redemptions>
   <applies_to_all_plans type="boolean">true</applies_to_all_plans>
   <created_at type="datetime">2011-04-30T08:00:00Z</created_at>
+  <duration>temporal</duration>
+  <temporal_unit>month</temporal_unit>
+  <temporal_amount type="integer">1</temporal_amount>
   <plan_codes type="array">
     <plan_code>saul_good</plan_code>
   </plan_codes>


### PR DESCRIPTION
**Related Items (JIRA/SF/Bugsnag)**:
https://jira.recurly.net/browse/CORE-1006

**Description**:
Add support for new coupon duration attributes (duration, temporal_unit, temporal_amount)

**Additional approvers**:
@cbarton 
@dnchilds 

**Testing**:
- Verify that new coupons can be created with duration=forever/single_use/temporal, single_use=true, & applies_for_months=n
- Verify that when reading all of the created coupons the values for duration, temporal_unit, temporal_amount, single_use, & applies_for_months are all correct

**Deployment instructions**:
This should be deployed after recurly/recurly-app#4780