### PR TITLE
Move nokogiri to a development dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+- Remove Nokogiri as a dependency of the recurly gem. If you'd like to continue using it (for that nice speed boost), make sure to add `gem "nokogiri"` to your Gemfile. [PR](https://github.com/recurly/recurly-client-ruby/pull/302)
+
 <a name="v2.8.0"></a>
 ## v2.8.0 (2017-03-21)
 

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency('nokogiri','~> 1.6.0')
+  s.add_development_dependency('nokogiri','~> 1.6.0')
 
   s.add_development_dependency 'rake', '~> 11.1.0'
   s.add_development_dependency 'minitest', '~> 5.8.0'


### PR DESCRIPTION
Recurly states this on their README:

    Recurly will automatically use Nokogiri (for a nice speed boost)
    if it's available and loaded in your app's environment.

This means nokogiri shouldn't be an actual dependency of Recurly, but
rather a development dependency, so developers can include it only if
they want to.