### PR TITLE
Bump 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.12.0"></a>
+## v2.12.0 (2017-11-20)
+
+- Added purchase authorize endpoint and other API version 2.9 changes. [PR](https://github.com/recurly/recurly-client-ruby/pull/347)
+
+### Upgrade Notes
+
+This version bumps us to API version 2.9. There are a few breaking changes.
+
+1. The 'subscription' link on an instance of `Adjustment` is now only created if adjustment is
+originating from a subscription plan charge, setup fee, add on, trial or proration credit.
+It is no longer created for other adjustments.
+2. Instances of `Transaction` and `Invoice` no longer have a `subscription` link and you must now
+use the `subscriptions` link.
+
 <a name="v2.11.3"></a>
 ## v2.11.3 (2017-11-10)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.11.3'
+gem 'recurly', '~> 2.12.0'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,8 +1,8 @@
 module Recurly
   module Version
     MAJOR   = 2
-    MINOR   = 11
-    PATCH   = 3
+    MINOR   = 12
+    PATCH   = 0
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
- Added purchase authorize endpoint and other API version 2.9 changes. [PR](https://github.com/recurly/recurly-client-ruby/pull/347)

### Upgrade Notes

This version bumps us to API version 2.9. There are a few breaking changes.

1. The 'subscription' link on an instance of `Adjustment` is now only created if adjustment is
originating from a subscription plan charge, setup fee, add on, trial or proration credit.
It is no longer created for other adjustments.
2. Instances of `Transaction` and `Invoice` no longer have a `subscription` link and you must now
use the `subscriptions` link.
