### PR TITLE
Rework the pagination so it's simpler to explain and support

### DIFF
--- a/lib/recurly/account_balance.rb
+++ b/lib/recurly/account_balance.rb
@@ -16,6 +16,6 @@ module Recurly
     # This object does not represent a model on the server side
     # so we do not need to expose these methods.
     protected(*%w(save save!))
-    private_class_method(*%w(all find_each first paginate scoped where create! create))
+    private_class_method(*%w(find_each first paginate create! create))
   end
 end

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -145,6 +145,6 @@ module Recurly
     # This object does not represent a model on the server side
     # so we do not need to expose these methods.
     protected(*%w(save save!))
-    private_class_method(*%w(all find_each first paginate scoped where post create! create))
+    private_class_method(*%w(find_each first paginate post create! create))
   end
 end

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -256,12 +256,6 @@ module Recurly
       def paginate(options = {})
         Pager.new self, options
       end
-      alias scoped paginate
-      alias where  paginate
-
-      def all(options = {})
-        paginate(options).to_a
-      end
 
       # @return [Hash] Defined scopes per resource.
       def scopes
@@ -285,14 +279,23 @@ module Recurly
 
       # Iterates through every record by automatically paging.
       #
+      # @option options [Hash] Optional hash to pass to Pager#paginate
+      #
       # @return [nil]
-      # @param [Integer] per_page The number of records returned per request.
       # @yield [record]
-      # @see Pager#find_each
+      # @see Pager#paginate
       # @example
       #   Recurly::Account.find_each { |a| p a }
-      def find_each(per_page = 50, &block)
-        paginate(:per_page => per_page).find_each(&block)
+      # @example With sorting and filter
+      #   opts = {
+      #     begin_time: DateTime.new(2016,1,1),
+      #     sort: :updated_at
+      #   }
+      #   Recurly::Account.find_each(opts) do |a|
+      #     puts a.inspect
+      #   end
+      def find_each(options = {}, &block)
+        paginate(options).find_each(&block)
       end
 
       # @return [Integer] The total record count of the resource in question.
@@ -596,7 +599,7 @@ module Recurly
         protected :initialize
         private_class_method(*%w(create create!))
         unless root_index
-          private_class_method(*%w(all find_each first paginate scoped where))
+          private_class_method(*%w(find_each first paginate))
         end
       end
     end

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -71,7 +71,7 @@ describe Account do
           'shipping_addresses/index-200'
         )
 
-        shads = account.shipping_addresses.all
+        shads = account.shipping_addresses.to_a
         shads.length.must_equal 1
         shads.first.must_be_instance_of Recurly::ShippingAddress
       end

--- a/spec/recurly/gift_card_spec.rb
+++ b/spec/recurly/gift_card_spec.rb
@@ -8,10 +8,10 @@ describe GiftCard do
 
   let(:gift_cards) {
     stub_api_request :get, 'gift_cards', 'gift_cards/index-200'
-    Recurly::GiftCard.all
+    Recurly::GiftCard.paginate
   }
 
-  describe "#all" do
+  describe "#paginate" do
     it "should return list of cards" do
       gift_cards.length.must_equal 2
     end

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -105,18 +105,18 @@ XML
 
     describe ".find_each" do
       it "must accept a block" do
-        stub_api_request(:get, 'resources?per_page=50') { XML[200][:index] }
+        stub_api_request(:get, 'resources?per_page=2') { XML[200][:index] }
         stub_api_request(:get, 'resources?cursor=1234567890&per_page=2') { XML[200][:index] }
         results = []
-        resource.find_each { |r| r.must_be_instance_of resource ; results << r }
+        resource.find_each(per_page: 2) { |r| r.must_be_instance_of resource ; results << r }
         results.wont_be_empty
       end
 
       it "must allow chaining of iterator methods without passing a block" do
         stub_api_request(:get, 'resources?cursor=1234567890&per_page=2') { XML[200][:index] }
-        stub_api_request(:get, 'resources?per_page=50') { XML[200][:index] }
+        stub_api_request(:get, 'resources?per_page=2') { XML[200][:index] }
         results = []
-        resource.find_each.to_a.map.each { |r| r.must_be_instance_of resource ; results << r }
+        resource.find_each(per_page: 2).to_a.map.each { |r| r.must_be_instance_of resource ; results << r }
         results.wont_be_empty
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,13 +49,19 @@ end
 
 XML = {
   200 => {
+    :head   => [
+      <<EOR,
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+X-Records: 3
+EOR
+    ],
     :index   => [
       <<EOR,
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
 Link: \
 <https://api.recurly.com/v2/resources?per_page=2&cursor=1234567890>; rel="next"
-X-Records: 3
 
 <resources>
 <resource>
@@ -71,7 +77,6 @@ HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
 Link: \
 <https://api.recurly.com/v2/resources?per_page=2>; rel="start"
-X-Records: 3
 
 <resources>
 <resource>


### PR DESCRIPTION
It was pointed out that the `Pager#find_each` method still only accepts an int option (per_page) when it should accept a Hash (for filtering and sorting). It was also pointed out that there isn't a consistent way or recommendation for how to do pagination. I decided I could take this opportunity to remove some of the API around pagination and only leave behind the recommended ways of pagination. 

This PR does a number of things:

1. Changes the signature of `Pager#find_each` to accept an options hash
rather than just the per_page param.
2. Removes aliased methods for pagination `all`, `where`, `scoped`.
3. Updates the yarddoc.

## Pagination Examples

```ruby
# given some filtering and sorting params (optional)
opts = {
  begin_time: DateTime.new(2016,1,1),
  end_time: DateTime.new(2017,1,1),
  state: :collected,
  sort: :created_at,
  per_page: 25
}

# To iterate through resources without worrying about paging, use `find_each`
# and the library will paginate for you under the hood
Recurly::Invoice.find_each(opts) do |invoice|
  puts invoice.invoice_number
end

# Or call find_each on any pager you get from a relationship
account.invoices.find_each(opts) do |invoice|
  puts invoice.invoice_number
end

# To manually iterate through pages, use `paginate` to create the Pager
# and `each` to iterate through each resource in the page
invoices = Recurly::Invoice.paginate(opts)
begin
  invoices.each do |invoice|
     puts invoice.invoice_number
  end
  puts "fetching next page..."
end while invoices.next
```
