### PR TITLE
Bump 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Adding all_line_items [PR](https://github.com/recurly/recurly-client-ruby/pull/293)
 - Implement fields for Vertex integration [PR](https://github.com/recurly/recurly-client-ruby/pull/289)
 - Adds geo_code to billing_info, account address, and shipping address [PR](https://github.com/recurly/recurly-client-ruby/pull/273)
+- Guard against passing `Resource.find` empty strings #307 [PR](https://github.com/recurly/recurly-client-ruby/pull/307)
+- Add yard docs link #305 [PR](https://github.com/recurly/recurly-client-ruby/pull/305)
 
 <a name="v2.7.6"></a>
 ## v2.7.6 (2017-01-30)


### PR DESCRIPTION
- Finishes API v2.5 updates [PR](https://github.com/recurly/recurly-client-ruby/pull/301)
- Adding product_code to Transactions and Adjustments [PR](https://github.com/recurly/recurly-client-ruby/pull/298)
- Adding all_line_items [PR](https://github.com/recurly/recurly-client-ruby/pull/293)
- Implement fields for Vertex integration [PR](https://github.com/recurly/recurly-client-ruby/pull/289)
- Adds geo_code to billing_info, account address, and shipping address [PR](https://github.com/recurly/recurly-client-ruby/pull/273)
- Guard against passing `Resource.find` empty strings #307
- Add yard docs link #305 

## Upgrade Notes:

If you were are using `as_json` on a Resource (previously unsupported) we are now returning the attributes as json rather than the resource as json. This means your returned Hash will not have an `attributes` key but will rather BE the `attributes` value. See #295 