### PR TITLE
"address" was being singularized as "addres"

### DIFF
--- a/lib/recurly/gift_card.rb
+++ b/lib/recurly/gift_card.rb
@@ -3,7 +3,8 @@ module Recurly
     belongs_to :invoice
     belongs_to :gifter_account, class_name: :Account, readonly: false
     belongs_to :recipient_account, class_name: :Account, readonly: false
-    has_one :delivery, readonly: false
+    has_one :delivery, readonly: false, class_name: :Delivery
+    has_one :address, readonly: false, class_name: :Address
 
     define_attribute_methods %w(
       balance_in_cents

--- a/lib/recurly/helper.rb
+++ b/lib/recurly/helper.rb
@@ -18,7 +18,7 @@ module Recurly
 
     def singularize word
       word = word.to_s
-      return "shipping_address" if word == "shipping_address"
+      return word if word.end_with?('address')
       return "shipping_address" if word == "shipping_addresses"
       word.sub(/s$/, '').sub(/ie$/, 'y')
     end


### PR DESCRIPTION
This caused an issue when creating a GiftCard with an address:

```
/Users/ben/R/recurly-client-ruby/lib/recurly/resource.rb:1085:in `fetch_associated': uninitialized constant Recurly::Addres (NameError)
Did you mean?  Recurly::Address
```

We need to remove the need to singularize and pluralize because it's so problematic. I don't want to add any dependencies to this library so we will fix this instance for now.