### PR TITLE
Fix account.address_changed? dirty check

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -74,6 +74,14 @@ module Recurly
       true
     end
 
+    def changed_attributes
+      attrs = super
+      if address && address.changed?
+        attrs['address'] = address
+      end
+      attrs
+    end
+
     private
 
     def xml_keys

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -437,7 +437,9 @@ module Recurly
           else
             val = XML.cast(el)
             if 'address' == el.name && val.kind_of?(Hash)
-              record[el.name] = Address.new val
+              address = Address.new val
+              address.instance_variable_set(:@changed_attributes, {})
+              record[el.name] = address
             else
               record[el.name] = val
             end

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -181,6 +181,22 @@ XML
     end
   end
 
+  describe "#changed_attributes" do
+    let(:account) do
+      stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-200'
+      Account.find 'abcdef1234567890'
+    end
+
+    it "should be dirty if address was modified" do
+      account.address.address1 = "1600 Pennsylvania Ave."
+      account.changed?.must_equal true
+    end
+
+    it "should be clean if address was not modified" do
+      account.changed?.must_equal false
+    end
+  end
+
   describe "#to_xml" do
     it "must serialize" do
       account = Account.new :username => 'importantbreakfast'


### PR DESCRIPTION
Fixed Issue https://github.com/recurly/recurly-client-ruby/issues/247

But this is only a quick fix. I think we need an audit and a conversation around all the problems with `changed_attributes` and nested models.

