### PR TITLE
Fix changed? method missing on hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+* Fix method missing `changed?` in `Account` [PR](https://github.com/recurly/recurly-client-ruby/pull/251)
+
 <a name="v2.6.0"></a>
 ## v2.6.0 (2016-06-01)
 

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -76,7 +76,7 @@ module Recurly
 
     def changed_attributes
       attrs = super
-      if address && address.changed?
+      if address.respond_to?(:changed?) && address.changed?
         attrs['address'] = address
       end
       attrs


### PR DESCRIPTION
{{[43] pry(main)> acct_hash
=> {:account_code=>"98844e8b6f850a3c8c499e326035a8",
:username=>"7b8d1c00b0c",
:first_name=>"5b8527aaeec",
:last_name=>"a4891a91319",
:company_name=>"e69c52bec5b74ff72c53f",
:email=>"e687310ab5@7eb29c7869.com",
:vat_number=>nil,
:address=>
{:address1=>"c0c1c3 test street",
:address2=>"Apt 241",
:city=>"ADAMSVILLE",
:state=>"RI",
:zip=>"02801",
:country=>"United States"}}
[44] pry(main)> account = Recurly::Account.create!(acct_hash)
NoMethodError: undefined method `changed?' for #<Hash:0x007fc038706250>
from /Users/ktobo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/recurly-client-ruby-99d03c7507f1/lib/recurly/account.rb:79:in `changed_attributes'}}

reported by @karentobo 

## Testing

```ruby
acct_hash =
 {:account_code=>"98844e8b6f850a3c8c499e326035a8",
    :username=>"7b8d1c00b0c",
    :first_name=>"5b8527aaeec",
    :last_name=>"a4891a91319",
    :company_name=>"e69c52bec5b74ff72c53f",
    :email=>"e687310ab5@7eb29c7869.com",
    :vat_number=>nil,
    :address=>
{:address1=>"c0c1c3 test street",
 :address2=>"Apt 241",
 :city=>"ADAMSVILLE",
 :state=>"RI",
 :zip=>"02801",
 :country=>"United States"}}

account = Recurly::Account.create!(acct_hash)

puts account.inspect
```