### PR TITLE
Fix bundler warnings related to dev dependencies

### DIFF
--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
 
   s.files            = Dir['lib/**/*']
 
-  s.has_rdoc         = true
   s.extra_rdoc_files = %w(README.md)
   s.rdoc_options     = %w(--main README.md)
 
@@ -23,19 +22,20 @@ Gem::Specification.new do |s|
   if RUBY_VERSION < "2.2"
     puts "WARNING: The recurly library is only supported on ruby 2.2 and above."
   else
-    s.add_development_dependency('nokogiri','~> 1.8.2')
+    s.add_development_dependency 'nokogiri', '~> 1.8', '>= 1.8.2'
   end
 
   s.add_development_dependency 'rake', '~> 11.3'
-  s.add_development_dependency 'minitest', '~> 5.8.0'
-  s.add_development_dependency 'addressable',  '~> 2.4.0'
-  s.add_development_dependency 'webmock',  '~> 2.3.2'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'minitest', '~> 5.8', '>= 5.8.0'
+  s.add_development_dependency 'addressable', '~> 2.4', '>= 2.4.0'
+  s.add_development_dependency 'webmock', '~> 2.3', '>= 2.3.2'
+  s.add_development_dependency 'simplecov', '~> 0'
 
   if RUBY_PLATFORM != 'java' && !ENV['CI']
     s.add_development_dependency 'yard', '~> 0.9.9'
-    s.add_development_dependency 'redcarpet'
-    s.add_development_dependency 'racc'
-    s.add_development_dependency 'pry'
+    s.add_development_dependency 'redcarpet', '~> 3.4', '>= 3.4.0'
+    s.add_development_dependency 'racc', '~> 1'
+    s.add_development_dependency 'pry', '~> 0'
+
   end
 end


### PR DESCRIPTION
There were several warnings that appeared when installing and building the package. Some of the dependencies were overly strict. `has_rdoc` is deprecated and defaults to true, so we can remove that line that sets it to true explicitly.