### PR TITLE
Add back ruby 1.9.3 and jruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,3 @@ matrix:
   allow_failures:
     - rvm: jruby-19mode
       env: XML=nokogiri
-    - rvm: jruby
-    - rvm: 1.9.3

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 11.1.0'
   s.add_development_dependency 'minitest', '~> 5.8.0'
+  s.add_development_dependency 'addressable',  '~> 2.4.0'
   s.add_development_dependency 'webmock',  '~> 1.24.6'
 
   if RUBY_PLATFORM != 'java' && !ENV['CI']


### PR DESCRIPTION
After talking to webmock maintainer, was instructed to lock `addressable` at a version before it lost 1.9.3 compatibility. This adds ruby 1.9.3 and jruby back to the testing matrix.