### PR TITLE
resource_class option should be class_name and other mislabeled options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+- resource_class option should be class_name and other mislabeled options [PR](https://github.com/recurly/recurly-client-ruby/pull/321)
+
 <a name="v2.9.0"></a>
 ## v2.9.0 (2017-04-05)
 

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -17,7 +17,7 @@ module Recurly
     has_many :subscriptions
     has_many :transactions
     has_many :redemptions
-    has_many :shipping_addresses, resource_class: :ShippingAddress, readonly: false
+    has_many :shipping_addresses, readonly: false
 
     # @return [BillingInfo, nil]
     has_one :billing_info, :readonly => false

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -18,7 +18,7 @@ module Recurly
     # @return [Subscription]
     belongs_to :subscription
     # @return [Invoice]
-    belongs_to :original_invoice, class_name: 'Invoice'
+    belongs_to :original_invoice, class_name: :Invoice
 
     # This will only be present if the invoice has > 500 line items
     # @return [Adjustment]

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -510,7 +510,7 @@ module Recurly
       # @param collection_name [Symbol] Association name.
       # @param options [Hash] A hash of association options.
       # @option options [true, false] :readonly Don't define a setter.
-      #                 [String] :resource_class Actual associated resource class name
+      #                 [String] :class_name Actual associated resource class name
       #                                      if not same as collection_name.
       def has_many(collection_name, options = {})
         associations << Association.new(:has_many, collection_name.to_s, options)
@@ -536,7 +536,7 @@ module Recurly
       # @param member_name [Symbol] Association name.
       # @param options [Hash] A hash of association options.
       # @option options [true, false] :readonly Don't define a setter.
-      #                 [String] :resource_class Actual associated resource class name
+      #                 [String] :class_name Actual associated resource class name
       #                                      if not same as member_name.
       def has_one(member_name, options = {})
         associations << Association.new(:has_one, member_name.to_s, options)
@@ -574,7 +574,7 @@ module Recurly
       # @param parent_name [Symbol] Association name.
       # @param options [Hash] A hash of association options.
       # @option options [true, false] :readonly Don't define a setter.
-      #                 [String] :resource_class Actual associated resource class name
+      #                 [String] :class_name Actual associated resource class name
       #                                      if not same as parent_name.
       def belongs_to(parent_name, options = {})
         associations << Association.new(:belongs_to, parent_name.to_s, options)
@@ -847,7 +847,7 @@ module Recurly
       if new_record? || changed?
         clear_errors
         @response = API.send(
-          persisted? ? :put : :post, path, to_xml(:delta => true)
+          persisted? ? :put : :post, path, to_xml
         )
         reload response
         persist! true

--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -21,7 +21,7 @@ module Recurly
     belongs_to :subscription
 
     # @return [Transaction, nil]
-    has_one :original_transaction, class_name: 'Transaction', readonly: true
+    has_one :original_transaction, class_name: :Transaction, readonly: true
 
     define_attribute_methods %w(
       id


### PR DESCRIPTION
The `resource_class` option in the association creation helpers should be `class_name`. This was obscuring the fact that Account#shipping_addresses should not use this option so I removed it.
Also found that Resource#to_xml does not have a `delta` option.