### PR TITLE
Support editing and restoring coupons

### DIFF
--- a/lib/recurly/coupon.rb
+++ b/lib/recurly/coupon.rb
@@ -43,16 +43,6 @@ module Recurly
     )
     alias to_param coupon_code
 
-    # Saves new records only.
-    #
-    # @return [true, false]
-    # @raise [Recurly::Error] For persisted coupons.
-    # @see Resource#save
-    def save
-      return super if new_record?
-      raise Recurly::Error, "#{self.class.collection_name} cannot be updated"
-    end
-
     # Redeem a coupon with a given account or account code.
     #
     # @return [true]
@@ -105,6 +95,11 @@ module Recurly
       redemption = redeem account_code, currency
       raise Invalid.new(self) unless redemption.persisted?
       redemption
+    end
+
+    def restore!
+      return false unless link? :restore
+      reload follow_link(:restore, body: self.to_xml(delta: true))
     end
 
     def unlimited_redemptions_per_account?

--- a/spec/fixtures/coupons/show-200.xml
+++ b/spec/fixtures/coupons/show-200.xml
@@ -27,4 +27,5 @@ Content-Type: application/xml; charset=utf-8
     <plan_code>saul_good</plan_code>
   </plan_codes>
   <a name="redeem" href="https://api.recurly.com/v2/coupons/bettercallsaul/redeem" method="put"/>
+  <a name="restore" href="https://api.recurly.com/v2/coupons/bettercallsaul/restore" method="put"/>
 </coupon>

--- a/spec/recurly/coupon_spec.rb
+++ b/spec/recurly/coupon_spec.rb
@@ -14,12 +14,6 @@ describe Coupon do
     end
   end
 
-  describe "#save" do
-    it "must not save a new record" do
-      proc { coupon.save }.must_raise Error
-    end
-  end
-
   describe "#redeem" do
     it "must be redeemable" do
       stub_api_request(


### PR DESCRIPTION
Supporting new paths for restoring and editing coupons

Approvers: @cbarton 

## Testing

* Fetch a coupon and test that you can edit these fields:

```ruby
coupon = Recurly::Coupon.find('derp')

coupon.max_redemptions = 99
coupon.max_redemptions_per_account = 3
coupon.redeem_by_date = '2025-09-09'
coupon.description = 'derp'
coupon.invoice_description = 'derp'

coupon.save
```

* Fetch an expired coupon and restore it from the dead:

```ruby
coupon = Recurly::Coupon.find('expired')

coupon.restore!
```
