### PR TITLE
Fix cloudflare 502 error

### DIFF
--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -370,13 +370,17 @@ module Recurly
       # @return [Resource]
       # @param response [Net::HTTPResponse]
       def from_response(response)
-        case response['Content-Type']
+        content_type = response['Content-Type']
+
+        case content_type
         when %r{application/pdf}
           response.body
-        else # when %r{application/xml}
+        when %r{application/xml}
           record = from_xml response.body
           record.instance_eval { @etag, @response = response['ETag'], response }
           record
+        else
+          raise Recurly::Error, "Content-Type \"#{content_type}\" is not accepted"
         end
       end
 

--- a/spec/fixtures/cloudflare_error.xml
+++ b/spec/fixtures/cloudflare_error.xml
@@ -1,0 +1,12 @@
+HTTP/1.1 502 Bad Gateway
+Content-Type: text/html; charset=utf-8
+
+<html>
+  <head>
+    <meta name="robots" content="noindex, nofollow">
+  </head>
+  <body bgcolor="#000000">
+    <center>::CLOUDFLARE_ERROR_500S_BOX::
+    </center>
+  </body>
+</html>

--- a/spec/recurly/api_spec.rb
+++ b/spec/recurly/api_spec.rb
@@ -8,5 +8,10 @@ describe API do
         proc { API.get 'endpoint' }.must_raise exception
       end
     end
+
+    it "must properly handle cloudflare 502 errors" do
+      stub_api_request(:any, 'endpoint', 'cloudflare_error')
+      proc { API.get 'endpoint' }.must_raise Recurly::API::GatewayError
+    end
   end
 end

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -28,6 +28,20 @@ describe Resource do
   end
 
   describe "class methods" do
+    describe ".from_response" do
+      it "must not accept text/html responses" do
+        stub_api_request(:get, 'resources/123') do
+<<HTML
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+
+<html></html>
+HTML
+        end
+        proc { Resource.find(123) }.must_raise Recurly::Error
+      end
+    end
+
     describe ".define_attribute_methods" do
       it "must define attribute methods" do
         resource.define_attribute_methods(names = %w(charisma endurance))
@@ -65,6 +79,7 @@ describe Resource do
         pager.must_be_instance_of Resource::Pager
         stub_api_request(:get, 'resources?active=true') { <<XML }
 HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
 
 <resources type="array"/>
 XML
@@ -245,6 +260,7 @@ XML
       it "must lazily fetch a record and assign a relation" do
         stub_api_request(:get, 'resources/1') { <<XML }
 HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <resource>
@@ -255,6 +271,7 @@ XML
         record = resource.find "1"
         stub_api_request(:get, 'resources/1/day') { <<XML }
 HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <day>
@@ -326,6 +343,7 @@ XML
         record[:uuid] = 'neo'
         stub_api_request(:get, 'resources/neo') { <<XML }
 HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
 
 <resource>
   <uuid>neo</uuid>
@@ -525,6 +543,5 @@ XML
         record.valid?.must_equal false
       end
     end
-
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,7 @@ XML = {
     :index   => [
       <<EOR,
 HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
 Link: \
 <https://api.recurly.com/v2/resources?per_page=2&cursor=1234567890>; rel="next"
 X-Records: 3
@@ -62,6 +63,7 @@ X-Records: 3
 EOR
       <<EOR
 HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
 Link: \
 <https://api.recurly.com/v2/resources?per_page=2>; rel="start"
 X-Records: 3
@@ -75,6 +77,7 @@ EOR
     ],
     :show    => <<EOR,
 HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
 
 <resource>
   <name>Spock</name>
@@ -82,6 +85,7 @@ HTTP/1.1 200 OK
 EOR
     :update  => <<EOR,
 HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
 
 <resource>
   <name>Persistent Little Bug</name>


### PR DESCRIPTION
When Cloudflare throws a 502 error, the response is html. The failure to parse the html was preventing the GatewayError from bubbling up. This makes sure the xml parsing is ignored and the gateway error bubbles up. I'm considering following up with some autoretry logic for some of these cases. 

Reported by @akannur https://github.com/recurly/recurly-js/issues/318