### PR TITLE
Bump 2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.15.1"></a>
+## v2.15.1 (2018-04-02)
+
+- Fix nokogiri security warnings [PR](https://github.com/recurly/recurly-client-ruby/pull/367)
+- API v2.11 changes [PR](https://github.com/recurly/recurly-client-ruby/pull/366)
+
 <a name="v2.15.0"></a>
 ## v2.15.0 (2018-02-27)
 

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 15
-    PATCH   = 0
+    PATCH   = 1
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
- Fix nokogiri security warnings [PR](https://github.com/recurly/recurly-client-ruby/pull/367)
- API v2.11 changes [PR](https://github.com/recurly/recurly-client-ruby/pull/366)