### PR TITLE
Handle malformed XML errors gracefully.

### DIFF
--- a/lib/recurly/api/errors.rb
+++ b/lib/recurly/api/errors.rb
@@ -47,7 +47,7 @@ module Recurly
       def xml
         @xml ||= begin
           XML.new(response.body) if response and response.body and not response.body.empty?
-        rescue REXML::ParseException
+        rescue Recurly::XML::ParseError
           nil
         end
       end

--- a/lib/recurly/api/errors.rb
+++ b/lib/recurly/api/errors.rb
@@ -47,6 +47,8 @@ module Recurly
       def xml
         @xml ||= begin
           XML.new(response.body) if response and response.body and not response.body.empty?
+        rescue REXML::ParseException
+          nil
         end
       end
     end

--- a/lib/recurly/xml.rb
+++ b/lib/recurly/xml.rb
@@ -1,5 +1,7 @@
 module Recurly
   class XML
+    ParseError = Class.new(StandardError)
+
     class << self
       def cast(el)
         # return nil if the `nil` attribute is present

--- a/lib/recurly/xml/nokogiri.rb
+++ b/lib/recurly/xml/nokogiri.rb
@@ -2,7 +2,9 @@ module Recurly
   class XML
     module NokogiriAdapter
       def initialize xml
-        @root = Nokogiri(xml).root
+        @root = Nokogiri::XML(xml) { |config| config.strict }.root
+      rescue Nokogiri::XML::SyntaxError
+        raise ParseError
       end
 
       def add_element name, value = nil

--- a/lib/recurly/xml/rexml.rb
+++ b/lib/recurly/xml/rexml.rb
@@ -5,6 +5,8 @@ module Recurly
     module REXMLAdapter
       def initialize xml
         @root = ::REXML::Document.new(xml).root
+      rescue REXML::ParseException
+        raise ParseError
       end
 
       def add_element name, value = nil

--- a/spec/recurly/api/errors_spec.rb
+++ b/spec/recurly/api/errors_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Recurly::API::ResponseError do
   describe "#xml" do
-    let(:xml) { '<?xml version="1.0"?>' }
+    let(:xml) { '<?xml version="1.0"?><root/>' }
 
     describe "when response not assigned" do
       let(:error) { Recurly::API::ResponseError.new nil, nil }
@@ -48,15 +48,13 @@ describe Recurly::API::ResponseError do
         end
       end
 
-      if ENV.fetch('XML', 'rexml') == 'rexml'
-        describe "when using REXML and response body is not valid XML" do
-          let(:html) { "<html><body><hr></body></html>" }
+      describe "when using response body is not valid XML" do
+        let(:html) { "<html><body><hr></body></html>" }
 
-          before { 3.times { response.expect :body, html } }
+        before { 3.times { response.expect :body, html } }
 
-          it "must return nil" do
-            error.send(:xml).must_equal nil
-          end
+        it "must return nil" do
+          error.send(:xml).must_equal nil
         end
       end
     end

--- a/spec/recurly/api/errors_spec.rb
+++ b/spec/recurly/api/errors_spec.rb
@@ -47,6 +47,18 @@ describe Recurly::API::ResponseError do
           error.send(:xml).must_be_instance_of Recurly::XML
         end
       end
+
+      if ENV.fetch('XML', 'rexml') == 'rexml'
+        describe "when using REXML and response body is not valid XML" do
+          let(:html) { "<html><body><hr></body></html>" }
+
+          before { 3.times { response.expect :body, html } }
+
+          it "must return nil" do
+            error.send(:xml).must_equal nil
+          end
+        end
+      end
     end
   end
 end

--- a/spec/recurly/xml_spec.rb
+++ b/spec/recurly/xml_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe Recurly::XML do
+  describe ".initialize" do
+    describe "when malformed XML is passed in" do
+      it "raises a Recurly::XML::ParseError" do
+        proc { Recurly::XML.new('<unclosed-root>') }.must_raise Recurly::XML::ParseError
+      end
+    end
+  end
+
   describe ".filter" do
     it "must filter sensitive data only on number and verification_value" do
       [


### PR DESCRIPTION
Sometimes errors come back from Recurly as HTML, which makes REXML choke while trying to log the error, so the real error is lost to us. If we handle the error a bit more gracefully then we can log the original backtrace and error.

I did think about doing this in the `REXMLAdapter` module, but I thought that we don't always want to quietly swallow malformed XML exceptions - e.g. if the response is OK and we should have valid subscription XML but don't, then we should blow up.

Because this code is specific to REXML, I've wrapped it up so it won't run when running the test suite for nokogiri. nokogiri seems to accept HTML just fine and doesn't throw a parse error.