### PR TITLE
Use gemspec instead of gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,3 @@
 source 'https://rubygems.org'
+
 gemspec
-
-group :development do
-  gem 'nokogiri',      '~> 1.6.0', :group     => :test
-  gem 'jruby-openssl', '~> 0.7.4', :platforms => :jruby # For WebMock.
-
-  gem 'redcarpet',                 :platforms => :ruby
-  gem 'yard'
-  gem 'rubysl',                    :platforms => :rbx
-  gem 'rubysl-resolv', '~> 2.0',   :platforms => :rbx
-  gem 'racc',                      :platforms => :rbx
-
-  gem 'webmock', '~> 1.7'
-  gem 'pry'
-end

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -22,7 +22,16 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
+  s.add_dependency('nokogiri','~> 1.6.0')
+
   s.add_development_dependency 'rake', '~> 11.1'
   s.add_development_dependency 'minitest', '~> 5.8'
-  s.add_development_dependency 'webmock',  '~> 1.24'
+  s.add_development_dependency 'webmock',  '~> 1.7'
+
+  if RUBY_PLATFORM != 'java'
+    s.add_development_dependency 'redcarpet'
+    s.add_development_dependency 'yard'
+    s.add_development_dependency 'racc'
+    s.add_development_dependency 'pry'
+  end
 end


### PR DESCRIPTION
Let's use the gemspec rather than the gemfile. I'll add some more explicit versions for some of these after seeing how they behave in the test matrix.