### PR TITLE
removes destroy_uri method that generates incorrect uri from redempti…

### DIFF
--- a/lib/recurly/redemption.rb
+++ b/lib/recurly/redemption.rb
@@ -28,10 +28,6 @@ module Recurly
       created_at
     )
 
-    def destroy_uri
-      uri + "s/#{uuid}"
-    end
-
     def save
       return false if persisted?
       copy_from coupon.redeem account, currency

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -913,14 +913,10 @@ module Recurly
     #   race_condition.destroy # raises Recurly::Resource::NotFound
     def destroy
       return false unless persisted?
-      @response = API.delete destroy_uri
+      @response = API.delete uri
       @destroyed = true
     rescue API::NotFound => e
       raise NotFound, e.description
-    end
-
-    def destroy_uri
-      uri
     end
 
     def signable_attributes


### PR DESCRIPTION
**Related Items (JIRA/SF/Bugsnag)**: https://jira.recurly.net/browse/SUPPORTENG-330

**Description**: destroy_uri method in redemption class was creating a bad uri with duplicate uuid; destroy_uri method in resource class was duplicating uri method. Removes destroy_uri methods from redemption and resource class.

**Approvers**: @jss79 

**Testing**: create a coupon redemption and call the uri method on the redemption to generate a uri that looks like this: https://:subdomain.recurly.com/v2/accounts/:account_code/redemptions/:uuid