### PR TITLE
Fix Subscription constructor API breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 ## Unreleased
 
 <a name="v2.10.1"></a>
-## v2.10.1 (2017-05-19)
+## v2.10.2 (2017-09-27)
 
-This release will upgrade us to API version 2.7. There are no breaking changes.
+- Fix Subscription constructor API breakage [PR](https://github.com/recurly/recurly-client-ruby/pull/339)
+
+<a name="v2.10.1"></a>
+## v2.10.1 (2017-07-03)
+
+**NOTE**: This release contains an accidental breaking change on `Subscription.new`.
+See [#338](https://github.com/recurly/recurly-client-ruby/issues/338) for more details.
+Upgrade to 2.10.2 for the fix.
+
+This release will upgrade us to API version 2.7.
 
 - Added `updated_account_notification` notification event [PR](https://github.com/recurly/recurly-client-ruby/pull/326)
 - Removed Plan#trial_requires_billing_info coercion [PR](https://github.com/recurly/recurly-client-ruby/pull/329)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.10.1'
+gem 'recurly', '~> 2.10.2'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -129,6 +129,16 @@ module Recurly
       end
     end
 
+    # TODO
+    # This is a temporary solution which allows us to
+    # embed these resources in a purchase without changing their
+    # interface. It will be removed once we get rid of default_currency.
+    def to_xml(options = {})
+      subscriptions.each {|s| s.currency = nil}
+      adjustments.each   {|a| a.currency = nil}
+      super(options)
+    end
+
     # This object does not represent a model on the server side
     # so we do not need to expose these methods.
     protected(*%w(save save!))

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -92,7 +92,7 @@ module Recurly
 
     # @return [Subscription] A new subscription.
     def initialize(attributes = {})
-      super(attributes)
+      super({ :currency => Recurly.default_currency }.merge attributes)
     end
 
     # Assign a Plan resource (rather than a plan code).

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 10
-    PATCH   = 1
+    PATCH   = 2
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -125,7 +125,7 @@ describe Subscription do
     end
 
     it "must serialize" do
-      subscription = Subscription.new(currency: 'USD')
+      subscription = Subscription.new
       subscription.add_ons << :trial
       subscription.to_xml.must_equal get_raw_xml("subscriptions/serialize-add-ons.xml")
     end


### PR DESCRIPTION
Fixes #338

This also contains the commit to bump us to `2.10.2`.