### PR TITLE
fix add_on quantity handling when adding an already existing add_on

### DIFF
--- a/lib/recurly/subscription/add_ons.rb
+++ b/lib/recurly/subscription/add_ons.rb
@@ -27,7 +27,7 @@ module Recurly
 
         exist = @add_ons.find { |a| a.add_on_code == add_on.add_on_code }
         if exist
-          exist.quantity ||= 1 and exist.quantity += 1
+          exist.quantity ||= 1 and exist.quantity += add_on.quantity || 1
 
           if add_on.unit_amount_in_cents
             exist.unit_amount_in_cents = add_on.unit_amount_in_cents


### PR DESCRIPTION
Hi,

I'm experiencing a weird behaviour when adding add-ons with quantity specified to subscription already having this add-on.

I can see in the Subscription::AddOns class that added add-on quantity is not handled properly if the add-on already exist since the code just adds 1 to the existing quantity.

I wrote a fix for this, I may write a test case too if you like.

What do you think?

Best regards,
