### PR TITLE
Bump 2.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.16.1"></a>
+## v2.16.1 (2018-08-06)
+
+- Adjust inline documentation for clarity, grammar, and syntax [PR](https://github.com/recurly/recurly-client-ruby/pull/393)
+- Correctly document the response type in Purchases [PR](https://github.com/recurly/recurly-client-ruby/pull/394)
+- Add gateway_token and gateway_code attributes to BillingInfo class [PR](https://github.com/recurly/recurly-client-ruby/pull/395)
+- Remove the old recurly binary [PR](https://github.com/recurly/recurly-client-ruby/pull/398)
+
 <a name="v2.16.0"></a>
 ## v2.16.0 (2018-06-26)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.16.0'
+gem 'recurly', '~> 2.16.1'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 16
-    PATCH   = 0
+    PATCH   = 1
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
- Adjust inline documentation for clarity, grammar, and syntax [PR](https://github.com/recurly/recurly-client-ruby/pull/393)
- Correctly document the response type in Purchases [PR](https://github.com/recurly/recurly-client-ruby/pull/394)
- Add gateway_token and gateway_code attributes to BillingInfo class [PR](https://github.com/recurly/recurly-client-ruby/pull/395)
- Remove the old recurly binary [PR](https://github.com/recurly/recurly-client-ruby/pull/398)