### PR TITLE
API Version 2.12

### DIFF
--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -17,7 +17,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.11'
+    RECURLY_API_VERSION = '2.12'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/gift_card.rb
+++ b/lib/recurly/gift_card.rb
@@ -12,6 +12,12 @@ module Recurly
     # @return [Delivery, nil] Delivery information of the recipient.
     has_one :delivery, class_name: :Delivery, readonly: false
 
+    # @return [Invoice, nil] The credit invoice for the gift card redemption.
+    has_one :redemption_invoice, class_name: :Invoice, readonly: true
+
+    # @return [Invoice, nil] The charge invoice for the gift card redemption.
+    has_one :purchase_invoice, class_name: :Invoice, readonly: true
+
     define_attribute_methods %w(
       balance_in_cents
       currency

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -160,6 +160,16 @@ module Recurly
         post(purchase, "#{collection_path}/authorize")
       end
 
+      # Use for Adyen HPP transaction requests. Runs validations
+      # but does not run any transactions.
+      #
+      # @param purchase [Purchase] The purchase data for the request.
+      # @return [InvoiceCollection] The authorized invoice collection representing this purchase.
+      # @raise [Invalid] Raised if the purchase cannot be invoiced.
+      def pending!(purchase)
+        post(purchase, "#{collection_path}/pending")
+      end
+
       def post(purchase, path)
         response = API.send(:post, path, purchase.to_xml)
         InvoiceCollection.from_response(response)

--- a/spec/fixtures/gift_cards/show-200.xml
+++ b/spec/fixtures/gift_cards/show-200.xml
@@ -2,10 +2,12 @@ HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
-<gift_card href="https://api.recurly.com.com/v2/gift_cards/2004005808969875135">
-  <gifter_account href="https://api.recurly.com.com/v2/accounts/b6e2372d-f857-4d6f-be11-05a3a1f83940"/>
-  <invoice href="https://api.recurly.com.com/v2/invoices/1017"/>
-  <recipient_account href="https://api.recurly.com.com/v2/accounts/b6e2372d-f857-4d6f-be11-05a3a1f83940"/>
+<gift_card href="https://api.recurly.com/v2/gift_cards/2004005808969875135">
+  <gifter_account href="https://api.recurly.com/v2/accounts/b6e2372d-f857-4d6f-be11-05a3a1f83940"/>
+  <invoice href="https://api.recurly.com/v2/invoices/1017"/>
+  <redemption_invoice href="https://api.recurly.com/v2/invoices/1017"/>
+  <purchase_invoice href="https://api.recurly.com/v2/invoices/1017"/>
+  <recipient_account href="https://api.recurly.com/v2/accounts/b6e2372d-f857-4d6f-be11-05a3a1f83940"/>
   <id type="integer">2004005808969875135</id>
   <redemption_code>8ED8CE30641A92E4</redemption_code>
   <balance_in_cents type="integer">1000</balance_in_cents>

--- a/spec/recurly/gift_card_spec.rb
+++ b/spec/recurly/gift_card_spec.rb
@@ -45,6 +45,11 @@ describe GiftCard do
       gift_card.unit_amount_in_cents.must_equal 2_000
       gift_card.updated_at.must_equal DateTime.parse("2016-07-28T00:01:46Z")
 
+      stub_api_request :get, 'invoices/1017', 'invoices/show-200'
+      gift_card.redemption_invoice.must_be_instance_of Invoice
+      stub_api_request :get, 'invoices/1017', 'invoices/show-200'
+      gift_card.purchase_invoice.must_be_instance_of Invoice
+
       delivery = gift_card.delivery
 
       delivery.must_be_instance_of Recurly::Delivery

--- a/spec/recurly/purchase_spec.rb
+++ b/spec/recurly/purchase_spec.rb
@@ -65,4 +65,20 @@ describe Purchase do
       purchase.adjustments.first.errors["unit_amount_in_cents"].must_equal ["is not a number"]
     end
   end
+
+  describe "Purchase.pending!" do
+    it "should return an authorized invoice when valid" do
+      stub_api_request(:post, 'purchases/pending', 'purchases/preview-201')
+      authorized_collection = Purchase.pending!(purchase)
+      authorized_invoice = authorized_collection.charge_invoice
+      authorized_invoice.must_be_instance_of Invoice
+    end
+    it "should raise an Invalid error when data is invalid" do
+      stub_api_request(:post, 'purchases/pending', 'purchases/invoice-422')
+      # ensure error is raised
+      proc {Purchase.pending!(purchase)}.must_raise Resource::Invalid
+      # ensure error details are mapped back
+      purchase.adjustments.first.errors["unit_amount_in_cents"].must_equal ["is not a number"]
+    end
+  end
 end


### PR DESCRIPTION
This bumps us to API version 2.12 and adds the new features.

* Support for `Purchase.pending!` endpoint
* Support for `redemption_invoice` and `purchase_invoice` on `GiftCard`