### PR TITLE
Updates to credit memos feature

### DIFF
--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -115,13 +115,16 @@ module Recurly
     end
 
     # Marks an invoice as failing collection.
+    # Returns a new {InvoiceCollection} and does not
+    # reload this invoice.
     #
-    # @return [true, false] +true+ when successful, +false+ when unable to
+    # @return [InvoiceCollection, false] InvoiceCollection when successful, +false+ when unable to
     #   (e.g., the invoice is no longer open).
     def mark_failed
       return false unless link? :mark_failed
-      reload follow_link :mark_failed
-      true
+      InvoiceCollection.from_response follow_link(:mark_failed)
+    rescue Recurly::API::UnprocessableEntity => e
+      raise Invalid, e.message
     end
 
     # Initiate a collection attempt on an invoice.

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -35,6 +35,9 @@ module Recurly
     # @return [ShippingAddress, nil]
     has_one :shipping_address, class_name: :ShippingAddress, readonly: false
 
+    # @return [InvoiceCollection, nil]
+    has_one :invoice_collection, class_name: :InvoiceCollection, readonly: true
+
     define_attribute_methods %w(
       uuid
       state

--- a/spec/fixtures/subscriptions/preview-200-change.xml
+++ b/spec/fixtures/subscriptions/preview-200-change.xml
@@ -25,45 +25,47 @@ Content-Type: application/xml; charset=utf-8
   <cost_in_cents type="integer">5000</cost_in_cents>
   <subscription_add_ons type="array">
   </subscription_add_ons>
-  <invoice href="">
-    <account href="https://api.recurly.com/v2/accounts/account_code"/>
-    <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
-    <uuid>abcdefg123</uuid>
-    <state>open</state>
-    <invoice_number nil="nil"></invoice_number>
-    <invoice_number_prefix></invoice_number_prefix>
-    <po_number nil="nil"></po_number>
-    <vat_number></vat_number>
-    <subtotal_in_cents type="integer">5000</subtotal_in_cents>
-    <tax_in_cents type="integer">0</tax_in_cents>
-    <total_in_cents type="integer">5000</total_in_cents>
-    <currency>USD</currency>
-    <created_at nil="nil"></created_at>
-    <closed_at nil="nil"></closed_at>
-    <line_items type="array">
-      <adjustment href="https://api.recurly.com/v2/adjustments/abcdefg111" type="charge">
-        <account href="https://api.recurly.com/v2/accounts/account_code"/>
-        <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
-        <uuid>abcdefg111</uuid>
-        <state>pending</state>
-        <description>plan_code</description>
-        <accounting_code></accounting_code>
-        <product_code>plan_code</product_code>
-        <origin>plan</origin>
-        <unit_amount_in_cents type="integer">5000</unit_amount_in_cents>
-        <quantity type="integer">5</quantity>
-        <discount_in_cents type="integer">0</discount_in_cents>
-        <tax_in_cents type="integer">0</tax_in_cents>
-        <total_in_cents type="integer">5000</total_in_cents>
-        <currency>USD</currency>
-        <taxable type="boolean">false</taxable>
-        <tax_exempt type="boolean">false</tax_exempt>
-        <start_date type="datetime">2014-05-20T18:14:08Z</start_date>
-        <end_date type="datetime">2014-06-20T16:29:59Z</end_date>
-        <created_at nil="nil"></created_at>
-      </adjustment>
-    </line_items>
-    <transactions type="array">
-    </transactions>
-  </invoice>
+  <invoice_collection>
+    <charge_invoice>
+      <account href="https://api.recurly.com/v2/accounts/account_code"/>
+      <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
+      <uuid>abcdefg123</uuid>
+      <state>open</state>
+      <invoice_number nil="nil"></invoice_number>
+      <invoice_number_prefix></invoice_number_prefix>
+      <po_number nil="nil"></po_number>
+      <vat_number></vat_number>
+      <subtotal_in_cents type="integer">5000</subtotal_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">5000</total_in_cents>
+      <currency>USD</currency>
+      <created_at nil="nil"></created_at>
+      <closed_at nil="nil"></closed_at>
+      <line_items type="array">
+        <adjustment href="https://api.recurly.com/v2/adjustments/abcdefg111" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/account_code"/>
+          <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
+          <uuid>abcdefg111</uuid>
+          <state>pending</state>
+          <description>plan_code</description>
+          <accounting_code></accounting_code>
+          <product_code>plan_code</product_code>
+          <origin>plan</origin>
+          <unit_amount_in_cents type="integer">5000</unit_amount_in_cents>
+          <quantity type="integer">5</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">5000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <tax_exempt type="boolean">false</tax_exempt>
+          <start_date type="datetime">2014-05-20T18:14:08Z</start_date>
+          <end_date type="datetime">2014-06-20T16:29:59Z</end_date>
+          <created_at nil="nil"></created_at>
+        </adjustment>
+      </line_items>
+      <transactions type="array">
+      </transactions>
+    </charge_invoice>
+  </invoice_collection>
 </subscription>

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -288,7 +288,8 @@ describe Subscription do
       subscription.preview
 
       subscription.cost_in_cents.must_equal subscription.unit_amount_in_cents * 5
-      subscription.invoice.must_be_instance_of Invoice
+      subscription.invoice_collection.must_be_instance_of InvoiceCollection
+      subscription.invoice_collection.charge_invoice.must_be_instance_of Invoice
     end
   end
 


### PR DESCRIPTION
This contains 2 breaking changes:

#### 1. `Invoice#mark_failed` now returns `InvoiceCollection`

`mark_failed` no longer reloads the invoice with the response returning true or false, it returns either an `InvoiceCollection` if failable and request is successful, it returns `false` if invoice cannot be marked failed. To keep functionality, take the `charge_invoice` of the returned collection:

```ruby
invoice = Recurly::Invoice.find('1001')

failed_collection = invoice.mark_failed
if failed_collection
  invoice = failed_collection.charge_invoice
end
```

#### 2. Subscription previews and `InvoiceCollection`

Subscription previews and preview changes now return `InvoiceCollection`s rather than `Invoice`. Utilize the `charge_invoice` to keep functionality the same:

```ruby
subscription.preview

# Change
invoice = subscription.invoice
# To
invoice = subscription.invoice_collection.charge_invoice
```
