### PR TITLE
Add currency attribute to BillingInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+* Add `currency` attribute to `BillingInfo` object so client can pass currency on create/update [PR](https://github.com/recurly/recurly-client-ruby/pull/231)
+
 <a name="v2.5.0"></a>
 ## v2.5.0 (2016-01-13)
 

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -23,6 +23,7 @@ module Recurly
       ip_address
       ip_address_country
       token_id
+      currency
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES
 
     # @return ["credit_card", "paypal", "amazon", "bank_account", nil] The type of billing info.


### PR DESCRIPTION
This allows the merchant to send a custom currency on billing info creation and update for verification purposes. For instance, if your site default is USD and you are trying to verify for EUR, you may end up having two verifications. 

### Testing

```ruby
account = Recurly::Account.find('1')

account.billing_info = {
  first_name: 'Verena',
  last_name: 'Example',
  number: '4111-1111-1111-1111',
  verification_value:  '123',
  month: 11,
  year: 2019,
  currency: 'EUR'
}

account.billing_info.save!
```

Approvers: @csmb 