### PR TITLE
Bumps to API version 2 7

### DIFF
--- a/lib/recurly/adjustment.rb
+++ b/lib/recurly/adjustment.rb
@@ -54,7 +54,7 @@ module Recurly
     # @example
     #   account.adjustments.new attributes
     # @see Resource#initialize
-    def initialize attributes = {}
+    def initialize(attributes = {})
       super({ :currency => Recurly.default_currency }.merge attributes)
     end
 

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -16,7 +16,7 @@ module Recurly
 
     @@base_uri = "https://api.recurly.com/v2/"
 
-    RECURLY_API_VERSION = '2.6'
+    RECURLY_API_VERSION = '2.7'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -151,7 +151,7 @@ module Recurly
 
     private
 
-    def initialize attributes = {}
+    def initialize(attributes = {})
       super({ :currency => Recurly.default_currency }.merge attributes)
     end
 

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -82,13 +82,20 @@ module Recurly
     has_many :adjustments, class_name: :Adjustment, readonly: false
 
     # @return [Account, nil]
-    has_one :account, readonly: false
+    has_one :account, class_name: :Account, readonly: false
+
+    # @return [GiftCard, nil]
+    has_one :gift_card, class_name: :GiftCard, readonly: false
+
+    # @return [[Subscription], nil]
+    has_many :subscriptions, class_name: :Subscription, readonly: false
 
     define_attribute_methods %w(
       currency
       collection_method
       po_number
       net_terms
+      coupon_codes
     )
 
     class << self

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -90,8 +90,8 @@ module Recurly
     end
 
     # @return [Subscription] A new subscription.
-    def initialize attributes = {}
-      super({ :currency => Recurly.default_currency }.merge attributes)
+    def initialize(attributes = {})
+      super(attributes)
     end
 
     # Assign a Plan resource (rather than a plan code).

--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -70,7 +70,7 @@ module Recurly
     attr_reader :type
 
     # @see Resource#initialize
-    def initialize attributes = {}
+    def initialize(attributes = {})
       super({ :currency => Recurly.default_currency }.merge attributes)
     end
 

--- a/spec/recurly/js_spec.rb
+++ b/spec/recurly/js_spec.rb
@@ -135,6 +135,7 @@ EOS
 
       it "must sign subscription request" do
         subscription = Subscription.new :plan_code => 'gold'
+        subscription.currency = 'USD'
         account = Account.new :account_code => '123'
         Recurly.js.sign(subscription, account).must_equal <<EOS.chomp
 c74db6318765b7f3e0e31ad54a7773000646df0b|\
@@ -148,6 +149,7 @@ EOS
 
       it "must sign transaction request" do
         transaction = Transaction.new :amount_in_cents => 50_00
+        transaction.currency = 'USD'
         transaction.persist!
         account = Account.new :account_code => '123'
         Recurly.js.sign(transaction, account).must_equal <<EOS.chomp

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -125,7 +125,7 @@ describe Subscription do
     end
 
     it "must serialize" do
-      subscription = Subscription.new
+      subscription = Subscription.new(currency: 'USD')
       subscription.add_ons << :trial
       subscription.to_xml.must_equal get_raw_xml("subscriptions/serialize-add-ons.xml")
     end


### PR DESCRIPTION
There is only one feature on API v2.7, the updates to the purchases endpoint.

```ruby
plan = Recurly::Plan.first

p = Recurly::Purchase.new({
  currency: 'USD',
  collection_method: :automatic,
  account: {
    #account_code: '361eecc8-6335-4c34-b1fc-a642975bc595',
    account_code: SecureRandom.uuid,
    billing_info: {
      first_name: 'Benjamin',
      last_name: 'Du Monde',
      address1: '400 Alabama St',
      city: 'San Francisco',
      state: 'CA',
      zip: '94110',
      country: 'US',
      number: '4111-1111-1111-1111',
      month: 12,
      year: 2019,
    }
  },
  subscriptions: [
    {
      plan_code: plan.plan_code,
    }
  ],
  coupon_codes: [
    "couponcode",
    "jyadk5mbv0",
  ],
  gift_card: {
    redemption_code: "BC3749AB38371F273"
  }
})

begin
  invoice = Recurly::Purchase.invoice!(p)
  # puts preview_invoice.inspect
  # invoice = Recurly::Purchase.invoice!(p)
  # puts invoice.inspect
  invoice.redemptions.each do |r|
    puts r.inspect
  end
rescue Recurly::Resource::Invalid => e
  puts e.inspect
  # Invalid data
rescue Recurly::Transaction::DeclinedError => e
  puts e.inspect
  # Display e.message and/or subscription (and associated) errors...
  # e.transaction
  # e.transaction_error_code
rescue Recurly::Transaction::RetryableError => e
  puts e.inspect
  # You should be able to attempt to save this again later.
  # e.transaction
  # e.transaction_error_code
rescue Recurly::Transaction::Error => e
  puts e.inspect
  # Fallback transaction error
  # e.transaction
  # e.transaction_error_code
end
```
