### PR TITLE
Ban nokogiri on dead rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,9 @@ env:
   - XML=nokogiri
 matrix:
   allow_failures:
-    - rvm: jruby-19mode
+    - rvm: 1.9.3
+      env: XML=nokogiri
+    - rvm: 2.0.0
+      env: XML=nokogiri
+    - rvm: jruby
       env: XML=nokogiri

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ gem 'recurly', '~> 2.8.0'
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice
 speed boost) if it's available and loaded in your app's environment.
 
-
 ## Configuration
 
 If you're using Rails, you can generate an initializer with the following
@@ -90,6 +89,19 @@ Any configuration items you do not include in the above config call will be defa
 configuration items. For example if you do not define default_currency then Recurly.default_currency
 will be used.
 
+## Supported Versions
+
+We are currently supporting versions `2.1.0` and above. `1.9` and `2.0` will still work but are deprecated.
+
+If you are still using one of these rubies, you should know that support for them ended in
+2015 (1.9) and 2016 (2.0) and continuing to use them is a security risk.
+
+- https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/
+- https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/
+
+For now, we are still running the tests on 1.9 and 2.0 but without `nokogiri` and only `rexml`. Nokogiri is
+no longer supported on 1.9 or 2.0 and has patched known vulnerabilities since dropping support.
+If you must run one of these rubies (this includes jruby1.7), you must use rexml and not nokogiri.
 
 ## Usage
 

--- a/lib/recurly/xml.rb
+++ b/lib/recurly/xml.rb
@@ -80,7 +80,18 @@ module Recurly
 end
 
 if defined? Nokogiri
-  require 'recurly/xml/nokogiri'
+  if RUBY_VERSION < "2.1.0"
+    raise <<-MSG
+
+      You are attempting to use an insecure version of
+      nokogiri on an insecure version of ruby. Please see
+      the documentation on supported versions for more information:
+      https://github.com/recurly/recurly-client-ruby#supported-versions
+
+    MSG
+  else
+    require 'recurly/xml/nokogiri'
+  end
 else
   require 'recurly/xml/rexml'
 end

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_development_dependency('nokogiri','~> 1.6.0')
+  if RUBY_VERSION >= "2.1.0"
+    s.add_development_dependency('nokogiri','~> 1.7.1')
+  end
 
   s.add_development_dependency 'rake', '~> 11.1.0'
   s.add_development_dependency 'minitest', '~> 5.8.0'


### PR DESCRIPTION
Resolves #316 

The purpose of this PR is to officially deprecate ruby versions 1.9 and 2.0 and no longer allow
an insecure version of nokogiri to be used. Looks like we will also need to deprecate jruby-1.7 as it reports as ruby version 1.9.

- Bumping nokogiri to 1.7.1
- Deprecating ruby 1.9 and 2.0 and only allowing rexml use on those versions
- Conditionally install nokogiri development dependency (for ruby >= 2.1)
- Allow failures in Travis for appropriate versions with nokogiri
- Update README with supported version information