### PR TITLE
[V3] Test more versions of ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
 before_install: gem install bundler -v 1.14.6

--- a/lib/recurly/schema/schema_validator.rb
+++ b/lib/recurly/schema/schema_validator.rb
@@ -36,7 +36,7 @@ module Recurly
 
       # Validates an individual attribute
       def validate_attribute!(schema_attr, val)
-        if !schema_attr.type.is_a?(Symbol) && val.class != schema_attr.type
+        unless schema_attr.type.is_a?(Symbol) || val.is_a?(schema_attr.type)
           expected = case schema_attr.type
                      when Array
                        "Array of #{schema_attr.type.item_type}s"


### PR DESCRIPTION
And fix an issue with 2.3 where a value like `2` is represented as a `Fixnum` rather than an `Integer` like in later versions. 