### PR TITLE
Add all_transactions link to Invoice

### DIFF
--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -29,6 +29,10 @@ module Recurly
     # @return [Pager<Adjustment>, []]
     has_many :all_line_items, class_name: :Adjustment
 
+    # This will only be present if the invoice has > 500 transactions
+    # @return [Pager<Transaction>, []]
+    has_many :all_transactions, class_name: :Transaction
+
     # @return [Pager<Redemption>, []]
     has_many :redemptions
 

--- a/spec/fixtures/invoices/show-200.xml
+++ b/spec/fixtures/invoices/show-200.xml
@@ -10,6 +10,7 @@ Content-Type: application/xml; charset=utf-8
   <original_invoices href="https://api.recurly.com/v2/invoices/created-invoice/original_invoices" />
   <original_invoice href="https://api.recurly.com/v2/invoices/1001" />
   <credit_invoices href="https://api.recurly.com/v2/invoices/created-invoice/credit_invoices" />
+  <all_transactions href="https://api.recurly.com/v2/invoices/1001/transactions" />
   <uuid>created-invoice</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -135,4 +135,13 @@ describe Invoice do
       end
     end
   end
+
+  describe "#all_transactions" do
+    it "must provide a link to all transactions if present" do
+      stub_api_request :get, 'invoices/1001', 'invoices/show-200'
+      invoice = Invoice.find(1001)
+      invoice.all_transactions.must_be_instance_of Resource::Pager
+      invoice.all_transactions.any?.must_equal true
+    end
+  end
 end


### PR DESCRIPTION
Adds the `all_transactions` link to invoices. This is only present when there are over 500 transactions. You can check for presence with `Pager#any?`

```ruby
if invoice.all_transactions.any?
  # fetch or page through them here
end
```