### PR TITLE
Fixing spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Add `cc_emails` attribute to `Account` [PR](https://github.com/recurly/recurly-client-ruby/pull/216)
 * Add webhooks parsers [PR](https://github.com/recurly/recurly-client-ruby/pull/217)
+* Fixed `setup_fee_accounting_code` spec [PR](https://github.com/recurly/recurly-client-ruby/pull/218)
 
 <a name="v2.4.7"></a>
 ## v2.4.7 (2015-10-02)

--- a/spec/recurly/plan_spec.rb
+++ b/spec/recurly/plan_spec.rb
@@ -8,7 +8,7 @@ describe Plan do
       :unit_amount_in_cents      => 79_00,
       :description               => "The Gold Plan is for folks who love gold.",
       :accounting_code           => "gold_plan_acc_code",
-      :setup_fee_accounting_code => "Setup Fee AC",
+      :setup_fee_accounting_code => "setup_fee_ac",
       :setup_fee_in_cents        => 60_00,
       :plan_interval_length      => 1,
       :plan_interval_unit        => 'months',
@@ -25,7 +25,7 @@ describe Plan do
 <plan_code>gold</plan_code>\
 <plan_interval_length>1</plan_interval_length>\
 <plan_interval_unit>months</plan_interval_unit>\
-<setup_fee_accounting_code>Setup Fee AC</setup_fee_accounting_code>\
+<setup_fee_accounting_code>setup_fee_ac</setup_fee_accounting_code>\
 <setup_fee_in_cents>\
 <USD>6000</USD>\
 </setup_fee_in_cents>\


### PR DESCRIPTION
Fixes a spec related to an impossible to set `setup_fee_accounting_code`. That filed does not allow spaces.