### PR TITLE
Remove X-Records header parsing

### DIFF
--- a/lib/recurly/resource/pager.rb
+++ b/lib/recurly/resource/pager.rb
@@ -65,7 +65,7 @@ module Recurly
         @uri    = options.delete :uri
         @etag   = options.delete :etag
         @resource_class, @options = resource_class, options
-        @collection = @count = nil
+        @collection = nil
       end
 
       # @return [Boolean] whether or not the xml element is present
@@ -81,7 +81,7 @@ module Recurly
       # @return [Integer] The total record count of the resource in question.
       # @see Resource.count
       def count
-        @count ||= API.head(uri, @options)['X-Records'].to_i
+        API.head(uri, @options)['X-Records'].to_i
       end
 
       # @return [Array] Iterates through the current page of records.
@@ -134,7 +134,7 @@ module Recurly
       #   Recurly::Account.active.paginate :per_page => 20
       def paginate options = {}
         dup.instance_eval {
-          @collection = @count = @etag = nil
+          @collection = @etag = nil
           @options = @options.merge options
           self
         }
@@ -220,7 +220,6 @@ module Recurly
         response = API.get uri, params, options
 
         @etag = response['ETag']
-        @count = response['X-Records'].to_i
         @links = {}
         if links = response['Link']
           links.scan(/<([^>]+)>; rel="([^"]+)"/).each do |link, rel|

--- a/spec/fixtures/accounts/index-200.xml
+++ b/spec/fixtures/accounts/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 123
 Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/accounts?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/fixtures/gift_cards/index-200.xml
+++ b/spec/fixtures/gift_cards/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 123
 Link: <https://api.recurly.com/v2/gift_cards?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/gift_cards?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/fixtures/shipping_addresses/index-200.xml
+++ b/spec/fixtures/shipping_addresses/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 123
 Link: <https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/fixtures/shipping_addresses/show-200.xml
+++ b/spec/fixtures/shipping_addresses/show-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 123
 
 <?xml version="1.0" encoding="UTF-8"?>
 <shipping_address href="https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses/2017683623137826835">

--- a/spec/recurly/resource/pager_spec.rb
+++ b/spec/recurly/resource/pager_spec.rb
@@ -37,12 +37,6 @@ describe Resource::Pager do
         stub_api_request(:head, 'resources') { XML[200][:index] }
         pager.count.must_equal 3
       end
-
-      it "must not fetch the count when already loaded" do
-        stub_api_request(:get, 'resources') { XML[200][:index] }
-        pager.reload
-        pager.count.must_equal 3
-      end
     end
 
     describe "#links" do


### PR DESCRIPTION
We are removing the X-Records header in api version 2.6 on paginating GET requests
and they only come back on HEAD requests. Now calling `Resource#count` or `Pager#count`
will always explicitly call the server with a HEAD request. This should maybe be considered a breaking change:

To get a count, you'll need to explicitly call count which will call the server on each call.

```ruby
params = {
  begin_time: Date.today.prev_month,
  order: :asc,
  sort: :created_at
}

count = Recurly::Transaction.where(params).count
puts count
```

