### PR TITLE
Add tax_exempt, tax_code, accounting_code to transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 * Added ability to enter offline payment [PR](https://github.com/recurly/recurly-client-ruby/pull/189/)
+* Add `tax_exempt`, `tax_code`, and `accounting_code` support for one time transactions [PR](https://github.com/recurly/recurly-client-ruby/pull/198)
 
 <a name="v2.4.4"></a>
 ## v2.4.4 (2015-6-25)

--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -43,9 +43,12 @@ module Recurly
       ip_address
       collected_at
       description
+      tax_exempt
+      tax_code
+      accounting_code
     )
     alias to_param uuid
-    
+
     def self.to_xml(attrs)
       transaction = new attrs
       transaction.to_xml


### PR DESCRIPTION
cc/ @bhelx 

tests:
  - the following should create a tax exempt charge
```ruby
t = Recurly::Transaction.create(amount_in_cents: 10_00, 
                            currency: 'USD',
                            tax_exempt: true,
                            account: { account_code: '<account_code>' })

puts t.uuid
```