### PR TITLE
Verify CVV Endpoint

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -106,6 +106,39 @@ module Recurly
       true
     end
 
+    # Verify a cvv code for the account's billing info.
+    #
+    # @example
+    #   acct = Recurly::Account.find('benjamin-du-monde')
+    #   begin
+    #     # If successful, returned billing_info will contain
+    #     # updated billing info details.
+    #     billing_info = acct.verify_cvv!("504")
+    #   rescue Recurly::API::BadRequest => e
+    #     e.message # => "This credit card has too many cvv check attempts."
+    #   rescue Recurly::Transaction::Error => e
+    #     # this will be the errors coming back from gateway
+    #     e.transaction_error_code # => "fraud_security_code"
+    #     e.gateway_error_code # => "fraud"
+    #   rescue Recurly::Resource::Invalid => e
+    #     e.message # => "verification_value must be three digits"
+    #   end
+    #
+    # @param [String] verification_value The CVV code to check
+    # @return [BillingInfo] The updated billing info
+    # @raise [Recurly::Transaction::Error] A Transaction Error will be raised if the gateway declines
+    # the cvv code.
+    # @raise [API::BadRequest] A BadRequest error will be raised if you attempt to check too many times
+    # and are locked out.
+    # @raise [Resource::Invalid] An Invalid Error will be raised if you send an invalid request (such as
+    # a value that is not a propert verification number).
+    def verify_cvv!(verification_value)
+      bi = BillingInfo.new(verification_value: verification_value)
+      bi.uri = "#{path}/billing_info/verify_cvv"
+      bi.save!
+      bi
+    end
+
     def changed_attributes
       attrs = super
       if address.respond_to?(:changed?) && address.changed?

--- a/spec/fixtures/billing_info/verify-cvv-200.xml
+++ b/spec/fixtures/billing_info/verify-cvv-200.xml
@@ -1,0 +1,26 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info" type="credit_card">
+  <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <first_name>Good</first_name>
+  <last_name>CVV</last_name>
+  <company nil="nil"></company>
+  <address1>123 Pretty Pretty Good St.</address1>
+  <address2 nil="nil"></address2>
+  <city>Los Angeles</city>
+  <state>CA</state>
+  <zip>90210</zip>
+  <country>US</country>
+  <phone nil="nil"></phone>
+  <vat_number>2000</vat_number>
+  <ip_address>127.0.0.1</ip_address>
+  <ip_address_country nil="nil"></ip_address_country>
+  <card_type>Visa</card_type>
+  <year type="integer">2015</year>
+  <month type="integer">1</month>
+  <first_six>411111</first_six>
+  <last_four>1111</last_four>
+  <updated_at type="datetime">2017-02-17T15:38:53Z</updated_at>
+</billing_info>

--- a/spec/fixtures/billing_info/verify-cvv-locked-400.xml
+++ b/spec/fixtures/billing_info/verify-cvv-locked-400.xml
@@ -1,0 +1,8 @@
+HTTP/1.1 400 Bad Request
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+  <symbol>cvv_verify_locked</symbol>
+  <description>This credit card has too many cvv check attempts.</description>
+</error>

--- a/spec/fixtures/billing_info/verify-cvv-transaction-err-422.xml
+++ b/spec/fixtures/billing_info/verify-cvv-transaction-err-422.xml
@@ -1,0 +1,13 @@
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+  <transaction_error>
+    <error_code>fraud_security_code</error_code>
+    <error_category>fraud</error_category>
+    <merchant_message>The payment gateway declined the transaction because the security code (CVV) or expiration date did not match.</merchant_message>
+    <customer_message>The security code you entered does not match. Please update the CVV and try again.</customer_message>
+  </transaction_error>
+  <error field="billing_info.billing_info.credit_card_verification_value" symbol="declined_bad">did not match</error>
+</errors>


### PR DESCRIPTION
Implements the `POST /accounts/{account_code}/billing_info/verify_cvv` endpoint for API 2.10:

### Usage

```ruby
acct = Recurly::Account.find("benjamin-du-monde")
begin
  # If successful, returned billing_info will contain
  # updated billing info details.
  billing_info = acct.verify_cvv!("504")
rescue Recurly::API::BadRequest => e
  e.message # => "This credit card has too many cvv check attempts."
rescue Recurly::Transaction::Error => e
  # this will be the errors coming back from gateway
  e.transaction_error_code # => "fraud_security_code"
  e.gateway_error_code # => "fraud"
rescue Recurly::Resource::Invalid => e
  e.message # => "verification_value must be three digits"
end
```