### PR TITLE
Fix partial address update bug

### DIFF
--- a/lib/recurly/address.rb
+++ b/lib/recurly/address.rb
@@ -1,6 +1,5 @@
 module Recurly
   class Address < Resource
-
     define_attribute_methods %w(
       address1
       address2
@@ -11,5 +10,12 @@ module Recurly
       phone
       geo_code
     )
+
+    # This ensures every attribute is rendered
+    # when updating. The Address object does not
+    # accept partial updates on the server
+    def xml_keys
+      attributes.keys
+    end
   end
 end

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -461,8 +461,8 @@ module Recurly
               # parsing here or else it always serializes. Need
               # a better way of handling changed attributes
               if el.name == 'address' && val.kind_of?(Hash)
-                address = Address.new val
-                address.changed_attributes.clear
+                address = Address.new(val)
+                address.instance_variable_set(:@changed_attributes, {})
                 record[el.name] = address
               else
                 record[el.name] = val


### PR DESCRIPTION
Resolves #309 

It appears there are two problems biting us here:

1. The endpoint does not accept partial updates of addresses. You have to send the whole address each time. 
2. `address.changed_attributes.clear` seems like it was mutating the reference to the attributes. That should probably be changed to be a copy of the attributes and not a reference.

## Testing

You should see that when updating the account, every field is serialized for the Address.

```ruby
require 'securerandom'

require 'logger'
Recurly.logger = Logger.new STDOUT

account = Recurly::Account.create(address: { city: "Brussels", country: "BE", zip: "1000" }, account_code: SecureRandom.uuid)
account.address.address1 = "1234 Rue du Lombard"
account.save!
```
