### PR TITLE
Removes Plan#trial_requires_billing_info coercion

### DIFF
--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -34,16 +34,5 @@ module Recurly
       updated_at
     )
     alias to_param plan_code
-
-    #TODO this can be removed after the server update
-    def trial_requires_billing_info
-      val = read_attribute(:trial_requires_billing_info)
-      case val
-      when String
-        val == 'true'
-      else
-        val
-      end
-    end
   end
 end


### PR DESCRIPTION
This field was coming back without the `type="boolean"` attribute in the xml. In order to not interrupt our 2.6 release date, I overrode the read accessor to coerce the field into a boolean (if it wasn't already). Now that the API change has been deployed we can safely remove this dead code.

### Testing

```ruby
plan = Recurly::Plan.all.first
attr = plan.trial_requires_billing_info

if [true, false].include?(attr)
  puts "It's a still boolean as expected"
else
  puts "It's not a boolean #{attr}"
end
```