### PR TITLE
Add exemption certificate

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -71,6 +71,7 @@ module Recurly
       vat_number
       address
       tax_exempt
+      exemption_certificate
       entity_use_code
       created_at
       updated_at

--- a/spec/fixtures/accounts/show-200-taxed.xml
+++ b/spec/fixtures/accounts/show-200-taxed.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
   <vat_number>12345-67</vat_number>
   <tax_exempt type="boolean">true</tax_exempt>
+  <exemption_certificate>Some Certificate</exemption_certificate>
   <address>
     <address1>123 Main St.</address1>
     <address2 nil="nil"></address2>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -119,6 +119,12 @@ describe Account do
       account.tax_exempt?.must_equal true
     end
 
+    it 'must return an account with exemption certificate' do
+      stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-200-taxed'
+      account = Account.find 'abcdef1234567890'
+      account.exemption_certificate.must_equal 'Some Certificate'
+    end
+
     it "must raise an exception when unavailable" do
       stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-404'
       proc { Account.find 'abcdef1234567890' }.must_raise Resource::NotFound


### PR DESCRIPTION
Adds `exemption_certificate` attribute to the account object.

Script:
```ruby
account = Recurly::Account.create(
  :account_code => 'new-account',
  :tax_exempt => true,
  :exemption_certificate => 'Some Certificate'
)
```