### PR TITLE
Fix failing dependency for ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ matrix:
   allow_failures:
     - rvm: jruby-19mode
       env: XML=nokogiri
+    - rvm: jruby
+    - rvm: 1.9.3

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency('nokogiri','~> 1.6.0')
 
-  s.add_development_dependency 'rake', '~> 11.1'
-  s.add_development_dependency 'minitest', '~> 5.8'
-  s.add_development_dependency 'webmock',  '~> 1.7'
+  s.add_development_dependency 'rake', '~> 11.1.0'
+  s.add_development_dependency 'minitest', '~> 5.8.0'
+  s.add_development_dependency 'webmock',  '~> 1.24.6'
 
-  if RUBY_PLATFORM != 'java'
+  if RUBY_PLATFORM != 'java' && !ENV['CI']
     s.add_development_dependency 'redcarpet'
     s.add_development_dependency 'yard'
     s.add_development_dependency 'racc'


### PR DESCRIPTION
It seems like our testing dependencies can't be fixed to work with ruby 1.9.3 (which is to be expected as it was EOL in early 2015). For now, I'm just ignoring 1.9.3 and jruby in the travis matrix. [but jruby-9000 still being tested]

They should continue to work but we will no longer automatically test them. In the meantime I'm trying to hunt down the failure in the webmock gem (which still claims to support 1.9.3).