### PR TITLE
Dont set the logger in railtie

### DIFF
--- a/lib/rails/recurly.rb
+++ b/lib/rails/recurly.rb
@@ -1,9 +1,5 @@
 module Recurly
   class Railtie < Rails::Railtie
-    initializer :recurly_set_logger do
-      Recurly.logger = Rails.logger
-    end
-
     initializer :recurly_set_accept_language do
       prepend_method = :prepend_before_filter
       if ActionController::Base.respond_to?(:prepend_before_action)


### PR DESCRIPTION
Follow up from conversation in #381 

This prevents the railtie from setting the logger. We want users to explicitly opt-in to logging for security reasons.