### PR TITLE
Keep original_invoice link on Invoice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,25 +106,11 @@ These methods, which before returned `Invoice` now return `InvoiceCollection`:
 * `Account#invoice!`
 * `Account#build_invoice`
 
-#### 2. Invoice#original_invoice removed
-
-`Invoice#original_invoice` was removed in favor of `Invoice#original_invoices`. If you want to maintain functionality, change your code grab the first invoice from that endpoint:
-
-```ruby
-# Change this
-invoice = Recurly::Invoice.find('1001')
-original = invoice.original_invoice
-
-# To this
-invoice = Recurly::Invoice.find('1001')
-original = invoice.original_invoices.first
-```
-
-#### 3. Invoice subtotal_* changes
+#### 2. Invoice subtotal_* changes
 
 If you want to preserve functionality, change any use of `Invoice#subtotal_after_discount_in_cents` to  `Invoice#subtotal_in_cents`. If you were previously using `Invoice#subtotal_in_cents`, this has been changed to `Invoice#subtotal_before_discount_in_cents`.
 
-#### 4. Invoice Refund -- `refund_apply_order` changed to `refund_method`
+#### 3. Invoice Refund -- `refund_apply_order` changed to `refund_method`
 
 If you were using `refund_apply_order` on any refunds, then you need to change this to use `refund_method` instead. The keys from this have changed from (`credit`, `transaction`) to (`credit_first`, `transaction_first`)
 

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -44,6 +44,9 @@ module Recurly
     # @return [Pager<Invoice>, []]
     has_many :original_invoices, class_name: :Invoice, readonly: true
 
+    # @return [Invoice, nil]
+    has_one :original_invoice, class_name: :Invoice, readonly: true
+
     # Returns the first redemption in the Invoice's redemptions.
     # This was placed here for backwards compatibility when we went from
     # having a single redemption per invoice to multiple redemptions per invoice.

--- a/spec/fixtures/invoices/show-200.xml
+++ b/spec/fixtures/invoices/show-200.xml
@@ -8,6 +8,7 @@ Content-Type: application/xml; charset=utf-8
   <subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890"/>
   <subscriptions href="https://api.recurly.com/v2/invoices/1001/subscriptions"/>
   <original_invoices href="https://api.recurly.com/v2/invoices/created-invoice/original_invoices" />
+  <original_invoice href="https://api.recurly.com/v2/invoices/1001" />
   <credit_invoices href="https://api.recurly.com/v2/invoices/created-invoice/credit_invoices" />
   <uuid>created-invoice</uuid>
   <state>open</state>

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -21,11 +21,13 @@ describe Invoice do
   describe 'attributes' do
     it 'should have proper links' do
       stub_api_request :get, 'invoices/1000', 'invoices/show-200'
+      stub_api_request :get, 'invoices/1001', 'invoices/show-200'
 
       invoice = Invoice.find('1000')
       invoice.redemptions.must_be_instance_of Resource::Pager
       invoice.subscriptions.must_be_instance_of Resource::Pager
       invoice.original_invoices.must_be_instance_of Resource::Pager
+      invoice.original_invoice.must_be_instance_of Invoice
       invoice.credit_payments.must_be_instance_of Array
       invoice.credit_payments.first.must_be_instance_of CreditPayment
     end


### PR DESCRIPTION
Keep the `original_invoice` link on the `Invoice` object.