### PR TITLE
Parse Fraud object if it exists

### DIFF
--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -47,8 +47,10 @@ module Recurly
       tax_exempt
       tax_code
       accounting_code
+      fraud
     )
     alias to_param uuid
+    alias fraud_info fraud
 
     def self.to_xml(attrs)
       transaction = new attrs

--- a/spec/fixtures/transactions/show-200.xml
+++ b/spec/fixtures/transactions/show-200.xml
@@ -49,4 +49,8 @@ Content-Type: application/xml; charset=utf-8
       </billing_info>
     </account>
   </details>
+  <fraud>
+    <score type="integer">88</score>
+    <decision>DECLINE</decision>
+  </fraud>
 </transaction>

--- a/spec/recurly/transaction_spec.rb
+++ b/spec/recurly/transaction_spec.rb
@@ -2,12 +2,21 @@ require 'spec_helper'
 
 describe Transaction do
   describe ".find" do
-    it "must return a transaction when available" do
+    let(:transaction) do
       stub_api_request(
         :get, 'transactions/abcdef1234567890', 'transactions/show-200'
       )
-      transaction = Transaction.find 'abcdef1234567890'
+      Transaction.find 'abcdef1234567890'
+    end
+
+    it "must return a transaction when available" do
       transaction.must_be_instance_of Transaction
+    end
+
+    it "must parse the fraud_info object if it exists" do
+      transaction.fraud_info.must_be_instance_of Hash
+      transaction.fraud_info["score"].must_equal 88
+      transaction.fraud_info["decision"].must_equal "DECLINE"
     end
   end
 


### PR DESCRIPTION
If it's available, the transaction may contain a `fraud` object with some fraud information. This will parse that object into a Hash. I've aliased it as `fraud_info` because I find that is easier to understand and in line with the schema.

## Testing

* Make sure it prints an `int` score and a `string` decision and nothing more.

```ruby
t = Recurly::Transaction.find("35cc481437fa97b566ccf04f7bad4ae0")
puts t.fraud.inspect
#=> {"score"=>99, "decision"=>"APPROVE"}
```