### PR TITLE
Bump 2.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.15.4"></a>
+## v2.15.4 (2018-05-15)
+
+- API version 2.12 [PR](https://github.com/recurly/recurly-client-ruby/pull/378)
+- New Credit Invoice Webhooks [PR](https://github.com/recurly/recurly-client-ruby/pull/380)
+
 <a name="v2.15.2"></a>
 ## v2.15.2 (2018-04-18)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.15.2'
+gem 'recurly', '~> 2.15.4'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 15
-    PATCH   = 2
+    PATCH   = 4
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
This brings us to API version 2.12. It has no breaking changes that need to be addressed.

- API version 2.12 [PR](https://github.com/recurly/recurly-client-ruby/pull/378)
- New Credit Invoice Webhooks [PR](https://github.com/recurly/recurly-client-ruby/pull/380)
