### PR TITLE
Bump 2.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.15.2"></a>
+## v2.15.2 (2018-04-18)
+
+- Keep original_invoice link on Invoice [PR](https://github.com/recurly/recurly-client-ruby/pull/372)
+- Coupon#redeem! should raise Invalid on failure [PR](https://github.com/recurly/recurly-client-ruby/pull/371)
+
 <a name="v2.15.1"></a>
 ## v2.15.1 (2018-04-02)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.15.0'
+gem 'recurly', '~> 2.15.2'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 15
-    PATCH   = 1
+    PATCH   = 2
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
- Keep original_invoice link on Invoice #372
- Coupon#redeem! should raise Invalid on failure #371  