### PR TITLE
Upgrade rake removing Fixnum warnings

### DIFF
--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency('nokogiri','~> 1.7.1')
   end
 
-  s.add_development_dependency 'rake', '~> 11.1.0'
+  s.add_development_dependency 'rake', '~> 11.3'
   s.add_development_dependency 'minitest', '~> 5.8.0'
   s.add_development_dependency 'addressable',  '~> 2.4.0'
   s.add_development_dependency 'webmock',  '~> 2.3.2'


### PR DESCRIPTION
This upgrades our development version of rake which gets rid of this warning:

```
$ bundle exec rake spec
/Users/ben/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-11.1.2/lib/rake/ext/fixnum.rb:4: warning: constant ::Fixnum is deprecated
/Users/ben/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-11.1.2/lib/rake/ext/fixnum.rb:4: warning: constant ::Fixnum is deprecated
```

Does not affect the code or the tests at all. Just prevents the deprecation warning.