### PR TITLE
Add gateway_code to invoice and subscription

### DIFF
--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -108,6 +108,7 @@ module Recurly
       subscription_ids
       dunning_events_count
       final_dunning_event
+      gateway_code
     )
     alias to_param invoice_number_with_prefix
 

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -94,6 +94,7 @@ module Recurly
       current_term_ends_at
       total_amount_in_cents
       resume_at
+      gateway_code
     )
     alias to_param uuid
 

--- a/spec/fixtures/invoices/show-200-updated.xml
+++ b/spec/fixtures/invoices/show-200-updated.xml
@@ -27,6 +27,7 @@ Content-Type: application/xml; charset=utf-8
   <terms_and_conditions>Dentist not responsible for broken teeth.</terms_and_conditions>
   <vat_reverse_charge_notes>can't be changed when invoice was not a reverse charge</vat_reverse_charge_notes>
   <net_terms type="integer">1</net_terms>
+  <gateway_code>Some Gateway Code</gateway_code>
   <collection_method>automatic</collection_method>
   <subtotal_after_discount_in_cents type="integer">300</subtotal_after_discount_in_cents>
   <attempt_next_collection_at nil="nil"></attempt_next_collection_at>

--- a/spec/fixtures/invoices/show-200.xml
+++ b/spec/fixtures/invoices/show-200.xml
@@ -26,6 +26,7 @@ Content-Type: application/xml; charset=utf-8
   <customer_notes>Some Customer Notes</customer_notes>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <net_terms type="integer">0</net_terms>
+  <gateway_code>Gateway Code</gateway_code>
   <collection_method>automatic</collection_method>
   <subtotal_after_discount_in_cents type="integer">300</subtotal_after_discount_in_cents>
   <attempt_next_collection_at nil="nil"></attempt_next_collection_at>

--- a/spec/fixtures/subscriptions/notes-200-change.xml
+++ b/spec/fixtures/subscriptions/notes-200-change.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
   <expires_at nil="nil"></expires_at>
   <total_billing_cycles nil="nil"></total_billing_cycles>
   <remaining_billing_cycles nil="nil"></remaining_billing_cycles>
+  <gateway_code>Some Gateway Code</gateway_code>
   <current_period_started_at type="datetime">2014-05-20T18:20:01Z</current_period_started_at>
   <current_period_ends_at type="datetime">2014-05-20T18:20:01Z</current_period_ends_at>
   <trial_started_at nil="nil"></trial_started_at>

--- a/spec/fixtures/subscriptions/show-200.xml
+++ b/spec/fixtures/subscriptions/show-200.xml
@@ -26,6 +26,7 @@ Content-Type: application/xml; charset=utf-8
   <current_period_started_at type="datetime">2011-04-01T07:00:00Z</current_period_started_at>
   <current_period_ends_at type="datetime">2011-05-01T06:59:59Z</current_period_ends_at>
   <trial_started_at nil="nil"></trial_started_at>
+  <gateway_code>Gateway Code</gateway_code>
   <trial_ends_at nil="nil"></trial_ends_at>
   <revenue_schedule_type>evenly</revenue_schedule_type>
   <no_billing_info_reason>plan_free_trial</no_billing_info_reason>

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -182,6 +182,7 @@ describe Invoice do
       invoice.customer_notes = "Oh, well, that's one way to pull a tooth out!"
       invoice.vat_reverse_charge_notes = "can't be changed when invoice was not a reverse charge"
       invoice.net_terms = 1
+      invoice.gateway_code = "Some Gateway Code"
       invoice.save()
 
       invoice.address.must_be_instance_of Address
@@ -199,6 +200,7 @@ describe Invoice do
       invoice.customer_notes.must_equal "Oh, well, that's one way to pull a tooth out!"
       invoice.vat_reverse_charge_notes.must_equal "can't be changed when invoice was not a reverse charge"
       invoice.net_terms.must_equal 1
+      invoice.gateway_code.must_equal "Some Gateway Code"
     end
   end
 end

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -332,7 +332,8 @@ describe Subscription do
       notes = {
         customer_notes: 'Some New Customer Notes',
         terms_and_conditions: 'Some New Terms and Conditions',
-        vat_reverse_charge_notes: 'Some New Vat Reverse Charge Notes'
+        vat_reverse_charge_notes: 'Some New Vat Reverse Charge Notes',
+        gateway_code: 'Some Gateway Code'
       }
 
       subscription.update_notes(notes)
@@ -340,6 +341,7 @@ describe Subscription do
       subscription.customer_notes.must_equal notes[:customer_notes]
       subscription.terms_and_conditions.must_equal notes[:terms_and_conditions]
       subscription.vat_reverse_charge_notes.must_equal notes[:vat_reverse_charge_notes]
+      subscription.gateway_code.must_equal notes[:gateway_code]
     end
   end
 


### PR DESCRIPTION
Adds gateway code to Invoice and Subscription objects for use with the `PUT invoice` and `PUT subscription/notes` endpoints

Scripts:
```ruby
invoice = Recurly::Invoice.find('1001')
invoice.gateway_code = 'jhpqd551evcn'
invoice.save()
```

```ruby
sub = Recurly::Subscription.find '489cf44ca794cd40b1e4b64c1db63023'
sub.update_notes(gateway_code: 'jotgbnxnecn0')
```