### PR TITLE
Allow programmer to set gateway code in purchase

### DIFF
--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -123,6 +123,7 @@ module Recurly
       customer_notes
       vat_reverse_charge_notes
       shipping_address_id
+      gateway_code
     )
 
     class << self


### PR DESCRIPTION
For API version 2.13. Allows programmer to set the gateway for a purchase. If this changes, I will follow up with another PR on the `api_version_2_13` branch.