### PR TITLE
Make currencies method public

### DIFF
--- a/lib/recurly/money.rb
+++ b/lib/recurly/money.rb
@@ -99,8 +99,6 @@ module Recurly
     end
     alias to_s inspect
 
-    protected
-
     attr_reader :currencies
 
     private

--- a/spec/recurly/money_spec.rb
+++ b/spec/recurly/money_spec.rb
@@ -23,4 +23,11 @@ describe Money do
       proc { Money.new(:USD => 1, :EUR => 2).to_i }.must_raise TypeError
     end
   end
+
+  describe "#eql?" do
+    it 'is true for two instances of Money with the same attributes' do
+      comparison = Money.new(:USD => 1).eql?(Money.new(:USD => 1))
+      comparison.must_equal true
+    end
+  end
 end


### PR DESCRIPTION
Previously the currencies method on Money was protected. However, the
eql? method depends upon the currencies method being public, resulting
in two instances of Money with the same attributes not to be considered
equal to one another.

This commit exposes currencies publicly to fulfill the dependencies in
the eql? method.