### PR TITLE
Adds missing credit memo opts to invoice refunds

### DIFF
--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -103,8 +103,16 @@ describe Invoice do
 
     describe "#refund_to_xml" do
       it "must serialize line_items" do
-        @invoice.send(:refund_line_items_to_xml, @line_items, 'credit_first').must_equal(
-          '<invoice><refund_method>credit_first</refund_method><line_items><adjustment><uuid>charge1</uuid><quantity>1</quantity><prorate>false</prorate></adjustment></line_items></invoice>'
+        options = {
+          credit_customer_notes: 'Credit Notes',
+          external_refund: true,
+          payment_method: 'check',
+          description: 'Check no. 12345678',
+          refunded_at: DateTime.new(2018, 12, 1, 0, 0, 0),
+          amount_in_cents: 17_500
+        }
+        @invoice.send(:refund_line_items_to_xml, @line_items, 'credit_first', options).must_equal(
+          '<invoice><refund_method>credit_first</refund_method><credit_customer_notes>Credit Notes</credit_customer_notes><external_refund>true</external_refund><payment_method>check</payment_method><description>Check no. 12345678</description><refunded_at>2018-12-01T00:00:00+00:00</refunded_at><amount_in_cents>17500</amount_in_cents><line_items><adjustment><uuid>charge1</uuid><quantity>1</quantity><prorate>false</prorate></adjustment></line_items></invoice>'
         )
       end
     end
@@ -129,8 +137,16 @@ describe Invoice do
 
     describe "#refund_to_xml" do
       it "must serialize amount_in_cents" do
-        @invoice.send(:refund_amount_to_xml, 1000, 'credit_first').must_equal(
-          '<invoice><refund_method>credit_first</refund_method><amount_in_cents>1000</amount_in_cents></invoice>'
+        options = {
+          credit_customer_notes: 'Credit Notes',
+          external_refund: true,
+          payment_method: 'check',
+          description: 'Check no. 12345678',
+          refunded_at: DateTime.new(2018, 12, 1, 0, 0, 0),
+          amount_in_cents: 17_500
+        }
+        @invoice.send(:refund_amount_to_xml, 1000, 'credit_first', options).must_equal(
+          '<invoice><refund_method>credit_first</refund_method><amount_in_cents>1000</amount_in_cents><credit_customer_notes>Credit Notes</credit_customer_notes><external_refund>true</external_refund><payment_method>check</payment_method><description>Check no. 12345678</description><refunded_at>2018-12-01T00:00:00+00:00</refunded_at><amount_in_cents>17500</amount_in_cents></invoice>'
         )
       end
     end


### PR DESCRIPTION
These credit invoice options were missing from the invoice refund methods. This commit is meant to add the functionality without any breaking changes. The next available minor release (2.17.0) will change the method signatures of both `refund` and `refund_line_items`.

These options can now be passed to both `refund` and `refund_line_items`.

Examples from @judith :
To refund a charge invoice:

```ruby
invoice = Recurly::Invoice.find('1001')
adjustments = invoice.line_items.map do |adjustment|
  { adjustment: adjustment, quantity: 1, prorate: false }
end
options = {
  credit_customer_notes: 'Credit Notes',
  external_refund: true,
  payment_method: 'check',
  description: 'Check no. 12345678',
  refunded_at: DateTime.new(2018, 12, 1, 0, 0, 0) # can take a datetime or a string
}
refund = invoice.refund(adjustments, 'credit_first', options)
```

```ruby
invoice = Recurly::Invoice.find('1001')

options = {
  credit_customer_notes: 'Credit Notes',
  external_refund: true,
  payment_method: 'check',
  description: 'Check no. 12345678',
  refunded_at: DateTime.new(2018, 12, 1, 0, 0, 0) # can take a datetime or a string
}
refund = invoice.refund_amount(1_000, 'credit_first', options)
```

To refund the remaining balance of a credit invoice:

```ruby
invoice = Recurly::Invoice.find('1001')

options = {
  external_refund: true,
  payment_method: 'check',
  description: 'Check no. 12345678',
  refunded_at: DateTime.new(2018, 12, 1, 0, 0, 0) # can take a datetime or a string
}
refund = invoice.refund_amount(1_00, 'all_transaction', options)
```