### PR TITLE
Upgrade webmock so specs can run in 2.4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.1.0
   - 2.2.4
   - 2.3.0
+  - 2.4.0
 env:
   - XML=rexml
   - XML=nokogiri

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 11.1.0'
   s.add_development_dependency 'minitest', '~> 5.8.0'
   s.add_development_dependency 'addressable',  '~> 2.4.0'
-  s.add_development_dependency 'webmock',  '~> 1.24.6'
+  s.add_development_dependency 'webmock',  '~> 2.3.2'
 
   if RUBY_PLATFORM != 'java' && !ENV['CI']
     s.add_development_dependency 'redcarpet'

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -333,9 +333,9 @@ describe Subscription do
 
         subscription = Subscription.find 'abcdef1234567890'
 
-        stub_request(:put, "https://api_key:@api.recurly.com/v2/subscriptions/abcdef1234567890").
+        stub_request(:put, "https://api.recurly.com/v2/subscriptions/abcdef1234567890").
           with(:body => "<subscription><plan_code>abc</plan_code><quantity>1</quantity><unit_amount_in_cents>1500</unit_amount_in_cents></subscription>",
-               :headers => {'Accept'=>'application/xml'}).
+               :headers => Recurly::API.headers).
           to_return(:status => 200, :body => "", :headers => {})
 
         subscription.update_attributes({ plan_code: 'abc', quantity: 1, unit_amount_in_cents: 1500 })
@@ -350,9 +350,9 @@ describe Subscription do
 
         subscription = Subscription.find 'abcdef1234567890'
 
-        stub_request(:put, "https://api_key:@api.recurly.com/v2/subscriptions/abcdef1234567890").
+        stub_request(:put, "https://api.recurly.com/v2/subscriptions/abcdef1234567890").
           with(:body => "<subscription><plan_code>plan_code</plan_code><unit_amount_in_cents>1500</unit_amount_in_cents></subscription>",
-               :headers => {'Accept'=>'application/xml'}).
+               :headers => Recurly::API.headers).
           to_return(:status => 200, :body => "", :headers => {})
 
         subscription.update_attributes({ plan_code: 'plan_code', quantity: 1, unit_amount_in_cents: 1500 })


### PR DESCRIPTION
We needed to upgrade webmock to get specs to run in 2.4.0 and above. I also added it to the travis matrix. Roughly followed webmock upgrade notes: https://github.com/bblimke/webmock/blob/master/CHANGELOG.md#200