### PR TITLE
API Version 2.9

### DIFF
--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -17,7 +17,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.8'
+    RECURLY_API_VERSION = '2.9'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -30,6 +30,7 @@ module Recurly
       currency
       geo_code
       updated_at
+      external_hpp_type
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES
 
     # @return ["credit_card", "paypal", "amazon", "bank_account", "roku", nil] The type of billing info.

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -18,9 +18,6 @@ module Recurly
     # @return [Account]
     belongs_to :account
 
-    # @return [Subscription]
-    belongs_to :subscription
-
     # @return [Pager<Subscription>, []]
     has_many :subscriptions
 

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -102,12 +102,12 @@ module Recurly
 
     class << self
 
-      # Generate an invoice for the purchase and run any needed transactions
+      # Generate an invoice for the purchase and run any needed transactions.
       #
-      # @param purchase [Purchase] The purchase data for the request
-      # @return [Invoice] The new invoice representing this purchase
-      # @raise [Invalid] Raised if the account cannot be invoiced.
-      # @raise [Transaction::Error] Raised if the transaction failed
+      # @param purchase [Purchase] The purchase data for the request.
+      # @return [Invoice] The saved invoice representing this purchase.
+      # @raise [Invalid] Raised if the purchase cannot be invoiced.
+      # @raise [Transaction::Error] Raised if the transaction failed.
       def invoice!(purchase)
         post(purchase, collection_path)
       end
@@ -115,9 +115,9 @@ module Recurly
       # Generate a preview invoice for the purchase. Runs validations
       # but does not run any transactions.
       #
-      # @param purchase [Purchase] The purchase data for the request
-      # @return [Invoice] The new invoice representing this purchase
-      # @raise [Invalid] Raised if the account cannot be invoiced.
+      # @param purchase [Purchase] The purchase data for the request.
+      # @return [Invoice] The preview invoice representing this purchase.
+      # @raise [Invalid] Raised if the purchase cannot be invoiced.
       def preview!(purchase)
         post(purchase, "#{collection_path}/preview")
       end

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -122,6 +122,19 @@ module Recurly
         post(purchase, "#{collection_path}/preview")
       end
 
+      # Generate an authorized invoice for the purchase. Runs validations
+      # but does not run any transactions. This endpoint will create a
+      # pending purchase that can be activated at a later time once payment
+      # has been completed on an external source (e.g. Adyen's Hosted
+      # Payment Pages).
+      #
+      # @param purchase [Purchase] The purchase data for the request.
+      # @return [Invoice] The authorized invoice representing this purchase.
+      # @raise [Invalid] Raised if the purchase cannot be invoiced.
+      def authorize!(purchase)
+        post(purchase, "#{collection_path}/authorize")
+      end
+
       def post(purchase, path)
         response = API.send(:post, path, purchase.to_xml)
         Invoice.from_response(response)

--- a/lib/recurly/transaction.rb
+++ b/lib/recurly/transaction.rb
@@ -16,8 +16,6 @@ module Recurly
     belongs_to :account
     # @return [Invoice, nil]
     belongs_to :invoice
-    # @return [Subscription, nil]
-    belongs_to :subscription
 
     # @return [Pager<Subscription>, nil]
     has_many :subscriptions

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -7,7 +7,6 @@ describe Invoice do
       stub_api_request :get, 'subscriptions/abcdef1234567890', 'subscriptions/show-200'
 
       invoice = Invoice.find 'created-invoice'
-      invoice.subscription.must_be_instance_of Subscription
       invoice.subscriptions.must_be_instance_of Recurly::Resource::Pager
     end
 
@@ -15,7 +14,6 @@ describe Invoice do
       stub_api_request :get, 'invoices/created-invoice', 'invoices/show-200-nosub'
 
       invoice = Invoice.find 'created-invoice'
-      invoice.subscription.must_equal nil
       invoice.subscriptions.must_equal []
     end
   end

--- a/spec/recurly/purchase_spec.rb
+++ b/spec/recurly/purchase_spec.rb
@@ -47,4 +47,19 @@ describe Purchase do
       purchase.adjustments.first.errors["unit_amount_in_cents"].must_equal ["is not a number"]
     end
   end
+
+  describe "Purchase.authorize!" do
+    it "should return an authorized invoice when valid" do
+      stub_api_request(:post, 'purchases/authorize', 'purchases/preview-201')
+      authorized_invoice = Purchase.authorize!(purchase)
+      authorized_invoice.must_be_instance_of Invoice
+    end
+    it "should raise an Invalid error when data is invalid" do
+      stub_api_request(:post, 'purchases/authorize', 'purchases/invoice-422')
+      # ensure error is raised
+      proc {Purchase.authorize!(purchase)}.must_raise Resource::Invalid
+      # ensure error details are mapped back
+      purchase.adjustments.first.errors["unit_amount_in_cents"].must_equal ["is not a number"]
+    end
+  end
 end


### PR DESCRIPTION
This PR implements the changes in API version 2.9.

1. We added the authorize endpoint for purchases. This is currently only used with Adyen. Example:

```ruby
require 'securerandom'
plan = Recurly::Plan.first
p = Recurly::Purchase.new({
  currency: 'USD',
  collection_method: :automatic,
  customer_notes: 'Some notes for the customer.',
  terms_and_conditions: 'Our company terms and conditions.',
  vat_reverse_charge_notes: 'Vat reverse charge notes',
  account: {
    email: 'benjamin.dumonde@example.com', # email required
    first_name: 'Benjamin',
    last_name: 'Du Monde',
    account_code: SecureRandom.uuid,
    billing_info: {
      external_hpp_type: :adyen, # billing info should use adyen external hpp
      first_name: 'Benjamin',
      last_name: 'Du Monde',
      address1: '400 Alabama St',
      city: 'San Francisco',
      state: 'CA',
      zip: '94110',
      country: 'US',
      number: '4111-1111-1111-1111',
      month: 12,
      year: 2019,
    }
  },
  subscriptions: [
    {
      plan_code: plan.plan_code,
    }
  ],
  coupon_codes: [
    "m18xnYyCv0",
    "ouxJSaAxUz",
  ],
  gift_card: {
    redemption_code: "L6MI4B95UQ0Z78X1"
  },
  adjustments: [
    {product_code: SecureRandom.uuid, unit_amount_in_cents: 10_000, quantity: 1, revenue_schedule_type: :at_invoice},
  ]
})

begin
  invoice = Recurly::Purchase.authorize!(p)
  puts invoice
rescue Recurly::Resource::Invalid => e
  puts e.inspect
  # Invalid data
end
```

2. We have removed the singular `subscription` links on `Transaction` and `Invoice`. You must now use the `subscriptions` link.

3. Although it required no code change, all `Subscription` list endpoints now accept a boolean parameter `started_with_gift`:

```ruby
Recurly::Subscription.paginate(started_with_gift: true).find_each do |sub|
  puts sub.uuid
end
```