### PR TITLE
Set id attribute for transactions from webhooks

### DIFF
--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -316,6 +316,12 @@ module Recurly
       # @example
       #   Recurly::Account.find "heisenberg"
       #   # => #<Recurly::Account account_code: "heisenberg", ...>
+      #   Use the following identifiers for these types of objects:
+      #     for accounts use account_code
+      #     for plans use plan_code
+      #     for invoices use invoice_number
+      #     for subscriptions use uuid
+      #     for transactions use uuid
       def find uuid, options = {}
         if uuid.nil?
           # Should we raise an ArgumentError, instead?

--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -21,6 +21,7 @@ module Recurly
     belongs_to :subscription
 
     define_attribute_methods %w(
+      id
       uuid
       action
       amount_in_cents


### PR DESCRIPTION
Description: Adds an id attribute to transactions so it can be used for transaction objects built from the xml sent in a webhook

To recreate the bug: 

```ruby
webhook_notification = Recurly::Webhook.parse(request.body.read)
transaction_id = webhook_notification.transaction.id
```

Results in the following error: 
NoMethodError: undefined method `id' for #<Recurly::Transaction:0x007fde896c7888>.

Testing the changes/fix: 
* use the parse method to parse a webhook sent for a new transaction
* call transaction and id on the webhook notification to get the uuid of the transaction

```ruby
webhook_notification = Recurly::Webhook.parse(request.body.read)
transaction_id = webhook_notification.transaction.id
```