### PR TITLE
Skip unknown associations in the XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+* Ignore associations defined in xml but not in the Resource subclasses
+
 <a name="v2.4.6"></a>
 ## v2.4.6 (2015-8-31)
 

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -403,10 +403,14 @@ module Recurly
           end
 
           if el.children.empty? && href = el.attribute('href')
-            resource_class = Recurly.const_get(
-              Helper.classify(klass.association_class_name(el.name) ||
-                el.attribute('type') || el.name), false
-            )
+            klass_name = Helper.classify(klass.association_class_name(el.name) ||
+                                         el.attribute('type') ||
+                                         el.name)
+
+            next unless Recurly.const_defined?(klass_name)
+
+            resource_class = Recurly.const_get(klass_name, false)
+
             case el.name
             when *klass.associations_for_relation(:has_many)
               record[el.name] = Pager.new(

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -170,6 +170,19 @@ XML
           proc { record.follow_link :cancel }.must_raise API::UnprocessableEntity
         end
       end
+
+      it 'should ignore the element and not raise an exception when unknown association is present' do
+        xml = <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<resource href="https://api.recurly.com/v2/resources/1">
+  <unknown_associations href="https://api.recurly.com/v2/resources/1/unknown_associations"/>
+</resource>
+XML
+
+        record = resource.from_xml(xml)
+        record.uri.must_equal "https://api.recurly.com/v2/resources/1"
+      end
+
     end
 
     describe ".associations" do


### PR DESCRIPTION
If there exist an unknown association it should just skip the element
instead of throwing an exception.

As an example, if you are using API version 2.1 and you try to fetch a bulk coupon, It will throw a NameError [here](https://github.com/recurly/recurly-client-ruby/blob/master/lib/recurly/resource.rb#L406) because it cannot find the association class for the element `<unique_coupon_codes />`. 

Approvers: @cbarton 

## Testing

* Fetch a bulk coupon with the `<unique_coupon_codes />` element, it should not throw an error

```ruby
coupon = Recurly::Coupon.find('mycouponcode')
```