### PR TITLE
Try to fix the jruby specs

### DIFF
--- a/spec/recurly/purchase_spec.rb
+++ b/spec/recurly/purchase_spec.rb
@@ -29,7 +29,7 @@ describe Purchase do
     end
     it "should raise a Transaction::Error error when transaction fails" do
       stub_api_request(:post, 'purchases', 'purchases/invoice-declined-422')
-      proc {Purchase.invoice!(purchase)}.must_raise Transaction::Error
+      proc {Purchase.invoice!(purchase)}.must_raise Transaction::DeclinedError
     end
   end
 


### PR DESCRIPTION
Seeing lots of failures like:
```
  1) Failure:
Recurly::Purchase::Purchase.invoice!#test_0003_should raise a Transaction::Error error when transaction fails [/home/travis/build/recurly/recurly-client-ruby/spec/recurly/purchase_spec.rb:32]:
[Recurly::Transaction::Error] exception expected, not
Class: <Recurly::Transaction::DeclinedError>
Message: <"Your transaction was declined. Please use a different card or contact your bank.">
---Backtrace---
/home/travis/build/recurly/recurly-client-ruby/lib/recurly/transaction/errors.rb:99:in `validate!'
/home/travis/build/recurly/recurly-client-ruby/lib/recurly/purchase.rb:130:in `post'
/home/travis/build/recurly/recurly-client-ruby/lib/recurly/purchase.rb:112:in `invoice!'
/home/travis/build/recurly/recurly-client-ruby/spec/recurly/purchase_spec.rb:32:in `block in test_0003_should raise a Transaction::Error error when transaction fails'
---------------
```
Seeing if going with the more specific subclass fixes it.