### PR TITLE
Adding setup_fee_accounting_code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 * Adding `gateway_error_code` to `Transaction`
+* Added `setup_fee_accounting_code` attribute to `Plan`
 
 <a name="v2.4.5"></a>
 ## v2.4.5 (2015-7-31)

--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ The default currency is USD. To override with a different code:
 Recurly.default_currency = 'EUR' # Assign nil to disable the default entirely.
 ```
 
-If you are using [Recurly.js](https://js.recurly.com) you can store "Public API Key" (which can be found under "API Credentials" on the `api_access` admin page):
+If you are using [Recurly.js](https://js.recurly.com) you can store "Public API Key" (which can be found
+under "API Credentials" on the `api_access` admin page):
 
 ``` ruby
 Recurly.js.public_key = ENV['RECURLY_PUBLIC_API_KEY']
 ```
 
-Then, in your Rails project you can create `recurly_service.js.erb` file and [configure](https://docs.recurly.com/js/#configure) recurly.js with public key this way:
+Then, in your Rails project you can create `recurly_service.js.erb` file and
+[configure](https://docs.recurly.com/js/#configure) recurly.js with public key this way:
 
 ``` js
 recurly.configure({ publicKey: '<%= Recurly.js.public_key %>'});
@@ -70,7 +72,8 @@ Recurly::API.net_http = {
 ```
 
 ## Multi-Threaded Configuration
-If you are using the client in a multi-threaded environment and require a different configuration per thread you can use the following within the thread's context:
+If you are using the client in a multi-threaded environment and require a different configuration per
+thread you can use the following within the thread's context:
 
 ``` ruby
 Recurly.config({
@@ -81,8 +84,9 @@ Recurly.config({
 })
 ```
 
-Any configuration items you do not include in the above config call will be defaulted to the standard configuration items.   For example if you do not define default_currency then
-Recurly.default_currency will be used.
+Any configuration items you do not include in the above config call will be defaulted to the standard
+configuration items. For example if you do not define default_currency then Recurly.default_currency
+will be used.
 
 
 ## Usage
@@ -107,9 +111,8 @@ Recurly's gem API is available
 
 Developing for the Recurly gem is easy with [Bundler](http://gembundler.com/).
 
-Fork and clone the repository, `cd` into the directory, and, with a Ruby of
-your choice (1.9.3 or greater), set up your
-environment.
+Fork and clone the repository, `cd` into the directory, and, with a Ruby of your choice
+(1.9.3 or greater), set up your environment.
 
 If you don't have Bundler installed, install it with the following command:
 
@@ -138,8 +141,7 @@ $ XML=nokogiri bundle exec rake
 If you plan on submitting a patch, please write tests for it (we use
 [MiniTest::Spec](http://bfts.rubyforge.org/minitest/MiniTest/Expectations.html)).
 
-If everything looks good, submit a pull request on GitHub and we'll bring in
-your changes.
+If everything looks good, submit a pull request on GitHub and we'll bring in your changes.
 
 ## License
 

--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -24,6 +24,7 @@ module Recurly
       trial_interval_unit
       total_billing_cycles
       accounting_code
+      setup_fee_accounting_code
       tax_exempt
       tax_code
       created_at

--- a/spec/recurly/plan_spec.rb
+++ b/spec/recurly/plan_spec.rb
@@ -3,18 +3,36 @@ require 'spec_helper'
 describe Plan do
   let(:plan) {
     Plan.new(
-      :plan_code            => "gold",
-      :name                 => "The Gold Plan",
-      :unit_amount_in_cents => 79_00
+      :plan_code                 => "gold",
+      :name                      => "The Gold Plan",
+      :unit_amount_in_cents      => 79_00,
+      :description               => "The Gold Plan is for folks who love gold.",
+      :accounting_code           => "gold_plan_acc_code",
+      :setup_fee_accounting_code => "Setup Fee AC",
+      :setup_fee_in_cents        => 60_00,
+      :plan_interval_length      => 1,
+      :plan_interval_unit        => 'months',
+      :tax_exempt                => false
     )
   }
 
   it 'must serialize' do
     plan.to_xml.must_equal <<XML.chomp
 <plan>\
+<accounting_code>gold_plan_acc_code</accounting_code>\
+<description>The Gold Plan is for folks who love gold.</description>\
 <name>The Gold Plan</name>\
 <plan_code>gold</plan_code>\
-<unit_amount_in_cents><USD>7900</USD></unit_amount_in_cents>\
+<plan_interval_length>1</plan_interval_length>\
+<plan_interval_unit>months</plan_interval_unit>\
+<setup_fee_accounting_code>Setup Fee AC</setup_fee_accounting_code>\
+<setup_fee_in_cents>\
+<USD>6000</USD>\
+</setup_fee_in_cents>\
+<tax_exempt>false</tax_exempt>\
+<unit_amount_in_cents>\
+<USD>7900</USD>\
+</unit_amount_in_cents>\
 </plan>
 XML
   end


### PR DESCRIPTION
Exposing a `setup_fee_accounting` code to the client library since it's now available.

Also updated spacing and fixed a typo in the Readme, and made the spec for creating a plan a bit more robust.