### PR TITLE
Support account notes

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -23,6 +23,7 @@ module Recurly
   require 'recurly/js'
   require 'recurly/money'
   require 'recurly/measured_unit'
+  require 'recurly/note'
   require 'recurly/plan'
   require 'recurly/redemption'
   require 'recurly/subscription'

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -26,6 +26,9 @@ module Recurly
     # @return [Pager<Transaction>, []] A pager that yields Transaction for persisted
     has_many :transactions
 
+    # @return [Pager<Note>, []] A pager that yields Note for persisted
+    has_many :notes
+
     # @return [Pager<Redemption>, []] A pager that yields Redemptions for persisted
     has_many :redemptions
 
@@ -106,7 +109,7 @@ module Recurly
     # Reopen an account.
     #
     # @return [true, false] +true+ when successful, +false+ when unable to
-    #   (e.g., the account is already opwn), and may raise an exception if the
+    #   (e.g., the account is already open), and may raise an exception if the
     #   attempt fails.
     def reopen
       return false unless link? :reopen

--- a/lib/recurly/note.rb
+++ b/lib/recurly/note.rb
@@ -1,0 +1,14 @@
+module Recurly
+  # Recurly Documentation: https://dev.recurly.com/docs/list-account-notes
+  class Note < Resource
+    # @return [Account]
+    belongs_to :account
+
+    define_attribute_methods %w(
+      account
+      message
+      created_at
+    )
+
+  end
+end

--- a/spec/fixtures/accounts/notes/show-200.xml
+++ b/spec/fixtures/accounts/notes/show-200.xml
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<notes type="array">
+    <note>
+        <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+        <message>This is a very important note</message>
+        <created_at type="datetime">2018-08-09T21:42:54Z</created_at>
+    </note>
+</notes>

--- a/spec/fixtures/accounts/show-200.xml
+++ b/spec/fixtures/accounts/show-200.xml
@@ -12,6 +12,7 @@ Content-Type: application/xml; charset=utf-8
   <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
   <credit_payments href="https://api.recurly.com/v2/accounts/abcdef1234567890/credit_payments"/>
   <account_balance href="https://api.recurly.com/v2/accounts/abcdef1234567890/balance"/>
+  <notes href="https://api.recurly.com/v2/accounts/abcdef1234567890/notes"/>
   <account_code>abcdef1234567890</account_code>
   <username>shmohawk58</username>
   <email>larry.david@example.com</email>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -295,6 +295,21 @@ XML
         balance[:EUR].must_equal(-520)
       end
     end
+
+    describe "when account has notes" do
+      let(:account) {
+        stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-200'
+        stub_api_request :get, 'accounts/abcdef1234567890/notes', 'accounts/notes/show-200'
+        Account.find 'abcdef1234567890'
+      }
+
+      it "is able to retrieve and parse notes" do
+        notes = account.notes
+        note = notes.first
+        note.must_be_instance_of Note
+        note.message.must_equal 'This is a very important note'
+      end
+    end
   end
 
   describe 'custom fields' do


### PR DESCRIPTION
Fixes #327. Client could not access account notes using `account.notes`. Requires an API change (notes href tag must be included in Account xml).