### PR TITLE
Bump 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.0"></a>
+## v2.17.0 (2018-09-20)
+
+- Remove Recurly.js v2 code and some other small improvements [PR](https://github.com/recurly/recurly-client-ruby/pull/411)
+- Adds missing credit memo opts to invoice refunds [PR](https://github.com/recurly/recurly-client-ruby/pull/415)
+
+### Upgrade Notes
+
+This release contains one breaking change. Older Recurly.js token signing is not longer supported. You should upgrade to version 4 of Recurly.js: https://dev.recurly.com/docs/recurlyjs
+The `js` module is still around to support storing the `public_key`.
+
 <a name="v2.16.2"></a>
 ## v2.16.2 (2018-08-21)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.16.2'
+gem 'recurly', '~> 2.17'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,8 +1,8 @@
 module Recurly
   module Version
     MAJOR   = 2
-    MINOR   = 16
-    PATCH   = 2
+    MINOR   = 17
+    PATCH   = 0
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION

- Remove Recurly.js v2 code and some other small improvements [PR](https://github.com/recurly/recurly-client-ruby/pull/411)
- Adds missing credit memo opts to invoice refunds [PR](https://github.com/recurly/recurly-client-ruby/pull/415)

### Upgrade Notes
This release contains one breaking change. Older Recurly.js token signing is not longer supported. You should upgrade to version 4 of Recurly.js: https://dev.recurly.com/docs/recurlyjs
The `js` module is still around to support storing the `public_key`.