### PR TITLE
Remove comment being interpreted as atoms

### DIFF
--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -86,7 +86,7 @@ module Recurly
       line_items
       transactions
       terms_and_conditions
-      vat_reverse_charge_notes # Only shows if reverse charge invoice
+      vat_reverse_charge_notes
       customer_notes
       address
       net_terms


### PR DESCRIPTION
The way `%w()` is interpreted does not allow comments. Each token in the comment was being interpreted as part of the list. It was not causing any problems so we didn't notice.

```
[9] pry(main)> Recurly::Invoice.new.methods.grep /shows/
=> [:shows,
 :shows_changed?,
 :shows_previously_changed?,
 :shows_previously_was,
 :shows=,
 :shows?,
 :shows_change,
 :shows_was]
[10] pry(main)> Recurly::Invoice.new.methods.grep /#/
=> [:"#",
 :#=,
 :"#?",
 :"#_change",
 :"#_changed?",
 :"#_was",
 :"#_previously_changed?",
 :"#_previously_was"]
```