### PR TITLE
Remove stray puts in spec

### DIFF
--- a/spec/recurly/usages_spec.rb
+++ b/spec/recurly/usages_spec.rb
@@ -36,7 +36,6 @@ describe Usage do
 
       query = "billing_status=all&datetime_type=usage&end_datetime=#{time}&start_datetime=#{time}"
 
-      puts query
       stub_api_request(
         :get,
         "subscriptions/abcdef1234567890/add_ons/marketing_email/usage?#{query}",


### PR DESCRIPTION
Found a stray `puts` call in the specs. This was my fault.