### PR TITLE
Correct rails deprecation warning

### DIFF
--- a/lib/rails/recurly.rb
+++ b/lib/rails/recurly.rb
@@ -5,7 +5,12 @@ module Recurly
     end
 
     initializer :recurly_set_accept_language do
-      ActionController::Base.prepend_before_filter do
+      prepend_method = :prepend_before_filter
+      if ActionController::Base.respond_to?(:prepend_before_action)
+        prepend_method = :prepend_before_action
+      end
+
+      ActionController::Base.send(prepend_method) do
         Recurly::API.accept_language = request.env['HTTP_ACCEPT_LANGUAGE']
       end
     end


### PR DESCRIPTION
The `prepend_before_filter` method is being removed, this gem causes these warnings on Rails 5:

| DEPRECATION WARNING: prepend_before_filter is deprecated and will be removed in Rails 5.1. Use prepend_before_action instead.

Fix falls back if the replacement `prepend_before_action` is unavailable.

Apologies for lack of unit test; was unable to think of a way without stubbing/mocking.
Have confirmed change works on Rails 5.0.0.1.