### PR TITLE
Bump 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
-
 ## Unreleased
+
+<a name="v2.6.0"></a>
+## v2.6.0 (2016-06-01)
 
 * Add support for free trial coupons [PR](https://github.com/recurly/recurly-client-ruby/pull/245)
 * Add support for `roku_billing_agreement_id` [PR](https://github.com/recurly/recurly-client-ruby/pull/246)

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,8 +1,8 @@
 module Recurly
   module Version
     MAJOR   = 2
-    MINOR   = 5
-    PATCH   = 2
+    MINOR   = 6
+    PATCH   = 0
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
## v2.6.0 (2016-06-01)

@csmb  Planning to do the push to rubygems tomorrow.

* Add support for free trial coupons [PR](https://github.com/recurly/recurly-client-ruby/pull/245)
* Add support for `roku_billing_agreement_id` [PR](https://github.com/recurly/recurly-client-ruby/pull/246)
* Fix `Account#address_changed?` dirty check [PR](https://github.com/recurly/recurly-client-ruby/pull/248)
* Add support for `<fraud>` if it exists on `Transaction` [PR](https://github.com/recurly/recurly-client-ruby/pull/244)
* Fix updating `unit_amount_in_cents` on `Subscription` [PR](https://github.com/recurly/recurly-client-ruby/pull/241)
* Fix stray `puts` in specs [PR](https://github.com/recurly/recurly-client-ruby/pull/239)