### PR TITLE
Bump 2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,40 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.15.0"></a>
+## v2.15.0 (2018-02-27)
+
+- Invoice refunds do not return InvoiceCollection [PR](https://github.com/recurly/recurly-client-ruby/pull/363)
+- Support gift card webhook [PR](https://github.com/recurly/recurly-client-ruby/pull/344)
+- Fixes to Resource#find_each [PR](https://github.com/recurly/recurly-client-ruby/pull/355)
+
+### Upgrade Notes
+
+#### 1. `Invoice#refund` and `Invoice#refund_amount` return type
+
+If you are upgrading from 2.13.X or 2.14.X, a design bug was fixed. `Invoice#refund` and `Invoice#refund_amount` once again return an `Invoice` and not
+an `InvoiceCollection`.
+
+#### 2. `Resource#find_each` arguments
+
+`Resource#find_each` previously only accepted `per_page` but now accepts an `options` Hash for pagination params. If you want to preserve functionality:
+
+```ruby
+# Change This
+Recurly::Invoice.find_each(50) do |invoice|
+  puts invoice
+end
+
+# To This
+Recurly::Invoice.find_each(per_page: 50) do |invoice|
+  puts invoice
+end
+```
+
 <a name="v2.14.0"></a>
 ## v2.14.0 (2018-02-20)
+
+*Note*: We recommend upgrading to 2.15.X for a bug fix around Invoice refunds.
 
 - Updates to credit memos feature [PR](https://github.com/recurly/recurly-client-ruby/pull/360)
 
@@ -36,6 +68,8 @@ invoice = subscription.invoice_collection.charge_invoice
 
 <a name="v2.13.0"></a>
 ## v2.13.0 (2018-02-09)
+
+*Note*: We recommend upgrading to 2.15.X for a bug fix around Invoice refunds.
 
 - Add NewUsageNotification class for Recurly webhook [PR](https://github.com/recurly/recurly-client-ruby/pull/354)
 - Verify CVV Endpoint [PR](https://github.com/recurly/recurly-client-ruby/pull/353)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.14.0'
+gem 'recurly', '~> 2.15.0'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,7 +1,7 @@
 module Recurly
   module Version
     MAJOR   = 2
-    MINOR   = 14
+    MINOR   = 15
     PATCH   = 0
     PRE     = nil
 


### PR DESCRIPTION
- Invoice refunds do not return InvoiceCollection [PR](https://github.com/recurly/recurly-client-ruby/pull/363)
- Support gift card webhook [PR](https://github.com/recurly/recurly-client-ruby/pull/344)
- Fixes to Resource#find_each [PR](https://github.com/recurly/recurly-client-ruby/pull/355)

### Upgrade Notes

#### 1. `Invoice#refund` and `Invoice#refund_amount` return type

If you are upgrading from 2.13.X or 2.14.X, a design bug was fixed. `Invoice#refund` and `Invoice#refund_amount` once again return an `Invoice` and not an `InvoiceCollection`.

#### 2. `Resource#find_each` arguments

`Resource#find_each` previously only accepted `per_page` but now accepts an `options` Hash for pagination params. If you want to preserve functionality:

```ruby
# Change This
Recurly::Invoice.find_each(50) do |invoice|
  puts invoice
end

# To This
Recurly::Invoice.find_each(per_page: 50) do |invoice|
  puts invoice
end
```