### PR TITLE
Remove line that assumes cursor is an integer

### DIFF
--- a/lib/recurly/resource/pager.rb
+++ b/lib/recurly/resource/pager.rb
@@ -88,7 +88,6 @@ module Recurly
       # @raise [API::NotModified] If the <tt>:etag</tt> option is set and
       #   matches the server's.
       def initialize resource_class, options = {}
-        options[:cursor] &&= options[:cursor].to_i
         @parent = options.delete :parent
         @uri    = options.delete :uri
         @etag   = options.delete :etag


### PR DESCRIPTION
Fixes #375

In v2.3, the API changed to support updated_at sorting and filtering. Because of this, cursor is no longer an integer.