### PR TITLE
Fix bug when company is not included in xml response

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -85,7 +85,10 @@ module Recurly
       preferred_locale
     )
     alias to_param account_code
-    alias company_name company
+
+    def company_name
+      super || company
+    end
 
     # Creates an invoice from the pending charges on the account.
     # Raises an error if it fails.

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -329,5 +329,10 @@ XML
       account.company_name.must_equal "My Company Inc."
       account.company.must_equal "My Company Inc."
     end
+
+    it 'should respond to company_name when company is not included in xml response' do
+      account = Account.from_xml '<account><company_name>My Company Inc.</company_name></account>'
+      account.company_name.must_equal 'My Company Inc.'
+    end
   end
 end


### PR DESCRIPTION
The 8908a771c commit broke the functionality for looking up an account and getting `company_name`.

This commit will fix that bug while preserving the intended functionality.