### PR TITLE
Bulk and unique coupons

### DIFF
--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -15,10 +15,10 @@ module Recurly
 
     # @return [Account]
     belongs_to :account
-		# @return [Invoice, nil]
-		belongs_to :invoice
-		# @return [Subscription, nil]
-		belongs_to :subscription
+    # @return [Invoice, nil]
+    belongs_to :invoice
+    # @return [Subscription, nil]
+    belongs_to :subscription
 
     define_attribute_methods %w(
       uuid


### PR DESCRIPTION
Adding support for creating bulk coupons and adding support for generating coupon codes from a parent coupon.

Approvers: @cbarton 

## Testing

* Create a bulk coupon

```ruby
require 'securerandom'

code = SecureRandom.uuid

coupon = Recurly::Coupon.create(
  name: "My coupon #{code}",
  coupon_code: code,
  discount_in_cents: 2_00,
  coupon_type: Recurly::Coupon::BULK,
  unique_code_template: "'#{code}-'******'-suffix'"
)
```

* Try to generate some codes on it and it should give you back a pager:

```ruby
unique_codes = coupon.generate(10)
unique_codes.each do |c|
  puts c.coupon_code
end
```

* You should also be able to pull them off of the coupon:

```ruby
coupon.unique_coupon_codes.each do |c|
  puts c.coupon_code
end
```