### PR TITLE
Guard against passing `Resource.find` empty strings

### DIFF
--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -332,8 +332,7 @@ module Recurly
       #     for subscriptions use uuid
       #     for transactions use uuid
       def find(uuid, options = {})
-        if uuid.nil?
-          # Should we raise an ArgumentError, instead?
+        if uuid.nil? || uuid.to_s.empty?
           raise NotFound, "can't find a record with nil identifier"
         end
 

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -97,6 +97,10 @@ XML
         stub_api_request(:get, 'resources/khan') { XML[404] }
         proc { resource.find :khan }.must_raise Resource::NotFound
       end
+
+      it "must reject empty strings" do
+        proc { resource.find '' }.must_raise Resource::NotFound
+      end
     end
 
     describe ".find_each" do


### PR DESCRIPTION
Thanks for your work on this gem! I have a small bugfix...

We currently raise an exception if a resource cannot be found:

```ruby
Recurly::Account.find('nope') # => makes an API call to accounts/nope
#=> Recurly::Resource::NotFound: Couldn't find Account with account_code = nope
```

However, if an empty string is passed into to `.find`, we fail to catch it:
```ruby
Recurly::Account.find('') # => makes an API call to accounts/
=> #<Recurly::Account#array accept_language: nil, account_code: nil, address: nil, company_name: nil, created_at: nil, email: nil, entity_use_code: nil, first_name: nil, hosted_login_token: nil, last_name: nil, state: nil, tax_exempt: nil, username: nil, vat_number: nil>
```

While this is an edge case, I believe it's easy enough to catch and raise. It's a bit unexpected that we end up hitting the "list accounts" endpoint. 
