### PR TITLE
Support shipping addresses

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -19,6 +19,7 @@ module Recurly
   require 'recurly/measured_unit'
   require 'recurly/plan'
   require 'recurly/redemption'
+  require 'recurly/shipping_address'
   require 'recurly/subscription'
   require 'recurly/subscription_add_on'
   require 'recurly/transaction'

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -17,6 +17,7 @@ module Recurly
     has_many :subscriptions
     has_many :transactions
     has_many :redemptions
+    has_many :shipping_addresses, resource_class: :ShippingAddress, readonly: false
 
     # @return [BillingInfo, nil]
     has_one :billing_info, :readonly => false

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -16,7 +16,7 @@ module Recurly
 
     @@base_uri = "https://api.recurly.com/v2/"
 
-    RECURLY_API_VERSION = '2.3'
+    RECURLY_API_VERSION = '2.4'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/helper.rb
+++ b/lib/recurly/helper.rb
@@ -17,7 +17,10 @@ module Recurly
     end
 
     def singularize word
-      word.to_s.sub(/s$/, '').sub(/ie$/, 'y')
+      word = word.to_s
+      return "shipping_address" if word == "shipping_address"
+      return "shipping_address" if word == "shipping_addresses"
+      word.sub(/s$/, '').sub(/ie$/, 'y')
     end
 
     def underscore camel_cased_word

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -23,6 +23,9 @@ module Recurly
     # @return [Redemption]
     has_many :redemptions
 
+    # return [ShippingAddress]
+    has_one :shipping_address, resource_class: :ShippingAddress, readonly: true
+
     def redemption
       redemptions.first
     end

--- a/lib/recurly/redemption.rb
+++ b/lib/recurly/redemption.rb
@@ -9,6 +9,7 @@ module Recurly
   class Redemption < Resource
     # @return [Coupon]
     belongs_to :coupon
+
     # @return [Account]
     belongs_to :account, :readonly => false
 

--- a/lib/recurly/shipping_address.rb
+++ b/lib/recurly/shipping_address.rb
@@ -1,0 +1,20 @@
+module Recurly
+  class ShippingAddress < Resource
+    define_attribute_methods %w(
+      id
+      address1
+      address2
+      first_name
+      last_name
+      city
+      state
+      zip
+      country
+      phone
+      nickname
+      company
+      email
+    )
+    alias to_param address1
+  end
+end

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -28,6 +28,9 @@ module Recurly
     # @return [Redemption]
     has_many :redemptions
 
+    # return [ShippingAddress]
+    has_one :shipping_address, resource_class: :ShippingAddress, readonly: false
+
     define_attribute_methods %w(
       uuid
       state
@@ -63,6 +66,7 @@ module Recurly
       vat_reverse_charge_notes
       address
       revenue_schedule_type
+      shipping_address_id
     )
     alias to_param uuid
 

--- a/spec/fixtures/accounts/create-201.xml
+++ b/spec/fixtures/accounts/create-201.xml
@@ -9,6 +9,7 @@ Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
   <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
   <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
   <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
   <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
   <account_code>abcdef1234567890</account_code>
   <username>shmohawk58</username>

--- a/spec/fixtures/accounts/index-200.xml
+++ b/spec/fixtures/accounts/index-200.xml
@@ -11,6 +11,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <invoices href="https://api.recurly.com/v2/accounts/api100/invoices"/>
     <redemption href="https://api.recurly.com/v2/accounts/api100/redemption"/>
     <subscriptions href="https://api.recurly.com/v2/accounts/api100/subscriptions"/>
+    <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
     <transactions href="https://api.recurly.com/v2/accounts/api100/transactions"/>
     <account_code>api100</account_code>
     <username>api100_u</username>

--- a/spec/fixtures/accounts/show-200-space.xml
+++ b/spec/fixtures/accounts/show-200-space.xml
@@ -7,6 +7,7 @@ Content-Type: application/xml; charset=utf-8
   <billing_info href="https://api.recurly.com/v2/accounts/my%20account/billing_info" />
   <invoices href="https://api.recurly.com/v2/accounts/my%20account/invoices" />
   <subscriptions href="https://api.recurly.com/v2/accounts/my%20account/subscriptions" />
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
   <transactions href="https://api.recurly.com/v2/accounts/my%20account/transactions" />
   <account_code>my account</account_code>
   <state>active</state>

--- a/spec/fixtures/accounts/show-200-taxed.xml
+++ b/spec/fixtures/accounts/show-200-taxed.xml
@@ -8,6 +8,7 @@ Content-Type: application/xml; charset=utf-8
   <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
   <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
   <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
   <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
   <account_code>abcdef1234567890</account_code>
   <username>shmohawk58</username>

--- a/spec/fixtures/accounts/show-200.xml
+++ b/spec/fixtures/accounts/show-200.xml
@@ -8,6 +8,7 @@ Content-Type: application/xml; charset=utf-8
   <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
   <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
   <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
   <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
   <account_balance href="https://api.recurly.com/v2/accounts/abcdef1234567890/balance"/>
   <account_code>abcdef1234567890</account_code>

--- a/spec/fixtures/accounts/update-200.xml
+++ b/spec/fixtures/accounts/update-200.xml
@@ -9,6 +9,7 @@ Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
   <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
   <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
   <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
   <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
   <account_code>abcdef1234567890</account_code>
   <username>shmohawk58</username>

--- a/spec/fixtures/shipping_addresses/index-200.xml
+++ b/spec/fixtures/shipping_addresses/index-200.xml
@@ -1,0 +1,28 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+X-Records: 123
+Link: <https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses?cursor=1234566890&per_page=20>; rel="next"
+
+<?xml version="1.0" encoding="UTF-8"?>
+<shipping_addresses type="array">
+  <shipping_address href="https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses/2017683623137826835">
+    <account href="https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577"/>
+    <subscriptions href="https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses/2017683623137826835/subscriptions"/>
+    <id type="integer">2017683623137826835</id>
+    <nickname>Work</nickname>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <company>Recurly Inc.</company>
+    <phone>555-555-5555</phone>
+    <email>verena@example.com</email>
+    <vat_number nil="nil"></vat_number>
+    <address1>123 Main St.</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94110</zip>
+    <country>US</country>
+    <created_at type="datetime">2016-08-15T20:57:11Z</created_at>
+    <updated_at type="datetime">2016-08-15T20:57:11Z</updated_at>
+  </shipping_address>
+</shipping_addresses>

--- a/spec/fixtures/shipping_addresses/show-200.xml
+++ b/spec/fixtures/shipping_addresses/show-200.xml
@@ -1,0 +1,25 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+X-Records: 123
+
+<?xml version="1.0" encoding="UTF-8"?>
+<shipping_address href="https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses/2017683623137826835">
+  <account href="https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses/2017683623137826835/subscriptions"/>
+  <id type="integer">2017683623137826835</id>
+  <nickname>Work</nickname>
+  <first_name>Verena</first_name>
+  <last_name>Example</last_name>
+  <company>Recurly Inc.</company>
+  <phone>555-555-5555</phone>
+  <email>verena@example.com</email>
+  <vat_number nil="nil"></vat_number>
+  <address1>123 Main St.</address1>
+  <address2 nil="nil"></address2>
+  <city>San Francisco</city>
+  <state>CA</state>
+  <zip>94110</zip>
+  <country>US</country>
+  <created_at type="datetime">2016-08-15T20:57:11Z</created_at>
+  <updated_at type="datetime">2016-08-15T20:57:11Z</updated_at>
+</shipping_address>

--- a/spec/fixtures/subscriptions/show-200-inactive.xml
+++ b/spec/fixtures/subscriptions/show-200-inactive.xml
@@ -4,6 +4,8 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890">
   <account href="https://api.recurly.com/v2/accounts/account_code"/>
+  <redemptions href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/redemptions" />
+  <shipping_address href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/shipping_address" />
   <plan href="https://api.recurly.com/v2/plans/plan_code">
     <plan_code>plan_code</plan_code>
     <name>A Man, a Plan, a Canal: Panama</name>

--- a/spec/fixtures/subscriptions/show-200-noinvoice.xml
+++ b/spec/fixtures/subscriptions/show-200-noinvoice.xml
@@ -4,6 +4,8 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890">
   <account href="https://api.recurly.com/v2/accounts/account_code"/>
+  <redemptions href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/redemptions" />
+  <shipping_address href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/shipping_address" />
   <plan href="https://api.recurly.com/v2/plans/plan_code">
     <plan_code>plan_code</plan_code>
     <name>A Man, a Plan, a Canal: Panama</name>

--- a/spec/fixtures/subscriptions/show-200-taxed.xml
+++ b/spec/fixtures/subscriptions/show-200-taxed.xml
@@ -5,6 +5,8 @@ Content-Type: application/xml; charset=utf-8
 <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890">
   <account href="https://api.recurly.com/v2/accounts/account_code"/>
   <invoice href="https://api.recurly.com/v2/invoices/created-invoice"/>
+  <redemptions href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/redemptions" />
+  <shipping_address href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/shipping_address" />
   <plan href="https://api.recurly.com/v2/plans/plan_code">
     <plan_code>plan_code</plan_code>
     <name>A Man, a Plan, a Canal: Panama</name>

--- a/spec/fixtures/subscriptions/show-200.xml
+++ b/spec/fixtures/subscriptions/show-200.xml
@@ -5,6 +5,7 @@ Content-Type: application/xml; charset=utf-8
 <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890">
   <account href="https://api.recurly.com/v2/accounts/account_code"/>
   <redemptions href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/redemptions" />
+  <shipping_address href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/shipping_address" />
   <invoice href="https://api.recurly.com/v2/invoices/created-invoice"/>
   <plan href="https://api.recurly.com/v2/plans/plan_code">
     <plan_code>plan_code</plan_code>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -62,6 +62,20 @@ describe Account do
         error.message.must_equal 'No charges to invoice'
       end
     end
+
+    describe "#shipping_addresses" do
+      it "must return shipping addresses" do
+        stub_api_request(
+          :get,
+          'accounts/abcdef1234567890/shipping_addresses',
+          'shipping_addresses/index-200'
+        )
+
+        shads = account.shipping_addresses.all
+        shads.length.must_equal 1
+        shads.first.must_be_instance_of Recurly::ShippingAddress
+      end
+    end
   end
 
   describe ".find" do

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -343,4 +343,22 @@ describe Subscription do
       end
     end
   end
+
+  describe "#shipping_address" do
+    it "should be able to find shipping address" do
+      stub_api_request(
+        :get,
+        'subscriptions/abcdef1234567890',
+        'subscriptions/show-200'
+      )
+      stub_api_request(
+        :get,
+        'subscriptions/abcdef1234567890/shipping_address',
+        'shipping_addresses/show-200'
+      )
+      subscription = Recurly::Subscription.find("abcdef1234567890")
+      shad = subscription.shipping_address
+      shad.must_be_instance_of Recurly::ShippingAddress
+    end
+  end
 end


### PR DESCRIPTION
# Usage

```ruby
shad = Recurly::ShippingAddress.new
shad.nickname = "Work"
shad.first_name = "Verena"
shad.last_name = "Example"
shad.company = "Recurly Inc."
shad.phone = "555-555-5555"
shad.email = "verena@example.com"
shad.address1 = "123 Main St."
shad.city = "San Francisco"
shad.state = "CA"
shad.zip = "94110"
shad.country = "US"

require 'securerandom'

account = Recurly::Account.new(account_code: SecureRandom.uuid)
account.shipping_addresses = [shad]
account.save!

# or make you can create one on a subscription

subscription = Recurly::Subscription.new(
  plan_code: 'gold',
  currency: 'USD',
  account: {
    account_code: SecureRandom.uuid,
    email: 'verena@example.com',
    first_name: 'Verena',
    last_name: 'Example',
    billing_info: {
      address1: '400 Alabama St',
      city: 'San Francisco',
      state: 'CA',
      zip: '94110',
      country: 'US',
      number: '4111-1111-1111-1111',
      month: 12,
      year: 2019,
    }
  },
  shipping_address: shad
)

subscription.save!

# you can use .destroy to remove a shipping address
shad.destroy

# we can fetch all of a subscription's shipping address
shad = subscription.shipping_address

# we can fetch all an account's shipping addresses
shads = account.shipping_addresses.all

# if we want to update a shipping address we only need to modify and save
shad.first_name = "Benjamin"
shad.save!

# suppose an account has many shipping addresses
# you can assign an existing shipping address to a subscription given the id

shad_ids = account.shipping_addresses.all.map(&:id)
#=> [2014803352277849054, 2014803352277828750]

subscription.shipping_address_id = shad_ids.first

# you can also read the shipping address that got associated with an invoice
invoice = subscription.invoice
invoice.shipping_address
```