### PR TITLE
Don't set changed attributes when reading a resource

### DIFF
--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -478,7 +478,11 @@ module Recurly
         associations << Association.new(:has_many, collection_name.to_s, options)
         associations_helper.module_eval do
           define_method collection_name do
-            self[collection_name] ||= []
+            if self[collection_name]
+              self[collection_name]
+            else
+              attributes[collection_name] = []
+            end
           end
           if options.key?(:readonly) && options[:readonly] == false
             define_method "#{collection_name}=" do |collection|

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -210,6 +210,12 @@ XML
       it "must return a pager for fresh records" do
         resource.new.reasons.must_be_kind_of Enumerable
       end
+
+      it "should not set changed attributes when reading a resource" do
+        record = resource.new
+        record.reasons
+        record.changed_attributes.keys.must_be_empty
+      end
     end
 
     describe ".has_one and .belongs_to" do


### PR DESCRIPTION
We don't want to set changed attributes when reading a resource, we only want to do that when writing to one. This change will return the changes if they're actual changes, and set the object's attribute to an empty array if they're not.

This addresses https://github.com/recurly/recurly-client-ruby/issues/222

cc: @bhelx 