### PR TITLE
Bump v 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,23 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.10.0"></a>
+## v2.10.0 (2017-05-19)
+
 - resource_class option should be class_name and other mislabeled options [PR](https://github.com/recurly/recurly-client-ruby/pull/321)
+- Upgrade rake to fix warnings [PR](https://github.com/recurly/recurly-client-ruby/pull/323)
+- Purchases endpoint [PR](https://github.com/recurly/recurly-client-ruby/pull/322)
+- Removal of X-Records header [PR](https://github.com/recurly/recurly-client-ruby/pull/324)
+
+### Upgrade Notes:
+
+This release will upgrade us to API version 2.6. There are two breaking changes:
+
+1. Since the X-Records header was removed in the pagination endpoint, you can no longer call `count` on a `Pager` and expect it to return a cached response.
+From now on, when you call `Pager#count`, it will send a `HEAD` request to the server. So make sure you aren't calling that method in places where you expect the value
+to be cached for you. For more info see [PR #324](https://github.com/recurly/recurly-client-ruby/pull/324).
+2. For `POST /v2/subscriptions` Sending `nil` for `total_billing_cycles` attribute will now override plan `total_billing_cycles` setting and will make subscription renew forever.
+Omitting the attribute will cause the setting to default to the value of plan `total_billing_cycles`.
 
 <a name="v2.9.0"></a>
 ## v2.9.0 (2017-04-05)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.9.0'
+gem 'recurly', '~> 2.10.0'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -30,6 +30,7 @@ module Recurly
   require 'recurly/xml'
   require 'recurly/delivery'
   require 'recurly/gift_card'
+  require 'recurly/purchase'
   require 'recurly/webhook'
 
   @subdomain = nil

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -16,7 +16,7 @@ module Recurly
 
     @@base_uri = "https://api.recurly.com/v2/"
 
-    RECURLY_API_VERSION = '2.5'
+    RECURLY_API_VERSION = '2.6'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -29,6 +29,7 @@ module Recurly
       setup_fee_revenue_schedule_type
       tax_exempt
       tax_code
+      trial_requires_billing_info
       created_at
       updated_at
     )

--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -34,5 +34,16 @@ module Recurly
       updated_at
     )
     alias to_param plan_code
+
+    #TODO this can be removed after the server update
+    def trial_requires_billing_info
+      val = read_attribute(:trial_requires_billing_info)
+      case val
+      when String
+        val == 'true'
+      else
+        val
+      end
+    end
   end
 end

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -1,0 +1,131 @@
+module Recurly
+  # The Purchase object works a slightly differently than the rest of the models.
+  # You build up the purchase data into an object then pass to either:
+  # {Purchase.invoice!} or {Purchase.preview!} and it will
+  # return an {Invoice}.
+  #
+  # You can build your purchase object with a new account or an existing account.
+  # For an existing account, you just need an account_code:
+  #   Recurly::Purchase.new({account: {account_code: 'myexistingaccount'}})
+  # or
+  #   account = Recurly::Account.find('existing_account')
+  #   Recurly::Purchase.new({account: account})
+  # or
+  #   account = Recurly::Account.find('existing_account')
+  #   purchase = Recurly::Purchase.new
+  #   purchase.account = account
+  #
+  # For a new account, you can pass in {Account} data, {BillingInfo} data, etc
+  # in the same way you would when creating a {Subscription} with a new account.
+  #
+  # You can also pass in adjustments and invoicing data to be passed to the invoice.
+  # Here is an example of a Purchase with a new account:
+  #   require 'securerandom'
+  #
+  #   purchase = Recurly::Purchase.new({
+  #     currency: 'USD',
+  #     collection_method: :automatic,
+  #     account: {
+  #       account_code: SecureRandom.uuid,
+  #       billing_info: {
+  #         first_name: 'Benjamin',
+  #         last_name: 'Du Monde',
+  #         address1: '400 Alabama St',
+  #         city: 'San Francisco',
+  #         state: 'CA',
+  #         zip: '94110',
+  #         country: 'US',
+  #         number: '4111-1111-1111-1111',
+  #         month: 12,
+  #         year: 2019,
+  #       }
+  #     },
+  #     adjustments: [
+  #       {
+  #          product_code: 'product_1',
+  #          unit_amount_in_cents: 1000,
+  #          quantity: 1,
+  #          revenue_schedule_type: :at_invoice
+  #       },
+  #       {
+  #         product_code: 'product_2'
+  #         unit_amount_in_cents: 3000,
+  #         quantity: 5,
+  #         revenue_schedule_type: :at_invoice
+  #       }
+  #     ]
+  #   })
+  #
+  #   begin
+  #     preview_invoice = Recurly::Purchase.invoice!(purchase)
+  #     puts preview_invoice.inspect
+  #   rescue Recurly::Resource::Invalid => e
+  #     # Invalid data
+  #   end
+  #
+  #   begin
+  #     invoice = Recurly::Purchase.invoice!(purchase)
+  #   rescue Recurly::Resource::Invalid => e
+  #     # Invalid data
+  #   rescue Recurly::Transaction::DeclinedError => e
+  #     # Display e.message and/or subscription (and associated) errors...
+  #   rescue Recurly::Transaction::RetryableError => e
+  #     # You should be able to attempt to save this again later.
+  #   rescue Recurly::Transaction::Error => e
+  #     # Fallback transaction error
+  #     # e.transaction
+  #     # e.transaction_error_code
+  #   end
+  #
+  class Purchase < Resource
+    # @return [[Adjustment], nil]
+    has_many :adjustments, class_name: :Adjustment, readonly: false
+
+    # @return [Account, nil]
+    has_one :account, readonly: false
+
+    define_attribute_methods %w(
+      currency
+      collection_method
+      po_number
+      terms
+    )
+
+    class << self
+
+      # Generate an invoice for the purchase and run any needed transactions
+      #
+      # @param purchase [Purchase] The purchase data for the request
+      # @return [Invoice] The new invoice representing this purchase
+      # @raise [Invalid] Raised if the account cannot be invoiced.
+      # @raise [Transaction::Error] Raised if the transaction failed
+      def invoice!(purchase)
+        post(purchase, collection_path)
+      end
+
+      # Generate a preview invoice for the purchase. Runs validations
+      # but does not run any transactions.
+      #
+      # @param purchase [Purchase] The purchase data for the request
+      # @return [Invoice] The new invoice representing this purchase
+      # @raise [Invalid] Raised if the account cannot be invoiced.
+      def preview!(purchase)
+        post(purchase, "#{collection_path}/preview")
+      end
+
+      def post(purchase, path)
+        response = API.send(:post, path, purchase.to_xml)
+        Invoice.from_response(response)
+      rescue API::UnprocessableEntity => e
+        purchase.apply_errors(e)
+        Transaction::Error.validate!(e, nil)
+        raise Resource::Invalid.new(purchase)
+      end
+    end
+
+    # This object does not represent a model on the server side
+    # so we do not need to expose thses methods.
+    protected(*%w(save save!))
+    private_class_method(*%w(all find_each first paginate scoped where post create! create))
+  end
+end

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -88,7 +88,7 @@ module Recurly
       currency
       collection_method
       po_number
-      terms
+      net_terms
     )
 
     class << self

--- a/lib/recurly/resource/pager.rb
+++ b/lib/recurly/resource/pager.rb
@@ -65,7 +65,7 @@ module Recurly
         @uri    = options.delete :uri
         @etag   = options.delete :etag
         @resource_class, @options = resource_class, options
-        @collection = @count = nil
+        @collection = nil
       end
 
       # @return [Boolean] whether or not the xml element is present
@@ -81,7 +81,7 @@ module Recurly
       # @return [Integer] The total record count of the resource in question.
       # @see Resource.count
       def count
-        @count ||= API.head(uri, @options)['X-Records'].to_i
+        API.head(uri, @options)['X-Records'].to_i
       end
 
       # @return [Array] Iterates through the current page of records.
@@ -134,7 +134,7 @@ module Recurly
       #   Recurly::Account.active.paginate :per_page => 20
       def paginate options = {}
         dup.instance_eval {
-          @collection = @count = @etag = nil
+          @collection = @etag = nil
           @options = @options.merge options
           self
         }
@@ -220,7 +220,6 @@ module Recurly
         response = API.get uri, params, options
 
         @etag = response['ETag']
-        @count = response['X-Records'].to_i
         @links = {}
         if links = response['Link']
           links.scan(/<([^>]+)>; rel="([^"]+)"/).each do |link, rel|

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -73,6 +73,7 @@ module Recurly
       timeframe
       started_with_gift
       converted_at
+      no_billing_info_reason
     )
     alias to_param uuid
 

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,7 +1,7 @@
 module Recurly
   module Version
     MAJOR   = 2
-    MINOR   = 9
+    MINOR   = 10
     PATCH   = 0
     PRE     = nil
 

--- a/spec/fixtures/accounts/index-200.xml
+++ b/spec/fixtures/accounts/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 123
 Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/accounts?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/fixtures/gift_cards/index-200.xml
+++ b/spec/fixtures/gift_cards/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 123
 Link: <https://api.recurly.com/v2/gift_cards?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/gift_cards?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/fixtures/plans/show-200.xml
+++ b/spec/fixtures/plans/show-200.xml
@@ -24,6 +24,7 @@ Content-Type: application/xml; charset=utf-8
   <setup_fee_accounting_code nil="nil"/>
   <revenue_schedule_type>evenly</revenue_schedule_type>
   <setup_fee_revenue_schedule_type>evenly</setup_fee_revenue_schedule_type>
+  <trial_requires_billing_info type="boolean">false</trial_requires_billing_info>
   <created_at type="datetime">2016-04-13T21:59:18Z</created_at>
   <unit_amount_in_cents>
     <USD type="integer">1000</USD>

--- a/spec/fixtures/purchases/invoice-201.xml
+++ b/spec/fixtures/purchases/invoice-201.xml
@@ -1,0 +1,148 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/3517
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="https://api.recurly.com/v2/invoices/3517">
+  <account href="https://api.recurly.com/v2/accounts/9743bb2a-6b6d-4d8d-9090-df0d13405f88"/>
+  <address>
+    <address1>400 Alabama St</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94110</zip>
+    <country>US</country>
+    <phone nil="nil"></phone>
+  </address>
+  <uuid>3cd714a6322d76b0dad1d640e4a27b2c</uuid>
+  <state>collected</state>
+  <invoice_number_prefix></invoice_number_prefix>
+  <invoice_number type="integer">3517</invoice_number>
+  <po_number nil="nil"></po_number>
+  <vat_number nil="nil"></vat_number>
+  <subtotal_in_cents type="integer">7000</subtotal_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">7000</total_in_cents>
+  <subtotal_after_discount_in_cents type="integer">7000</subtotal_after_discount_in_cents>
+  <currency>USD</currency>
+  <created_at type="datetime">2017-04-13T17:08:12Z</created_at>
+  <updated_at type="datetime">2017-04-13T17:08:12Z</updated_at>
+  <attempt_next_collection_at nil="nil"></attempt_next_collection_at>
+  <closed_at type="datetime">2017-04-13T17:08:12Z</closed_at>
+  <terms_and_conditions nil="nil"></terms_and_conditions>
+  <customer_notes nil="nil"></customer_notes>
+  <recovery_reason nil="nil"></recovery_reason>
+  <net_terms type="integer">0</net_terms>
+  <collection_method>automatic</collection_method>
+  <line_items type="array">
+    <adjustment href="https://api.recurly.com/v2/adjustments/3cd714a628875d77f09dea4cabafe367" type="charge">
+      <account href="https://api.recurly.com/v2/accounts/9743bb2a-6b6d-4d8d-9090-df0d13405f88"/>
+      <invoice href="https://api.recurly.com/v2/invoices/3517"/>
+      <uuid>3cd714a628875d77f09dea4cabafe367</uuid>
+      <state>invoiced</state>
+      <description nil="nil"></description>
+      <accounting_code nil="nil"></accounting_code>
+      <product_code>7b3e439a-802e-4339-b37f-28a98e65ef4f</product_code>
+      <origin>debit</origin>
+      <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
+      <discount_in_cents type="integer">0</discount_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">1000</total_in_cents>
+      <currency>USD</currency>
+      <taxable type="boolean">false</taxable>
+      <tax_exempt type="boolean">false</tax_exempt>
+      <tax_code nil="nil"></tax_code>
+      <start_date type="datetime">2017-04-13T17:08:12Z</start_date>
+      <end_date nil="nil"></end_date>
+      <created_at type="datetime">2017-04-13T17:08:12Z</created_at>
+      <updated_at type="datetime">2017-04-13T17:08:12Z</updated_at>
+      <revenue_schedule_type>at_invoice</revenue_schedule_type>
+    </adjustment>
+    <adjustment href="https://api.recurly.com/v2/adjustments/3cd714a62d3c8333b9d01b4c73aee8ad" type="charge">
+      <account href="https://api.recurly.com/v2/accounts/9743bb2a-6b6d-4d8d-9090-df0d13405f88"/>
+      <invoice href="https://api.recurly.com/v2/invoices/3517"/>
+      <uuid>3cd714a62d3c8333b9d01b4c73aee8ad</uuid>
+      <state>invoiced</state>
+      <description nil="nil"></description>
+      <accounting_code nil="nil"></accounting_code>
+      <product_code>bf61ee52-5c22-4f38-b06b-3ffc74e479ab</product_code>
+      <origin>debit</origin>
+      <unit_amount_in_cents type="integer">3000</unit_amount_in_cents>
+      <quantity type="integer">2</quantity>
+      <discount_in_cents type="integer">0</discount_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">6000</total_in_cents>
+      <currency>USD</currency>
+      <taxable type="boolean">false</taxable>
+      <tax_exempt type="boolean">false</tax_exempt>
+      <tax_code nil="nil"></tax_code>
+      <start_date type="datetime">2017-04-13T17:08:12Z</start_date>
+      <end_date nil="nil"></end_date>
+      <created_at type="datetime">2017-04-13T17:08:12Z</created_at>
+      <updated_at type="datetime">2017-04-13T17:08:12Z</updated_at>
+      <revenue_schedule_type>at_invoice</revenue_schedule_type>
+    </adjustment>
+  </line_items>
+  <transactions type="array">
+    <transaction href="https://api.recurly.com/v2/transactions/3cd714a646a4d8f4413db2433b972f3f" type="credit_card">
+      <account href="https://api.recurly.com/v2/accounts/9743bb2a-6b6d-4d8d-9090-df0d13405f88"/>
+      <invoice href="https://api.recurly.com/v2/invoices/3517"/>
+      <uuid>3cd714a646a4d8f4413db2433b972f3f</uuid>
+      <action>purchase</action>
+      <amount_in_cents type="integer">7000</amount_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <currency>USD</currency>
+      <status>success</status>
+      <payment_method>credit_card</payment_method>
+      <reference>3358286</reference>
+      <source>transaction</source>
+      <recurring type="boolean">false</recurring>
+      <test type="boolean">true</test>
+      <voidable type="boolean">true</voidable>
+      <refundable type="boolean">true</refundable>
+      <ip_address nil="nil"></ip_address>
+      <gateway_type>test</gateway_type>
+      <origin>api</origin>
+      <description nil="nil"></description>
+      <message>Successful test transaction</message>
+      <approval_code nil="nil"></approval_code>
+      <failure_type nil="nil"></failure_type>
+      <gateway_error_codes nil="nil"></gateway_error_codes>
+      <cvv_result code="" nil="nil"></cvv_result>
+      <avs_result code="D">Street address and postal code match.</avs_result>
+      <avs_result_street nil="nil"></avs_result_street>
+      <avs_result_postal nil="nil"></avs_result_postal>
+      <created_at type="datetime">2017-04-13T17:08:12Z</created_at>
+      <collected_at type="datetime">2017-04-13T17:08:12Z</collected_at>
+      <updated_at type="datetime">2017-04-13T17:08:12Z</updated_at>
+      <details>
+        <account>
+          <account_code>9743bb2a-6b6d-4d8d-9090-df0d13405f88</account_code>
+          <first_name nil="nil"></first_name>
+          <last_name nil="nil"></last_name>
+          <company nil="nil"></company>
+          <email nil="nil"></email>
+          <billing_info type="credit_card">
+            <first_name>Benjamin</first_name>
+            <last_name>Du Monde</last_name>
+            <address1>400 Alabama St</address1>
+            <address2 nil="nil"></address2>
+            <city>San Francisco</city>
+            <state>CA</state>
+            <zip>94110</zip>
+            <country>US</country>
+            <phone nil="nil"></phone>
+            <vat_number nil="nil"></vat_number>
+            <card_type>Visa</card_type>
+            <year type="integer">2019</year>
+            <month type="integer">12</month>
+            <first_six>411111</first_six>
+            <last_four>1111</last_four>
+          </billing_info>
+        </account>
+      </details>
+    </transaction>
+  </transactions>
+  <a name="refund" href="https://api.recurly.com/v2/invoices/3517/refund" method="post"/>
+</invoice>

--- a/spec/fixtures/purchases/invoice-422.xml
+++ b/spec/fixtures/purchases/invoice-422.xml
@@ -1,0 +1,7 @@
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+  <error field="purchase.adjustments[0].unit_amount_in_cents" symbol="not_a_number">is not a number</error>
+</errors>

--- a/spec/fixtures/purchases/invoice-declined-422.xml
+++ b/spec/fixtures/purchases/invoice-declined-422.xml
@@ -1,0 +1,77 @@
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+  <transaction_error>
+    <error_code>declined</error_code>
+    <error_category>soft</error_category>
+    <merchant_message>The customer's bank has declined their card. The customer will need to contact their bank to learn the cause.</merchant_message>
+    <customer_message>Your transaction was declined. Please use a different card or contact your bank.</customer_message>
+    <gateway_error_code nil="nil"></gateway_error_code>
+  </transaction_error>
+  <error field="purchase.base" symbol="declined">Your transaction was declined. Please use a different card or contact your bank.</error>
+  <transaction href="https://bhelx.recurly.com/v2/transactions/3cd7feef9657cb6e8316344bb4aaa891" type="credit_card">
+    <uuid>3cd7feef9657cb6e8316344bb4aaa891</uuid>
+    <action>purchase</action>
+    <amount_in_cents type="integer">1000</amount_in_cents>
+    <tax_in_cents type="integer">0</tax_in_cents>
+    <currency>USD</currency>
+    <status>declined</status>
+    <payment_method>credit_card</payment_method>
+    <reference>9154060</reference>
+    <source>transaction</source>
+    <recurring type="boolean">false</recurring>
+    <test type="boolean">true</test>
+    <voidable type="boolean">false</voidable>
+    <refundable type="boolean">false</refundable>
+    <ip_address nil="nil"></ip_address>
+    <gateway_type>test</gateway_type>
+    <origin>api</origin>
+    <description nil="nil"></description>
+    <message>Declined transaction</message>
+    <approval_code nil="nil"></approval_code>
+    <failure_type>declined</failure_type>
+    <gateway_error_codes nil="nil"></gateway_error_codes>
+    <transaction_error>
+      <error_code>declined</error_code>
+      <error_category>soft</error_category>
+      <merchant_message>The customer's bank has declined their card. The customer will need to contact their bank to learn the cause.</merchant_message>
+      <customer_message>Your transaction was declined. Please use a different card or contact your bank.</customer_message>
+      <gateway_error_code nil="nil"></gateway_error_code>
+    </transaction_error>
+    <cvv_result code="" nil="nil"></cvv_result>
+    <avs_result code="" nil="nil"></avs_result>
+    <avs_result_street nil="nil"></avs_result_street>
+    <avs_result_postal nil="nil"></avs_result_postal>
+    <created_at type="datetime">2017-04-13T21:24:06Z</created_at>
+    <collected_at type="datetime">2017-04-13T21:24:06Z</collected_at>
+    <updated_at type="datetime">2017-04-13T21:24:06Z</updated_at>
+    <details>
+      <account>
+        <account_code>da319525-0efd-4d45-8d09-2f375ccf7af3</account_code>
+        <first_name nil="nil"></first_name>
+        <last_name nil="nil"></last_name>
+        <company nil="nil"></company>
+        <email nil="nil"></email>
+        <billing_info type="credit_card">
+          <first_name>Benjamin</first_name>
+          <last_name>Du Monde</last_name>
+          <address1>400 Alabama St</address1>
+          <address2 nil="nil"></address2>
+          <city>San Francisco</city>
+          <state>CA</state>
+          <zip>94110</zip>
+          <country>US</country>
+          <phone nil="nil"></phone>
+          <vat_number nil="nil"></vat_number>
+          <card_type>Visa</card_type>
+          <year type="integer">2019</year>
+          <month type="integer">12</month>
+          <first_six>400000</first_six>
+          <last_four>0002</last_four>
+        </billing_info>
+      </account>
+    </details>
+  </transaction>
+</errors>

--- a/spec/fixtures/purchases/preview-201.xml
+++ b/spec/fixtures/purchases/preview-201.xml
@@ -1,0 +1,64 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/3517
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="">
+  <account href="https://api.recurly.com/v2/accounts/e33a27ba-d040-4055-b792-7908f375519c"/>
+  <address>
+    <address1>400 Alabama St</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94110</zip>
+    <country>US</country>
+    <phone nil="nil"></phone>
+  </address>
+  <uuid>3cd86c538142718179ec4a4b4586efc4</uuid>
+  <state>open</state>
+  <invoice_number_prefix></invoice_number_prefix>
+  <invoice_number nil="nil"></invoice_number>
+  <po_number nil="nil"></po_number>
+  <vat_number nil="nil"></vat_number>
+  <subtotal_in_cents type="integer">1000</subtotal_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">1000</total_in_cents>
+  <subtotal_after_discount_in_cents type="integer">1000</subtotal_after_discount_in_cents>
+  <currency>USD</currency>
+  <created_at nil="nil"></created_at>
+  <updated_at nil="nil"></updated_at>
+  <attempt_next_collection_at type="datetime">2017-04-13T23:23:35Z</attempt_next_collection_at>
+  <closed_at nil="nil"></closed_at>
+  <terms_and_conditions nil="nil"></terms_and_conditions>
+  <customer_notes nil="nil"></customer_notes>
+  <recovery_reason nil="nil"></recovery_reason>
+  <net_terms type="integer">0</net_terms>
+  <collection_method>automatic</collection_method>
+  <line_items type="array">
+    <adjustment href="" type="charge">
+      <account href="https://api.recurly.com/v2/accounts/e33a27ba-d040-4055-b792-7908f375519c"/>
+      <uuid>3cd86c5379c19c7f92dca34d46846c46</uuid>
+      <state>pending</state>
+      <description nil="nil"></description>
+      <accounting_code nil="nil"></accounting_code>
+      <product_code>c6b6ea2e-770d-4b1e-bdec-279d4be7e22f</product_code>
+      <origin>debit</origin>
+      <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
+      <discount_in_cents type="integer">0</discount_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">1000</total_in_cents>
+      <currency>USD</currency>
+      <taxable type="boolean">false</taxable>
+      <tax_exempt type="boolean">false</tax_exempt>
+      <tax_code nil="nil"></tax_code>
+      <start_date type="datetime">2017-04-13T23:23:35Z</start_date>
+      <end_date nil="nil"></end_date>
+      <created_at nil="nil"></created_at>
+      <updated_at nil="nil"></updated_at>
+      <revenue_schedule_type>at_invoice</revenue_schedule_type>
+    </adjustment>
+  </line_items>
+  <transactions type="array">
+  </transactions>
+</invoice>

--- a/spec/fixtures/shipping_addresses/index-200.xml
+++ b/spec/fixtures/shipping_addresses/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 123
 Link: <https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/fixtures/shipping_addresses/show-200.xml
+++ b/spec/fixtures/shipping_addresses/show-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 123
 
 <?xml version="1.0" encoding="UTF-8"?>
 <shipping_address href="https://api.recurly.com/v2/accounts/bd8d90fb-9581-4b44-9e61-26eab86b0577/shipping_addresses/2017683623137826835">

--- a/spec/fixtures/subscriptions/show-200.xml
+++ b/spec/fixtures/subscriptions/show-200.xml
@@ -28,6 +28,7 @@ Content-Type: application/xml; charset=utf-8
   <trial_started_at nil="nil"></trial_started_at>
   <trial_ends_at nil="nil"></trial_ends_at>
   <revenue_schedule_type>evenly</revenue_schedule_type>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
   <subscription_add_ons type="array">
     <subscription_add_on>
       <add_on_type>usage</add_on_type>

--- a/spec/recurly/purchase_spec.rb
+++ b/spec/recurly/purchase_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Purchase do
+  let(:purchase) do
+    Purchase.new(
+      account: {account_code: 'account123'},
+      adjustments: [
+        {
+          product_code: 'product_code',
+          unit_amount_in_cents: 1_000,
+          quantity: 1
+        }
+      ]
+    )
+  end
+
+  describe "Purchase.invoice!" do
+    it "should return an invoice when valid" do
+      stub_api_request(:post, 'purchases', 'purchases/invoice-201')
+      invoice = Purchase.invoice!(purchase)
+      invoice.must_be_instance_of Invoice
+    end
+    it "should raise an Invalid error when data is invalid" do
+      stub_api_request(:post, 'purchases', 'purchases/invoice-422')
+      # ensure error is raised
+      proc {Purchase.invoice!(purchase)}.must_raise Resource::Invalid
+      # ensure error details are mapped back
+      purchase.adjustments.first.errors["unit_amount_in_cents"].must_equal ["is not a number"]
+    end
+    it "should raise a Transaction::Error error when transaction fails" do
+      stub_api_request(:post, 'purchases', 'purchases/invoice-declined-422')
+      proc {Purchase.invoice!(purchase)}.must_raise Transaction::Error
+    end
+  end
+
+  describe "Purchase.preview!" do
+    it "should return a preview invoice when valid" do
+      stub_api_request(:post, 'purchases/preview', 'purchases/preview-201')
+      preview_invoice = Purchase.preview!(purchase)
+      preview_invoice.must_be_instance_of Invoice
+    end
+    it "should raise an Invalid error when data is invalid" do
+      stub_api_request(:post, 'purchases/preview', 'purchases/invoice-422')
+      # ensure error is raised
+      proc {Purchase.preview!(purchase)}.must_raise Resource::Invalid
+      # ensure error details are mapped back
+      purchase.adjustments.first.errors["unit_amount_in_cents"].must_equal ["is not a number"]
+    end
+  end
+end

--- a/spec/recurly/resource/pager_spec.rb
+++ b/spec/recurly/resource/pager_spec.rb
@@ -37,12 +37,6 @@ describe Resource::Pager do
         stub_api_request(:head, 'resources') { XML[200][:index] }
         pager.count.must_equal 3
       end
-
-      it "must not fetch the count when already loaded" do
-        stub_api_request(:get, 'resources') { XML[200][:index] }
-        pager.reload
-        pager.count.must_equal 3
-      end
     end
 
     describe "#links" do


### PR DESCRIPTION
## v2.10.0 (2017-05-19)

 - resource_class option should be class_name and other mislabeled options [PR](https://github.com/recurly/recurly-client-ruby/pull/321)
- Upgrade rake to fix warnings [PR](https://github.com/recurly/recurly-client-ruby/pull/323)
- Purchases endpoint [PR](https://github.com/recurly/recurly-client-ruby/pull/322)
- Removal of X-Records header [PR](https://github.com/recurly/recurly-client-ruby/pull/324)