### PR TITLE
Fix stack-level-too-deep for as_json

### DIFF
--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -742,6 +742,10 @@ module Recurly
       }
     end
 
+    def as_json(options = nil)
+      attributes.reject { |k, v| v.is_a?(Recurly::Resource::Pager) }
+    end
+
     # @return [Hash] The raw hash of record href links.
     def links
       @links ||= {}


### PR DESCRIPTION
Resolves #274 

Calling `attributes` in this way has the effect of calling remote resources. I'll need to find a way to only return set attributes.