### PR TITLE
Adds proration_rate float to Adjustment

### DIFF
--- a/lib/recurly/adjustment.rb
+++ b/lib/recurly/adjustment.rb
@@ -44,6 +44,7 @@ module Recurly
       tax_code
       tax_details
       tax_types
+      proration_rate
     )
     alias to_param uuid
 

--- a/spec/fixtures/adjustments/show-200.xml
+++ b/spec/fixtures/adjustments/show-200.xml
@@ -36,6 +36,7 @@ Content-Type: application/xml; charset=utf-8
       <tax_in_cents type="integer">2000</tax_in_cents>
     </tax_detail>
   </tax_details>
+  <proration_rate type="float">0.5</proration_rate>
   <start_date type="datetime">2011-04-30T07:00:00Z</start_date>
   <end_date type="datetime">2011-04-30T07:00:00Z</end_date>
   <created_at type="datetime">2011-08-31T03:30:00Z</created_at>

--- a/spec/recurly/adjustment_spec.rb
+++ b/spec/recurly/adjustment_spec.rb
@@ -23,6 +23,7 @@ describe Adjustment do
       adjustment.tax_region.must_equal 'CA'
       adjustment.tax_rate.must_equal 0.0875
       adjustment.revenue_schedule_type.must_equal 'evenly'
+      adjustment.proration_rate.must_equal 0.5
 
       tax_details = adjustment.tax_details
       tax_details.length.must_equal 2


### PR DESCRIPTION
This is a small addition that had to be made to API 2.9. This will be released on Thursday so it is blocked. I will do a bump and release on Thursday night or Friday morning. It will become part of `2.12.1`.