### PR TITLE
Bump 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.5.2"></a>
+## v2.5.2 (2016-05-02)
+
+* Remove Gemfile.lock, add more rubies to testing matrix [PR](https://github.com/recurly/recurly-client-ruby/pull/234)
+* Remove autoload and reorder requires [PR](https://github.com/recurly/recurly-client-ruby/pull/236)
+* Usage Based Billing [PR](https://github.com/recurly/recurly-client-ruby/pull/237)
+
 <a name="v2.5.1"></a>
 ## v2.5.1 (2016-02-18)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.5.1'
+gem 'recurly', '~> 2.5.2'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 5
-    PATCH   = 1
+    PATCH   = 2
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
Bumping for release

* Remove Gemfile.lock, add more rubies to testing matrix [PR](https://github.com/recurly/recurly-client-ruby/pull/234)
* Remove autoload and reorder requires [PR](https://github.com/recurly/recurly-client-ruby/pull/236)
* Usage Based Billing [PR](https://github.com/recurly/recurly-client-ruby/pull/237)