### PR TITLE
Fix redemptions on bulk coupons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+- Fix coupon redemption bug on bulk coupons #284 [PR](https://github.com/recurly/recurly-client-ruby/pull/286)
+
 <a name="v2.7.4"></a>
 ## v2.7.4 (2016-11-17)
 

--- a/lib/recurly/coupon.rb
+++ b/lib/recurly/coupon.rb
@@ -73,7 +73,7 @@ module Recurly
         :currency     => currency || Recurly.default_currency
       }.merge(extra_opts)
 
-      redemption = redemptions.new(redemption_options)
+      redemption = Redemption.new(redemption_options)
 
       Redemption.from_response follow_link(:redeem,
         :body => redemption.to_xml

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -579,8 +579,8 @@ module Recurly
       end
 
       def embedded!(root_index = false)
-        private :initialize
-        private_class_method(*%w(new create create!))
+        protected :initialize
+        private_class_method(*%w(create create!))
         unless root_index
           private_class_method(*%w(all find_each first paginate scoped where))
         end

--- a/spec/fixtures/coupons/bulk-200.xml
+++ b/spec/fixtures/coupons/bulk-200.xml
@@ -1,0 +1,30 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<coupon href="https://api.recurly.com/v2/coupons/cm2016-abcdefg">
+  <bulk_coupon href="https://api.recurly.com/v2/coupons/cyber-monday-2016/"/>
+  <coupon_code>cm2016-abcdefg</coupon_code>
+  <name>Cyber Monday</name>
+  <state>redeemable</state>
+  <discount_type>dollars</discount_type>
+  <discount_in_cents>
+    <USD>1000</USD>
+  </discount_in_cents>
+  <redeem_by_date type="datetime">2020-05-01T08:00:00Z</redeem_by_date>
+  <single_use type="boolean">true</single_use>
+  <applies_for_months type="integer">1</applies_for_months>
+  <max_redemptions type="integer">100</max_redemptions>
+  <max_redemptions_per_account type="integer">1</max_redemptions_per_account>
+  <applies_to_all_plans type="boolean">true</applies_to_all_plans>
+  <created_at type="datetime">2011-04-30T08:00:00Z</created_at>
+  <duration>temporal</duration>
+  <temporal_unit>month</temporal_unit>
+  <temporal_amount type="integer">1</temporal_amount>
+  <applies_to_non_plan_charges type="boolean">false</applies_to_non_plan_charges>
+  <redemption_resource>account</redemption_resource>
+  <plan_codes type="array">
+    <plan_code>saul_good</plan_code>
+  </plan_codes>
+  <a name="redeem" href="https://api.recurly.com/v2/coupons/cm2016-abcdefg/redeem" method="put"/>
+</coupon>

--- a/spec/recurly/coupon_spec.rb
+++ b/spec/recurly/coupon_spec.rb
@@ -19,7 +19,24 @@ describe Coupon do
       stub_api_request(
         :put, "coupons/bettercallsaul/redeem", "redemptions/create-201"
       )
-      coupon.redeem 'xX_pinkman_Xx', 'USD', subscription_uuid: 'abcdef1234567890'
+      redemption = coupon.redeem 'xX_pinkman_Xx', 'USD', subscription_uuid: 'abcdef1234567890'
+      redemption.must_be_instance_of Redemption
+    end
+
+    describe "with a bulk coupon" do
+      let(:coupon) { Coupon.find 'cm2016-abcdefg' }
+
+      before do
+        stub_api_request :get, 'coupons/cm2016-abcdefg', 'coupons/bulk-200'
+      end
+
+      it "must be redeemable" do
+        stub_api_request(
+          :put, "coupons/cm2016-abcdefg/redeem", "redemptions/create-201"
+        )
+        redemption = coupon.redeem 'xX_pinkman_Xx', 'USD', subscription_uuid: 'abcdef1234567890'
+        redemption.must_be_instance_of Redemption
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #284

Bulk coupons do not contain the `<redemptions />` element thus the `redemptions.new` line was failing. We use the `redeem` action and should only rely on that because it's always there. I had to change the `embedded!` method so we can at least call new on embedded resources. It's perhaps worth rethinking how we do that. Those methods should be protected not private.

Here is a script you can use to check that this works.

```ruby
require 'securerandom'

# use a bulk coupon code you created
coupon_code = 'cm2016-bx50h76kv1'
account_code = SecureRandom.uuid

# create a throwaway ccount
Recurly::Account.create(account_code: account_code)

coupon = Recurly::Coupon.find(coupon_code)

# should now throw an error
redemption = coupon.redeem(account_code)
puts redemption.inspect
```