### PR TITLE
Add support for canceled-at field on the GiftCard resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Add `updated_at` to `MeasuredUnit` [PR](https://github.com/recurly/recurly-client-ruby/pull/263)
+- Support gift card `canceled_at` timestamp [PR](https://github.com/recurly/recurly-client-ruby/pull/264)
 
 <a name="v2.7.3"></a>
 ## v2.7.3 (2016-08-19)

--- a/lib/recurly/gift_card.rb
+++ b/lib/recurly/gift_card.rb
@@ -16,6 +16,7 @@ module Recurly
       redemption_code
       unit_amount_in_cents
       updated_at
+      canceled_at
     )
 
     def self.preview(attributes = {})

--- a/spec/fixtures/gift_cards/index-200.xml
+++ b/spec/fixtures/gift_cards/index-200.xml
@@ -29,6 +29,7 @@ Link: <https://api.recurly.com/v2/gift_cards?cursor=1234567890&per_page=20>; rel
     <updated_at type="datetime">2016-07-28T00:01:46Z</updated_at>
     <delivered_at nil="nil"></delivered_at>
     <redeemed_at type="datetime">2016-07-28T00:01:46Z</redeemed_at>
+    <canceled_at nil="nil"></canceled_at>
   </gift_card>
   <gift_card href="https://api.recurly.com.com/v2/gift_cards/2004005397179840592">
     <gifter_account href="https://api.recurly.com.com/v2/accounts/200fb60f-d94f-48d1-87dd-25eb7f1a66c6"/>
@@ -54,5 +55,6 @@ Link: <https://api.recurly.com/v2/gift_cards?cursor=1234567890&per_page=20>; rel
     <updated_at type="datetime">2016-07-28T00:00:57Z</updated_at>
     <delivered_at nil="nil"></delivered_at>
     <redeemed_at type="datetime">2016-07-28T00:00:56Z</redeemed_at>
+    <canceled_at nil="nil"></canceled_at>
   </gift_card>
 </gift_cards>

--- a/spec/fixtures/gift_cards/show-200.xml
+++ b/spec/fixtures/gift_cards/show-200.xml
@@ -34,4 +34,5 @@ Content-Type: application/xml; charset=utf-8
   <updated_at type="datetime">2016-07-28T00:01:46Z</updated_at>
   <delivered_at nil="nil"></delivered_at>
   <redeemed_at type="datetime">2016-07-28T00:01:46Z</redeemed_at>
+  <canceled_at nil="nil"></canceled_at>
 </gift_card>

--- a/spec/recurly/gift_card_spec.rb
+++ b/spec/recurly/gift_card_spec.rb
@@ -30,6 +30,7 @@ describe GiftCard do
       gift_card.balance_in_cents.must_equal 1_000
       gift_card.currency.must_equal "USD"
       gift_card.created_at.must_equal DateTime.parse("2016-07-28T00:01:48Z")
+      gift_card.canceled_at.must_equal nil
       gift_card.delivered_at.must_equal nil
       gift_card.id.must_equal 2004005808969875135
       gift_card.product_code.must_equal "gift_card"


### PR DESCRIPTION
Gift cards can now be canceled in the Recurly admin console if they have not already been redeemed. This adds support for the `canceled_at` timestamp on the `GiftCard` resource so that merchants can track if a gift card has been canceled or not and when the cancelation occurred.