### PR TITLE
updates redemption method for account to get specific redemption base…

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -22,8 +22,8 @@ module Recurly
 
     has_many :redemptions
 
-    def redemption
-      redemptions.first
+    def redemption coupon_code
+      redemptions.detect { |r| r.coupon_code == coupon_code }
     end
 
     define_attribute_methods %w(

--- a/lib/recurly/redemption.rb
+++ b/lib/recurly/redemption.rb
@@ -24,13 +24,10 @@ module Recurly
       total_discounted_in_cents
       currency
       state
+      coupon_code
       subscription_uuid
       created_at
     )
-
-    def destroy_uri
-      uri + "s/#{uuid}"
-    end
 
     def save
       return false if persisted?

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -917,14 +917,10 @@ module Recurly
     #   race_condition.destroy # raises Recurly::Resource::NotFound
     def destroy
       return false unless persisted?
-      @response = API.delete destroy_uri
+      @response = API.delete uri
       @destroyed = true
     rescue API::NotFound => e
       raise NotFound, e.description
-    end
-
-    def destroy_uri
-      uri
     end
 
     def signable_attributes


### PR DESCRIPTION
Description: Adds a way to get and delete coupon redemptions on accounts with more than one coupon redemption and fixes bug where coupon_redemption.destroy made DELETE request to the wrong url

To recreate the bug: 

```ruby
account = Recurly::Account.find('account_with_coupon_redemption')
redemption = account.redemption
redemption.destroy
```

Results in a 404 because delete request is made to a url in this form:
http://:subdomain.recurly.com/v2/accounts/:account_code/redemptions/:uuids/:uuid

When it should be made to a url in this form: 
http://:subdomain.recurly.com/v2/accounts/:account_code/redemptions/:uuid

Testing the changes/fix: 
* Create an account with multiple coupon redemptions. 
* Get a specific redemption using the coupon_code of the redemption. 
* Delete the redemption. 

```ruby
account = Recurly::Account.find('account_with_one_or_more_coupon_redemptions')
redemption = account.redemption('coupon_code_for_redemption')
redemption.destroy
```