### PR TITLE
Add Ruby 2.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.1.0
   - 2.2.4
   - 2.3.0
+  - 2.4.0
 env:
   - XML=rexml
   - XML=nokogiri

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Remove Nokogiri as a dependency of the recurly gem. If you'd like to continue using it (for that nice speed boost), make sure to add `gem "nokogiri"` to your Gemfile. [PR](https://github.com/recurly/recurly-client-ruby/pull/302)
+- Ruby 2.4 support [PR](https://github.com/recurly/recurly-client-ruby/pull/313)
 
 <a name="v2.8.0"></a>
 ## v2.8.0 (2017-03-21)

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('nokogiri','~> 1.6.0')
 
-  s.add_development_dependency 'rake', '~> 11.1.0'
+  s.add_development_dependency 'rake', '~> 11.3.0'
   s.add_development_dependency 'minitest', '~> 5.8.0'
   s.add_development_dependency 'addressable',  '~> 2.4.0'
-  s.add_development_dependency 'webmock',  '~> 1.24.6'
+  s.add_development_dependency 'webmock',  '~> 2.3.2'
 
   if RUBY_PLATFORM != 'java' && !ENV['CI']
     s.add_development_dependency 'redcarpet'

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -333,8 +333,9 @@ describe Subscription do
 
         subscription = Subscription.find 'abcdef1234567890'
 
-        stub_request(:put, "https://api_key:@api.recurly.com/v2/subscriptions/abcdef1234567890").
-          with(:body => "<subscription><plan_code>abc</plan_code><quantity>1</quantity><unit_amount_in_cents>1500</unit_amount_in_cents></subscription>",
+        stub_request(:put, "https://api.recurly.com/v2/subscriptions/abcdef1234567890").
+          with(:basic_auth => [Recurly.api_key, ''],
+               :body => "<subscription><plan_code>abc</plan_code><quantity>1</quantity><unit_amount_in_cents>1500</unit_amount_in_cents></subscription>",
                :headers => {'Accept'=>'application/xml'}).
           to_return(:status => 200, :body => "", :headers => {})
 
@@ -350,8 +351,9 @@ describe Subscription do
 
         subscription = Subscription.find 'abcdef1234567890'
 
-        stub_request(:put, "https://api_key:@api.recurly.com/v2/subscriptions/abcdef1234567890").
-          with(:body => "<subscription><plan_code>plan_code</plan_code><unit_amount_in_cents>1500</unit_amount_in_cents></subscription>",
+        stub_request(:put, "https://api.recurly.com/v2/subscriptions/abcdef1234567890").
+          with(:basic_auth => [Recurly.api_key, ''],
+               :body => "<subscription><plan_code>plan_code</plan_code><unit_amount_in_cents>1500</unit_amount_in_cents></subscription>",
                :headers => {'Accept'=>'application/xml'}).
           to_return(:status => 200, :body => "", :headers => {})
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'logger'
 require 'cgi'
 require 'minitest/autorun'
 require 'minitest/spec'
-require 'webmock'
+require 'webmock/minitest'
 
 module SpecHelper
   include WebMock::API
@@ -15,14 +15,14 @@ module SpecHelper
 
   def stub_api_request method, uri, fixture = nil
     uri = API.base_uri + uri
-    uri.user = CGI.escape Recurly.api_key
-    uri.password = ''
+    user = CGI.escape Recurly.api_key
+    password = ''
     response = if block_given?
       yield
     else
       File.read File.expand_path("../fixtures/#{fixture}.xml", __FILE__)
     end
-    stub_request(method, uri.to_s).to_return response
+    stub_request(method, uri.to_s).with(basic_auth: [user, password]).to_return response
   end
 
   def reset_recurly_environment!
@@ -35,9 +35,8 @@ end
 
 class Minitest::Spec
   include SpecHelper
-  
+
   before do |tests|
-    WebMock.reset!
     reset_recurly_environment!
   end
 end


### PR DESCRIPTION
- Run tests on Ruby 2.4 with travis
- Bump rake to 11.3.0 to remove Fixnum warnings:
  https://github.com/ruby/rake/blob/master/History.rdoc#1130--2016-09-20
- Bump Webmock to latest with Ruby 2.4 support:
  https://github.com/bblimke/webmock/blob/master/CHANGELOG.md#231
  The main changes include:
    - requiring the proper integration, `webmock/minitest` in this case,
      which also handles resetting webmock after each test is executed
    - the way basic auth now needs to be explicitly matched rather than
      simply passed through the URI:
      https://github.com/bblimke/webmock/blob/master/CHANGELOG.md#200
- ~Bump Nokogiri to 1.7.x to remove Fixnum warnings:
  https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#170--2016-12-26~ removed due to Ruby 1.9.3/2.0 compatibility

All tests with Ruby 2.4 are passing locally.