### PR TITLE
Support original_transaction link

### DIFF
--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -16,7 +16,7 @@ module Recurly
 
     @@base_uri = "https://api.recurly.com/v2/"
 
-    RECURLY_API_VERSION = '2.2'
+    RECURLY_API_VERSION = '2.3'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -19,6 +19,8 @@ module Recurly
     belongs_to :invoice
     # @return [Subscription, nil]
     belongs_to :subscription
+    # @return [Transaction, nil]
+    belongs_to :original_transaction, class_name: 'Transaction'
 
     define_attribute_methods %w(
       id

--- a/spec/fixtures/transactions/show-200.xml
+++ b/spec/fixtures/transactions/show-200.xml
@@ -4,6 +4,7 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <transaction href="https://api.recurly.com/v2/transactions/abcdef1234567890">
   <account href="https://api.recurly.com/v2/accounts/account"/>
+  <original_transaction href="https://api.recurly.com/v2/transactions/1234567890abcdef"/>
   <uuid>abcdef1234567890</uuid>
   <action>purchase</action>
   <amount_in_cents type="integer">30000</amount_in_cents>

--- a/spec/recurly/transaction_spec.rb
+++ b/spec/recurly/transaction_spec.rb
@@ -11,6 +11,16 @@ describe Transaction do
     end
   end
 
+  describe ".original_transaction" do
+    it "must return a Transaction object" do
+      stub_api_request(:get, 'transactions/abcdef1234567890', 'transactions/show-200')
+      stub_api_request(:get, 'transactions/1234567890abcdef', 'transactions/show-200')
+
+      transaction = Transaction.find 'abcdef1234567890'
+      transaction.original_transaction.must_be_instance_of Transaction
+    end
+  end
+
   describe "#save" do
     it "must re-raise a transaction error" do
       stub_api_request :post, 'transactions', 'transaction_error'


### PR DESCRIPTION
It's for a new feature that returns an original_transaction link on refunded transactions:

https://github.com/recurly/recurly-client-php/issues/216