### PR TITLE
Use Net-http-persistent for persistent connection

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'logger'
 require_relative './schema/json_parser'
+require_relative './client/adapter'
 
 module Recurly
   class Client
@@ -71,15 +72,7 @@ module Recurly
           faraday.response :logger
         end
         faraday.basic_auth(api_key, '')
-        faraday.adapter :net_http_persistent do |http| # yields Net::HTTP
-          # Let's not use the bundled cert in production yet
-          # but we will use these certs for any other staging or dev environment
-          unless BASE_URL.end_with?('.recurly.com')
-            http.ca_file = File.join(File.dirname(__FILE__), '../data/ca-certificates.crt')
-          end
-          http.open_timeout = 50
-          http.read_timeout = 60
-        end
+        configure_adapter(faraday)
       end
 
       # TODO this is undocumented until we finalize it

--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -71,17 +71,14 @@ module Recurly
           faraday.response :logger
         end
         faraday.basic_auth(api_key, '')
-        faraday.adapter :net_http do |http| # yields Net::HTTP
+        faraday.adapter :net_http_persistent do |http| # yields Net::HTTP
           # Let's not use the bundled cert in production yet
           # but we will use these certs for any other staging or dev environment
           unless BASE_URL.end_with?('.recurly.com')
             http.ca_file = File.join(File.dirname(__FILE__), '../data/ca-certificates.crt')
           end
-          http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
           http.open_timeout = 50
           http.read_timeout = 60
-          http.keep_alive_timeout = 60
         end
       end
 

--- a/lib/recurly/client/adapter.rb
+++ b/lib/recurly/client/adapter.rb
@@ -1,0 +1,46 @@
+require 'openssl'
+
+module Recurly
+  class Client
+    module NetHttpPersistentAdapter
+      protected
+      def configure_adapter(faraday)
+        faraday.adapter :net_http_persistent do |http| # yields Net::HTTP
+          # Let's not use the bundled cert in production yet
+          # but we will use these certs for any other staging or dev environment
+          unless BASE_URL.end_with?('.recurly.com')
+            http.ca_file = File.join(File.dirname(__FILE__), '../data/ca-certificates.crt')
+          end
+          http.open_timeout = 50
+          http.read_timeout = 60
+        end
+      end
+    end
+
+    module NetHttpAdapter
+      protected
+      def configure_adapter(http)
+        faraday.adapter :net_http do |http| # yields Net::HTTP
+          # Let's not use the bundled cert in production yet
+          # but we will use these certs for any other staging or dev environment
+          unless BASE_URL.end_with?('.recurly.com')
+            http.ca_file = File.join(File.dirname(__FILE__), '../data/ca-certificates.crt')
+          end
+          http.use_ssl = true
+          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          http.open_timeout = 50
+          http.read_timeout = 60
+          http.keep_alive_timeout = 60
+        end
+      end
+    end
+
+    include NetHttpAdapter
+
+    begin
+      require 'net/http/persistent'
+      include NetHttpPersistentAdapter
+    rescue LoadError
+    end
+  end
+end

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   # spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "net-http-persistent", "~> 3.0"
   spec.add_dependency "faraday", "~> 0.12"
 
+  spec.add_development_dependency "net-http-persistent", "~> 2.9.4"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   # spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "net-http-persistent", "~> 3.0"
   spec.add_dependency "faraday", "~> 0.12"
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
Should discuss some configuration and dependency management here.

Tested against this script:

```ruby
require 'recurly'
require 'benchmark'

API_KEY = 'KEY'
SITE_ID = 'subdomain-SUBDOMAIN'

@client = Recurly::Client.new(api_key: API_KEY, site_id: SITE_ID)

# Get first 30 ids
ids = @client.list_accounts(limit: 30).each_page.first.map(&:id)

measurement = Benchmark.measure do
  # Fetch 30 accounts
  # Obviously we could use `ids=` in list_accounts but this
  # is unoptimized for benchmarking purposes
  ids.each do |id|
    acct = @client.get_account(account_id: id)
  end
end
puts measurement
```

Without persistent:
`0.520000   0.040000   0.560000 ( 11.453849)`
With persistent:
`  0.390000   0.030000   0.420000 (  4.655093)`

With persistent, the wall-clock time is over halved.
