### PR TITLE
Bump 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.7.1"></a>
+## v2.7.1 (2016-08-04)
+
+Bumps to API version 2.4
+
+- Add `updated_at` fields [PR](https://github.com/recurly/recurly-client-ruby/pull/256)
+- Add support for gift cards [PR](https://github.com/recurly/recurly-client-ruby/pull/257)
+
 <a name="v2.7.0"></a>
 ## v2.7.0 (2016-07-07)
 

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 7
-    PATCH   = 0
+    PATCH   = 1
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
Bumps to API version 2.4

- Add `updated_at` fields [PR](https://github.com/recurly/recurly-client-ruby/pull/256)
- Add support for gift cards [PR](https://github.com/recurly/recurly-client-ruby/pull/257)