### PR TITLE
Release version 2.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.3"></a>
+## v2.17.3 (2018-11-06)
+
+- Fix bug related to aliasing company and company_name [PR](https://github.com/recurly/recurly-client-ruby/pull/428)
+
 <a name="v2.17.2"></a>
 ## v2.17.2 (2018-10-30)
 

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 17
-    PATCH   = 2
+    PATCH   = 3
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
## v2.17.3 (2018-11-06)
 - Fix bug related to aliasing company and company_name [PR](https://github.com/recurly/recurly-client-ruby/pull/428)
