### PR TITLE
Add all_line_items

### DIFF
--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -20,6 +20,10 @@ module Recurly
     # @return [Invoice]
     belongs_to :original_invoice, class_name: 'Invoice'
 
+    # This will only be present if the invoice has > 500 line items
+    # @return [Adjustment]
+    has_many :all_line_items, class_name: :Adjustment
+
     # @return [Redemption]
     has_many :redemptions
 

--- a/lib/recurly/resource/pager.rb
+++ b/lib/recurly/resource/pager.rb
@@ -55,6 +55,11 @@ module Recurly
         @collection = @count = nil
       end
 
+      # @return [Boolean] whether or not the xml element is present
+      def any?
+        !@uri.nil?
+      end
+
       # @return [String] The URI of the paginated resource.
       def uri
         @uri ||= resource_class.collection_path


### PR DESCRIPTION
If there are more than 500 line items, there will be a link to create a line item pager:

```ruby
invoice = Recurly::Invoice.find '1012'

# this if checks to see if the link is present in the xml
# if so, your line items were truncated
if invoice.all_line_items.any?
  # use find_each or all.each to iterate through every adjustment
  invoice.all_line_items.find_each do |adjustment|
    puts adjustment
  end
end
```