### PR TITLE
API V2.3

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -6,6 +6,7 @@ module Recurly
   require 'recurly/resource'
   require 'recurly/billing_info'
   require 'recurly/account'
+  require 'recurly/account_balance'
   require 'recurly/add_on'
   require 'recurly/address'
   require 'recurly/tax_detail'

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -16,11 +16,13 @@ module Recurly
     has_many :invoices
     has_many :subscriptions
     has_many :transactions
+    has_many :redemptions
 
     # @return [BillingInfo, nil]
     has_one :billing_info, :readonly => false
 
-    has_many :redemptions
+    # @return [AccountBalance, nil]
+    has_one :account_balance, :readonly => true
 
     def redemption coupon_code
       redemptions.detect { |r| r.coupon_code == coupon_code }

--- a/lib/recurly/account_balance.rb
+++ b/lib/recurly/account_balance.rb
@@ -1,0 +1,11 @@
+module Recurly
+  class AccountBalance < Resource
+    # @return [Account, nil]
+    has_one :account, :readonly => true
+
+    define_attribute_methods %w(
+      past_due
+      balance_in_cents
+    )
+  end
+end

--- a/lib/recurly/add_on.rb
+++ b/lib/recurly/add_on.rb
@@ -16,6 +16,7 @@ module Recurly
       optional
       usage_type
       usage_percentage
+      revenue_schedule_type
       created_at
     )
     alias to_param add_on_code

--- a/lib/recurly/adjustment.rb
+++ b/lib/recurly/adjustment.rb
@@ -32,6 +32,7 @@ module Recurly
       end_date
       created_at
       quantity_remaining
+      revenue_schedule_type
 
       tax_in_cents
       tax_type

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -16,7 +16,7 @@ module Recurly
 
     @@base_uri = "https://api.recurly.com/v2/"
 
-    RECURLY_API_VERSION = '2.2'
+    RECURLY_API_VERSION = '2.3'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -25,6 +25,8 @@ module Recurly
       total_billing_cycles
       accounting_code
       setup_fee_accounting_code
+      revenue_schedule_type
+      setup_fee_revenue_schedule_type
       tax_exempt
       tax_code
       created_at

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -61,6 +61,7 @@ module Recurly
       customer_notes
       vat_reverse_charge_notes
       address
+      revenue_schedule_type
     )
     alias to_param uuid
 

--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -20,6 +20,9 @@ module Recurly
     # @return [Subscription, nil]
     belongs_to :subscription
 
+    # @return [Transaction, nil]
+    has_one :original_transaction, class_name: 'Transaction', readonly: true
+
     define_attribute_methods %w(
       id
       uuid

--- a/spec/fixtures/account_balance/show-200.xml
+++ b/spec/fixtures/account_balance/show-200.xml
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account_balance href="https://api.recurly.com/v2/accounts/abcdef1234567890/balance">
+  <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <past_due type="boolean">true</past_due>
+  <balance_in_cents>
+    <USD type="integer">2910</USD>
+    <EUR type="integer">-520</EUR>
+  </balance_in_cents>
+</account_balance>

--- a/spec/fixtures/accounts/show-200.xml
+++ b/spec/fixtures/accounts/show-200.xml
@@ -9,6 +9,7 @@ Content-Type: application/xml; charset=utf-8
   <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
   <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
   <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+  <account_balance href="https://api.recurly.com/v2/accounts/abcdef1234567890/balance"/>
   <account_code>abcdef1234567890</account_code>
   <username>shmohawk58</username>
   <email>larry.david@example.com</email>

--- a/spec/fixtures/adjustments/show-200.xml
+++ b/spec/fixtures/adjustments/show-200.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
   <total_in_cents type="integer">1200</total_in_cents>
   <currency>USD</currency>
   <product_code>basic</product_code>
+  <revenue_schedule_type>evenly</revenue_schedule_type>
   <tax_details type="array">
     <tax_detail>
       <name>california</name>

--- a/spec/fixtures/plans/add_ons/index-200.xml
+++ b/spec/fixtures/plans/add_ons/index-200.xml
@@ -9,6 +9,7 @@ Content-Type: application/xml; charset=utf-8
     <name>Marketing Email</name>
     <default_quantity type="integer">1</default_quantity>
     <display_quantity_on_hosted_page type="boolean">false</display_quantity_on_hosted_page>
+    <revenue_schedule_type>evenly</revenue_schedule_type>
     <unit_amount_in_cents>
       <USD type="integer">5</USD>
     </unit_amount_in_cents>

--- a/spec/fixtures/plans/show-200.xml
+++ b/spec/fixtures/plans/show-200.xml
@@ -22,6 +22,8 @@ Content-Type: application/xml; charset=utf-8
   <total_billing_cycles nil="nil"/>
   <accounting_code nil="nil"/>
   <setup_fee_accounting_code nil="nil"/>
+  <revenue_schedule_type>evenly</revenue_schedule_type>
+  <setup_fee_revenue_schedule_type>evenly</setup_fee_revenue_schedule_type>
   <created_at type="datetime">2016-04-13T21:59:18Z</created_at>
   <unit_amount_in_cents>
     <USD type="integer">1000</USD>

--- a/spec/fixtures/subscriptions/show-200.xml
+++ b/spec/fixtures/subscriptions/show-200.xml
@@ -24,6 +24,7 @@ Content-Type: application/xml; charset=utf-8
   <current_period_ends_at type="datetime">2011-05-01T06:59:59Z</current_period_ends_at>
   <trial_started_at nil="nil"></trial_started_at>
   <trial_ends_at nil="nil"></trial_ends_at>
+  <revenue_schedule_type>evenly</revenue_schedule_type>
   <subscription_add_ons type="array">
     <subscription_add_on>
       <add_on_type>usage</add_on_type>

--- a/spec/fixtures/transactions/show-200.xml
+++ b/spec/fixtures/transactions/show-200.xml
@@ -4,6 +4,7 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <transaction href="https://api.recurly.com/v2/transactions/abcdef1234567890">
   <account href="https://api.recurly.com/v2/accounts/account"/>
+  <original_transaction href="https://api.recurly.com/v2/transactions/0987654321fedcba"/>
   <uuid>abcdef1234567890</uuid>
   <action>purchase</action>
   <amount_in_cents type="integer">30000</amount_in_cents>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -227,5 +227,21 @@ XML
         account.subscriptions.first.must_be_instance_of Subscription
       end
     end
+
+    describe "when account has a balance" do
+      let(:account) {
+        stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-200'
+        stub_api_request :get, 'accounts/abcdef1234567890/balance', 'account_balance/show-200'
+        Account.find 'abcdef1234567890'
+      }
+
+      it "is able to retrieve and parse account balance" do
+        account_balance = account.account_balance
+        account_balance.past_due.must_equal true
+        balance = account_balance.balance_in_cents
+        balance[:USD].must_equal(2910)
+        balance[:EUR].must_equal(-520)
+      end
+    end
   end
 end

--- a/spec/recurly/adjustment_spec.rb
+++ b/spec/recurly/adjustment_spec.rb
@@ -22,6 +22,7 @@ describe Adjustment do
       adjustment.tax_type.must_equal 'usst'
       adjustment.tax_region.must_equal 'CA'
       adjustment.tax_rate.must_equal 0.0875
+      adjustment.revenue_schedule_type.must_equal 'evenly'
 
       tax_details = adjustment.tax_details
       tax_details.length.must_equal 2

--- a/spec/recurly/plan_spec.rb
+++ b/spec/recurly/plan_spec.rb
@@ -12,7 +12,8 @@ describe Plan do
       :setup_fee_in_cents        => 60_00,
       :plan_interval_length      => 1,
       :plan_interval_unit        => 'months',
-      :tax_exempt                => false
+      :tax_exempt                => false,
+      :revenue_schedule_type     => 'evenly'
     )
   }
 
@@ -25,6 +26,7 @@ describe Plan do
 <plan_code>gold</plan_code>\
 <plan_interval_length>1</plan_interval_length>\
 <plan_interval_unit>months</plan_interval_unit>\
+<revenue_schedule_type>evenly</revenue_schedule_type>\
 <setup_fee_accounting_code>setup_fee_ac</setup_fee_accounting_code>\
 <setup_fee_in_cents>\
 <USD>6000</USD>\

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -35,6 +35,7 @@ describe Subscription do
                                 terms_and_conditions
                                 customer_notes
                                 address
+                                revenue_schedule_type
                                 vat_reverse_charge_notes
                                 bank_account_authorized_at
                               }

--- a/spec/recurly/transaction_spec.rb
+++ b/spec/recurly/transaction_spec.rb
@@ -13,6 +13,14 @@ describe Transaction do
       transaction.must_be_instance_of Transaction
     end
 
+    it "must link to original_transaction if available" do
+      # original_transaction uses the same fixture for the sake of the test
+      stub_api_request(
+        :get, 'transactions/0987654321fedcba', 'transactions/show-200'
+      )
+      transaction.original_transaction.must_be_instance_of Transaction
+    end
+
     it "must parse the fraud_info object if it exists" do
       transaction.fraud_info.must_be_instance_of Hash
       transaction.fraud_info["score"].must_equal 88


### PR DESCRIPTION
Route changes:

- Added `GET /v2/account/:code/balance`

Request and Response Changes:

- Changed Transaction response:
  - Added `<original_transaction>` link element.
- Changed Add-On response:
  - Added `<revenue_schedule_type>` element.
- Changed Charge response:
  - Added `<revenue_schedule_type>` element.
- Changed Plan response:
  - Added `<revenue_schedule_type>` element.
  - Added `<setup_fee_revenue_schedule_type>` element.
- Changed Subscription response:
  - Added `<revenue_schedule_type>` element.
- Changed Account response:
  - Added `<account_balance>` link element.
- Added pagination options:
  - Added `sort` option: accepts `created_at`/`updated_at`, defaults to `created_at`.
  - Added `order` option: accepts `desc`/`asc`, defaults to `desc`.
  - Added `begin_time`/`end_time` options: accepts an ISO 8601 date or date and time.

Example of sort params:

```ruby
Recurly::Plan.all(
  begin_time: "2015-03-01T15:57:43Z",
  end_time: "2016-06-20T15:57:43Z",
  sort: :created_at
)
```

\cc @drewish @ajnadel 