### PR TITLE
Fix AddOn quantity accumulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - Add `updated_at` to `MeasuredUnit` [PR](https://github.com/recurly/recurly-client-ruby/pull/263)
 - Support gift card `canceled_at` timestamp [PR](https://github.com/recurly/recurly-client-ruby/pull/264)
+- Fix AddOns quantity accumulator bug from #226 [PR](https://github.com/recurly/recurly-client-ruby/pull/278)
 
 <a name="v2.7.3"></a>
 ## v2.7.3 (2016-08-19)

--- a/lib/recurly/subscription/add_ons.rb
+++ b/lib/recurly/subscription/add_ons.rb
@@ -27,7 +27,8 @@ module Recurly
 
         exist = @add_ons.find { |a| a.add_on_code == add_on.add_on_code }
         if exist
-          exist.quantity ||= 1 and exist.quantity += 1
+          exist.quantity ||= 1
+          exist.quantity += add_on.quantity || 1
 
           if add_on.unit_amount_in_cents
             exist.unit_amount_in_cents = add_on.unit_amount_in_cents

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -108,6 +108,22 @@ describe Subscription do
       ])
     end
 
+    it "must accumulate quantity if new addon has quantity" do
+      subscription = Subscription.new :add_ons => [:trial, :trial]
+      subscription.add_ons << SubscriptionAddOn.new(add_on_code: :trial, quantity: 3)
+      subscription.add_ons.to_a.must_equal([
+        SubscriptionAddOn.new(add_on_code: :trial, quantity: 5)
+      ])
+    end
+
+    it "must assume new addon has a quantity of 1 if not specified" do
+      subscription = Subscription.new :add_ons => [:trial, :trial]
+      subscription.add_ons << SubscriptionAddOn.new(add_on_code: :trial)
+      subscription.add_ons.to_a.must_equal([
+        SubscriptionAddOn.new(add_on_code: :trial, quantity: 3)
+      ])
+    end
+
     it "must serialize" do
       subscription = Subscription.new
       subscription.add_ons << :trial


### PR DESCRIPTION
Resolves #226 - Seems this PR was abandoned so I am picking up the torch

When appending an existing add on that has a quantity, the new addon's quantity was not being respected. All new addons were being assumed to have a quantity of 1.

See original PR and this test for more details.