### PR TITLE
Fix jruby+nokogiri failure on comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,5 @@ env:
   - XML=nokogiri
 matrix:
   allow_failures:
-    - rvm: jruby
-      env: XML=nokogiri
     - rvm: jruby-19mode
       env: XML=nokogiri

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -411,6 +411,9 @@ module Recurly
         end
 
         xml.each_element do |el|
+          # skip this element if it's an xml comment
+          next if defined?(Nokogiri::XML::Node::TEXT_NODE) && el.is_a?(Nokogiri::XML::Comment)
+
           if el.name == 'a'
             record.links[el.attribute('name').value] = {
               :method => el.attribute('method').to_s,


### PR DESCRIPTION
Jruby+nokogiri was blowing up thanks to XML comments. This adds a line to skip any nokogiri xml comment node.