### PR TITLE
Custom Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,7 +202,7 @@ This release will upgrade us to API version 2.8.
 
 ### Upgrade Notes
 
-There are two breaking changes in this API version you must consider. 
+There are two breaking changes in this API version you must consider.
 
 #### Country Codes
 

--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -6,6 +6,7 @@ module Recurly
   require 'recurly/resource'
   require 'recurly/shipping_address'
   require 'recurly/billing_info'
+  require 'recurly/custom_field'
   require 'recurly/account'
   require 'recurly/account_balance'
   require 'recurly/add_on'

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -42,6 +42,9 @@ module Recurly
     # @return [Pager<CreditPayment>, []]
     has_many :credit_payments, class_name: :CreditPayment, readonly: true
 
+    # @return [[CustomField], []]
+    has_many :custom_fields, class_name: :CustomField, readonly: false
+
     # Get's the first redemption given a coupon code
     # @deprecated Use #{redemptions} instead
     # @param coupon_code [String] The coupon code for the redemption
@@ -148,6 +151,9 @@ module Recurly
       attrs = super
       if address.respond_to?(:changed?) && address.changed?
         attrs['address'] = address
+      end
+      if custom_fields.any?(&:changed?)
+        attrs['custom_fields'] = custom_fields.select(&:changed?)
       end
       attrs
     end

--- a/lib/recurly/custom_field.rb
+++ b/lib/recurly/custom_field.rb
@@ -1,0 +1,15 @@
+module Recurly
+  # Recurly Documentation: https://dev.recurly.com/docs/custom-fields
+  class CustomField < Resource
+
+    define_attribute_methods %w(
+      name
+      value
+    )
+
+    # include the name with the serialized field, even though it can't change
+    def xml_keys
+      attributes.keys
+    end
+  end
+end

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -508,7 +508,7 @@ module Recurly
       # @return [Proc, nil]
       # @param collection_name [Symbol] Association name.
       # @param options [Hash] A hash of association options.
-      # @option options [true, false] :readonly Don't define a setter.
+      # @option options [true, false] :readonly Define a setter when false, defaults to true
       #                 [String] :class_name Actual associated resource class name
       #                                      if not same as collection_name.
       def has_many(collection_name, options = {})
@@ -518,7 +518,7 @@ module Recurly
             if self[collection_name]
               self[collection_name]
             else
-              attributes[collection_name] = []
+              attributes[collection_name.to_s] = []
             end
           end
           if options.key?(:readonly) && options[:readonly] == false

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -20,6 +20,9 @@ module Recurly
     # @return [Pager<Redemption>, []]
     has_many :redemptions
 
+    # @return [[CustomField], []]
+    has_many :custom_fields, class_name: :CustomField, readonly: false
+
     # @return [Account]
     belongs_to :account
 
@@ -280,6 +283,15 @@ module Recurly
     def signable_attributes
       super.merge :plan_code => plan_code
     end
+
+    def changed_attributes
+      attrs = super
+      if custom_fields.any?(&:changed?)
+        attrs['custom_fields'] = custom_fields.select(&:changed?)
+      end
+      attrs
+    end
+
 
     private
 

--- a/spec/fixtures/accounts/show-200.xml
+++ b/spec/fixtures/accounts/show-200.xml
@@ -41,4 +41,10 @@ Content-Type: application/xml; charset=utf-8
   <has_canceled_subscription type="boolean">false</has_canceled_subscription>
   <has_past_due_invoice type="boolean">false</has_past_due_invoice>
   <preferred_locale>fr-FR</preferred_locale>
+  <custom_fields type="array">
+    <custom_field>
+      <name>acct_field</name>
+      <value>acct value</value>
+    </custom_field>
+  </custom_fields>
 </account>

--- a/spec/fixtures/subscriptions/show-200.xml
+++ b/spec/fixtures/subscriptions/show-200.xml
@@ -41,6 +41,12 @@ Content-Type: application/xml; charset=utf-8
       <usage_percentage nil="nil"/>
     </subscription_add_on>
   </subscription_add_ons>
+  <custom_fields type="array">
+    <custom_field>
+      <name>sub_field1</name>
+      <value>sub-value-1</value>
+    </custom_field>
+  </custom_fields>
   <a name="cancel" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/cancel" method="put"/>
   <a name="terminate" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/terminate" method="put"/>
   <a name="notes" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/notes" method="put"/>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -296,4 +296,15 @@ XML
       end
     end
   end
+
+  describe 'custom fields' do
+    let(:account) {
+      stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-200'
+      Account.find 'abcdef1234567890'
+    }
+
+    it 'should have a custom field' do
+      account.custom_fields.must_equal [CustomField.new(name: 'acct_field', value: 'acct value')]
+    end
+  end
 end

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -232,6 +232,11 @@ XML
         resource.new.reasons.must_be_kind_of Enumerable
       end
 
+      it "must return the same object_id when uninitialized" do
+        instance = resource.new
+        instance.reasons.object_id.must_equal instance.reasons.object_id
+      end
+
       it "should not set changed attributes when reading a resource" do
         record = resource.new
         record.reasons

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -144,6 +144,17 @@ describe Subscription do
     end
   end
 
+  describe "custom fields" do
+    let(:subscription) {
+      stub_api_request :get, 'subscriptions/active', 'subscriptions/show-200'
+      Subscription.find 'active'
+    }
+
+    it 'should have a custom field' do
+      subscription.custom_fields.must_equal [CustomField.new(name: 'sub_field1', value: 'sub-value-1')]
+    end
+  end
+
   describe "active and inactive" do
     let(:active) {
       stub_api_request :get, 'subscriptions/active', 'subscriptions/show-200'


### PR DESCRIPTION
Adds `Recurly::CustomField` model with associations:

- **Account** `has_many :custom_fields`
- **Subscription** `has_many :custom_fields`

*Updating Account Custom Fields*
```ruby
# get custom fields on Account
> account.custom_fields
=> [#<Recurly::CustomField name: "dog_breed", value: "Pompoo">, #<Recurly::CustomField name: "dog_dad", value: "Clownsworth">]
# add a custom field to the account
> account.custom_fields << Recurly::CustomField.new(name: "dog_mom", value: "Cinderella")
=> [#<Recurly::CustomField name: "dog_breed", value: "Pompoo">, #<Recurly::CustomField name: "dog_dad", value: "Clownsworth">, #<Recurly::CustomField name: "dog_mom", value: "Cinderella">]
# delete an existing field
> account.custom_fields[1].value = nil
=> nil
# or
> account.custom_fields[1].value = ""

irb(main):021:0> account.save
=> true
```

*Updating Subscription Custom Fields*
```ruby
# get custom fields on subscription
> subscription.custom_fields
=> [#<Recurly::CustomField name: "salesperson", value: "jeff">, #<Recurly::CustomField name: "contact", value: "sales_email@example.com">]
# find an existing field by name, update the value
> subscription.custom_fields.find { |cf| cf.name == "salesperson" }.value = "jeff sales"
=> "jeff sales"
# delete an existing field
> subscription.custom_fields[1].value = nil
=> nil
# or
> subscription.custom_fields[1].value = ""

irb(main):021:0> subscription.save
=> true
```