### PR TITLE
Bump 2.8.0.rc1

### DIFF
--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,9 +1,9 @@
 module Recurly
   module Version
     MAJOR   = 2
-    MINOR   = 7
-    PATCH   = 5
-    PRE     = nil
+    MINOR   = 8
+    PATCH   = 0
+    PRE     = 'rc1'
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze
 


### PR DESCRIPTION
Bumps use to API version 2.5. This is a release candidate and we cannot guarantee a stable API yet.

* Implement tax fields for Vertex integration #289
* adds geo_code to billing_info, account address, and shipping address #273