### PR TITLE
Release version 2.17.2 / API version 2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.2"></a>
+## v2.17.2 (2018-10-30)
+
+This brings us up to API version 2.16. There are no breaking changes.
+
+- Remove Rails Generator mention in README.md [PR](https://github.com/recurly/recurly-client-ruby/pull/426)
+- Gracefully handle XML parsing errors [PR](https://github.com/recurly/recurly-client-ruby/pull/424)
+- Add missing webhook properties to models [PR](https://github.com/recurly/recurly-client-ruby/pull/422)
+- Do not assume cursor is an integer [PR](https://github.com/recurly/recurly-client-ruby/pull/421)
+- Fix bundler warnings [PR](https://github.com/recurly/recurly-client-ruby/pull/420)
+- Alias company and company_name [PR](https://github.com/recurly/recurly-client-ruby/pull/413)
+
 <a name="v2.17.1"></a>
 ## v2.17.1 (2018-09-25)
 

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -17,7 +17,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.15'
+    RECURLY_API_VERSION = '2.16'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 17
-    PATCH   = 1
+    PATCH   = 2
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
## v2.17.2 (2018-10-30)

This brings us up to API version 2.16. There are no breaking changes.

- Remove Rails Generator mention in README.md [PR](https://github.com/recurly/recurly-client-ruby/pull/426)
- Gracefully handle XML parsing errors [PR](https://github.com/recurly/recurly-client-ruby/pull/424)
- Add missing webhook properties to models [PR](https://github.com/recurly/recurly-client-ruby/pull/422)
- Do not assume cursor is an integer [PR](https://github.com/recurly/recurly-client-ruby/pull/421)
- Fix bundler warnings [PR](https://github.com/recurly/recurly-client-ruby/pull/420)
- Alias company and company_name [PR](https://github.com/recurly/recurly-client-ruby/pull/413)