### PR TITLE
Make the travis badge reflect master only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Recurly [![Build Status](https://secure.travis-ci.org/recurly/recurly-client-ruby.png)](http://travis-ci.org/recurly/recurly-client-ruby) [![Gem Version](https://badge.fury.io/rb/recurly.svg)](http://badge.fury.io/rb/recurly)
+# Recurly [![Build Status](https://secure.travis-ci.org/recurly/recurly-client-ruby.png?branch=master)](http://travis-ci.org/recurly/recurly-client-ruby) [![Gem Version](https://badge.fury.io/rb/recurly.svg)](http://badge.fury.io/rb/recurly)
 
 <https://github.com/recurly/recurly-client-ruby>
 


### PR DESCRIPTION
The travis badge was showing the latest build which doesn't reflect that master is actually stable.