### PR TITLE
Move SSL and timeout config to Faraday options

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -179,7 +179,18 @@ module Recurly
     end
 
     def set_faraday_connection(api_key)
-      @conn = Faraday.new(url: BASE_URL) do |faraday|
+      options = {
+        url: BASE_URL,
+        request: { timeout: 60, open_timeout: 50 },
+        ssl: { verify: true }
+      }
+      # Let's not use the bundled cert in production yet
+      # but we will use these certs for any other staging or dev environment
+      unless BASE_URL.end_with?('.recurly.com')
+        options[:ssl][:ca_file] = File.join(File.dirname(__FILE__), '../data/ca-certificates.crt')
+      end
+
+      @conn = Faraday.new(nil, options) do |faraday|
         if @log_level == Logger::INFO
           faraday.response :logger
         end

--- a/lib/recurly/client/adapter.rb
+++ b/lib/recurly/client/adapter.rb
@@ -5,14 +5,9 @@ module Recurly
     module NetHttpPersistentAdapter
       protected
       def configure_net_adapter(faraday)
-        faraday.adapter :net_http_persistent do |http| # yields Net::HTTP
-          # Let's not use the bundled cert in production yet
-          # but we will use these certs for any other staging or dev environment
-          unless BASE_URL.end_with?('.recurly.com')
-            http.ca_file = File.join(File.dirname(__FILE__), '../data/ca-certificates.crt')
-          end
-          http.open_timeout = 50
-          http.read_timeout = 60
+        faraday.adapter :net_http_persistent do |http|
+          # yields Net::HTTP::Persistent
+          http.keep_alive_timeout = 60
         end
       end
     end
@@ -20,17 +15,8 @@ module Recurly
     module NetHttpAdapter
       protected
       def configure_net_adapter(faraday)
-        faraday.adapter :net_http do |http| # yields Net::HTTP
-          # Let's not use the bundled cert in production yet
-          # but we will use these certs for any other staging or dev environment
-          unless BASE_URL.end_with?('.recurly.com')
-            http.ca_file = File.join(File.dirname(__FILE__), '../data/ca-certificates.crt')
-          end
-          http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-          http.open_timeout = 50
-          http.read_timeout = 60
-          http.keep_alive_timeout = 60
+        faraday.adapter :net_http do |http|
+          # yields Net::HTTP
         end
       end
     end

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Recurly::Client do
   let(:subdomain) { 'test' }
   let(:api_key) { 'recurly-good' }
-  let(:client) { Recurly::Client.new(api_key: api_key, subdomain: subdomain) }
+  subject(:client) { Recurly::Client.new(api_key: api_key, subdomain: subdomain) }
 
   context "#api_version" do
     it "should respond with a valid api version" do


### PR DESCRIPTION
I realized that most of what we were setting in the Adapter class could be done using Faraday's built in options.