### PR TITLE
Alias company and company_name

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -61,6 +61,7 @@ module Recurly
       first_name
       last_name
       company_name
+      company
       accept_language
       hosted_login_token
       vat_number
@@ -80,6 +81,7 @@ module Recurly
       preferred_locale
     )
     alias to_param account_code
+    alias company_name company
 
     # Creates an invoice from the pending charges on the account.
     # Raises an error if it fails.

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -307,4 +307,12 @@ XML
       account.custom_fields.must_equal [CustomField.new(name: 'acct_field', value: 'acct value')]
     end
   end
+
+  describe "#company" do
+    it "should respond to company_name even if the xml gives you company" do
+      account = Account.from_xml "<account><company>My Company Inc.</company></account>"
+      account.company_name.must_equal "My Company Inc."
+      account.company.must_equal "My Company Inc."
+    end
+  end
 end


### PR DESCRIPTION
When included in transaction.details, the account xml uses `company` instead of `company_name`. This aliases the two so calling`account.company` will give you the `company_name`.

## Testing

```ruby
txn = Recurly::Transaction.find('473e49b3fbce91bc3a94c34b61a1cb7d')
puts txn.details['account'].company      # prints "Your Company Name"
puts txn.details['account'].company_name # prints "Your Company Name"
```
