### PR TITLE
adding support for new coupon duration attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 * Added ability to enter offline payment [PR](https://github.com/recurly/recurly-client-ruby/pull/189/)
 * Add `tax_exempt`, `tax_code`, and `accounting_code` support for one time transactions [PR](https://github.com/recurly/recurly-client-ruby/pull/198)
+* Added 'duration' to 'Coupon'
+* Added 'temporal_unit' to 'Coupon'
+* Added 'temporal_amount' to 'Coupon'
 
 <a name="v2.4.4"></a>
 ## v2.4.4 (2015-6-25)

--- a/lib/recurly/coupon.rb
+++ b/lib/recurly/coupon.rb
@@ -20,6 +20,9 @@ module Recurly
       redeem_by_date
       single_use
       applies_for_months
+      duration
+      temporal_unit
+      temporal_amount
       max_redemptions
       applies_to_all_plans
       created_at

--- a/spec/fixtures/coupons/show-200.xml
+++ b/spec/fixtures/coupons/show-200.xml
@@ -17,6 +17,9 @@ Content-Type: application/xml; charset=utf-8
   <max_redemptions type="integer">100</max_redemptions>
   <applies_to_all_plans type="boolean">true</applies_to_all_plans>
   <created_at type="datetime">2011-04-30T08:00:00Z</created_at>
+  <duration>temporal</duration>
+  <temporal_unit>month</temporal_unit>
+  <temporal_amount type="integer">1</temporal_amount>
   <plan_codes type="array">
     <plan_code>saul_good</plan_code>
   </plan_codes>


### PR DESCRIPTION
**Description**:
Add support for new coupon duration attributes (duration, temporal_unit, temporal_amount)

**Additional approvers**:
@bhelx

**Testing**:
- Verify that new coupons can be created with duration=forever/single_use/temporal, single_use=true, & applies_for_months=n
- Verify that when reading all of the created coupons the values for duration, temporal_unit, temporal_amount, single_use, & applies_for_months are all correct

```
test_param_sets = [
  {duration: :forever},
  {duration: :single_use},
  {duration: :temporal, temporal_unit: :month, temporal_amount: 3},
  {single_use: true},
  {applies_for_months: 3}
]

test_param_sets.each do |param_set|
  puts param_set
  puts Recurly::Coupon.create({name: SecureRandom.uuid, coupon_code: SecureRandom.uuid, discount_in_cents: 2_00}.merge(param_set)).reload
  puts
end
```

**Deployment instructions**:
On hold until server side feature is deployed