### PR TITLE
allow Resource.find_each to be chained with other iterator methods without passing a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Adding `gateway_error_code` to `Transaction`
 * Added `setup_fee_accounting_code` attribute to `Plan`
+* Add support for `Resource.find_each` to be chained with other iterator methods without passing a block
 
 <a name="v2.4.5"></a>
 ## v2.4.5 (2015-7-31)

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -283,8 +283,8 @@ module Recurly
       # @see Pager#find_each
       # @example
       #   Recurly::Account.find_each { |a| p a }
-      def find_each per_page = 50
-        paginate(:per_page => per_page).find_each(&Proc.new)
+      def find_each per_page = 50, &block
+        paginate(:per_page => per_page).find_each(&block)
       end
 
       # @return [Integer] The total record count of the resource in question.

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -84,6 +84,22 @@ XML
       end
     end
 
+    describe ".find_each" do
+      it "must accept a block" do
+        stub_api_request(:get, 'resources?per_page=50') { XML[200][:index] }
+        results = []
+        resource.find_each { |r| r.must_be_instance_of resource ; results << r }
+        results.wont_be_empty
+      end
+
+      it "must allow chaining of iterator methods without passing a block" do
+        stub_api_request(:get, 'resources?per_page=50') { XML[200][:index] }
+        results = []
+        resource.find_each.to_a.map.each { |r| r.must_be_instance_of resource ; results << r }
+        results.wont_be_empty
+      end
+    end
+
     describe ".create" do
       it "must return a saved record when valid" do
         stub_api_request(:post, 'resources') { XML[201] }


### PR DESCRIPTION
Add support for `Resource.find_each` to be chained with other iterator methods without passing a block.

#### Before
``` ruby
Recurly::Account.find_each.map {|a| a.email }
# => ArgumentError: tried to create Proc object without a block
```

#### After
```ruby
Recurly::Account.find_each.map {|a| a.email }
# => ["test1@example.com", "test2@example.com"]
```