### PR TITLE
Adding product_code to Transaction and Adjustment

### DIFF
--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -52,6 +52,7 @@ module Recurly
       tax_code
       accounting_code
       fraud
+      product_code
     )
     alias to_param uuid
     alias fraud_info fraud


### PR DESCRIPTION
`product_code` should be writable on Adjustment and writable on Transaction. This is for Vertex integration.