### PR TITLE
Release version 2.17.4 / API version 2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.4"></a>
+## v2.17.4 (2018-12-11)
+
+This brings us up to API version 2.17. There are no breaking changes.
+
+- Add exemption_certificate to Account [PR](https://github.com/recurly/recurly-client-ruby/pull/434)
+- Add gateway_code to Invoice and Subscription [PR](https://github.com/recurly/recurly-client-ruby/pull/432)
+- Add transaction_status_updated_notification and updated_invoice_notification webhooks [PR](https://github.com/recurly/recurly-client-ruby/pull/433)
+- Fix missing type instance variable [PR](https://github.com/recurly/recurly-client-ruby/pull/436)
+- Fix README [PR](https://github.com/recurly/recurly-client-ruby/pull/437)
+- Add OpenSSL version to user agent [PR](https://github.com/recurly/recurly-client-ruby/pull/438)
+
 <a name="v2.17.3"></a>
 ## v2.17.3 (2018-11-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.3"></a>
+## v2.17.3 (2018-11-06)
+
+- Fix bug related to aliasing company and company_name [PR](https://github.com/recurly/recurly-client-ruby/pull/428)
+
 <a name="v2.17.2"></a>
 ## v2.17.2 (2018-10-30)
 

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -85,7 +85,10 @@ module Recurly
       preferred_locale
     )
     alias to_param account_code
-    alias company_name company
+
+    def company_name
+      super || company
+    end
 
     # Creates an invoice from the pending charges on the account.
     # Raises an error if it fails.

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -71,6 +71,7 @@ module Recurly
       vat_number
       address
       tax_exempt
+      exemption_certificate
       entity_use_code
       created_at
       updated_at

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -17,7 +17,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.16'
+    RECURLY_API_VERSION = '2.17'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -108,6 +108,7 @@ module Recurly
       subscription_ids
       dunning_events_count
       final_dunning_event
+      gateway_code
     )
     alias to_param invoice_number_with_prefix
 

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -94,6 +94,7 @@ module Recurly
       current_term_ends_at
       total_amount_in_cents
       resume_at
+      gateway_code
     )
     alias to_param uuid
 

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 17
-    PATCH   = 3
+    PATCH   = 4
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 17
-    PATCH   = 2
+    PATCH   = 3
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze

--- a/spec/fixtures/accounts/show-200-taxed.xml
+++ b/spec/fixtures/accounts/show-200-taxed.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
   <vat_number>12345-67</vat_number>
   <tax_exempt type="boolean">true</tax_exempt>
+  <exemption_certificate>Some Certificate</exemption_certificate>
   <address>
     <address1>123 Main St.</address1>
     <address2 nil="nil"></address2>

--- a/spec/fixtures/invoices/show-200-updated.xml
+++ b/spec/fixtures/invoices/show-200-updated.xml
@@ -27,6 +27,7 @@ Content-Type: application/xml; charset=utf-8
   <terms_and_conditions>Dentist not responsible for broken teeth.</terms_and_conditions>
   <vat_reverse_charge_notes>can't be changed when invoice was not a reverse charge</vat_reverse_charge_notes>
   <net_terms type="integer">1</net_terms>
+  <gateway_code>Some Gateway Code</gateway_code>
   <collection_method>automatic</collection_method>
   <subtotal_after_discount_in_cents type="integer">300</subtotal_after_discount_in_cents>
   <attempt_next_collection_at nil="nil"></attempt_next_collection_at>

--- a/spec/fixtures/invoices/show-200.xml
+++ b/spec/fixtures/invoices/show-200.xml
@@ -26,6 +26,7 @@ Content-Type: application/xml; charset=utf-8
   <customer_notes>Some Customer Notes</customer_notes>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <net_terms type="integer">0</net_terms>
+  <gateway_code>Gateway Code</gateway_code>
   <collection_method>automatic</collection_method>
   <subtotal_after_discount_in_cents type="integer">300</subtotal_after_discount_in_cents>
   <attempt_next_collection_at nil="nil"></attempt_next_collection_at>

--- a/spec/fixtures/subscriptions/notes-200-change.xml
+++ b/spec/fixtures/subscriptions/notes-200-change.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
   <expires_at nil="nil"></expires_at>
   <total_billing_cycles nil="nil"></total_billing_cycles>
   <remaining_billing_cycles nil="nil"></remaining_billing_cycles>
+  <gateway_code>Some Gateway Code</gateway_code>
   <current_period_started_at type="datetime">2014-05-20T18:20:01Z</current_period_started_at>
   <current_period_ends_at type="datetime">2014-05-20T18:20:01Z</current_period_ends_at>
   <trial_started_at nil="nil"></trial_started_at>

--- a/spec/fixtures/subscriptions/show-200.xml
+++ b/spec/fixtures/subscriptions/show-200.xml
@@ -26,6 +26,7 @@ Content-Type: application/xml; charset=utf-8
   <current_period_started_at type="datetime">2011-04-01T07:00:00Z</current_period_started_at>
   <current_period_ends_at type="datetime">2011-05-01T06:59:59Z</current_period_ends_at>
   <trial_started_at nil="nil"></trial_started_at>
+  <gateway_code>Gateway Code</gateway_code>
   <trial_ends_at nil="nil"></trial_ends_at>
   <revenue_schedule_type>evenly</revenue_schedule_type>
   <no_billing_info_reason>plan_free_trial</no_billing_info_reason>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -119,6 +119,12 @@ describe Account do
       account.tax_exempt?.must_equal true
     end
 
+    it 'must return an account with exemption certificate' do
+      stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-200-taxed'
+      account = Account.find 'abcdef1234567890'
+      account.exemption_certificate.must_equal 'Some Certificate'
+    end
+
     it "must raise an exception when unavailable" do
       stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-404'
       proc { Account.find 'abcdef1234567890' }.must_raise Resource::NotFound

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -329,5 +329,10 @@ XML
       account.company_name.must_equal "My Company Inc."
       account.company.must_equal "My Company Inc."
     end
+
+    it 'should respond to company_name when company is not included in xml response' do
+      account = Account.from_xml '<account><company_name>My Company Inc.</company_name></account>'
+      account.company_name.must_equal 'My Company Inc.'
+    end
   end
 end

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -182,6 +182,7 @@ describe Invoice do
       invoice.customer_notes = "Oh, well, that's one way to pull a tooth out!"
       invoice.vat_reverse_charge_notes = "can't be changed when invoice was not a reverse charge"
       invoice.net_terms = 1
+      invoice.gateway_code = "Some Gateway Code"
       invoice.save()
 
       invoice.address.must_be_instance_of Address
@@ -199,6 +200,7 @@ describe Invoice do
       invoice.customer_notes.must_equal "Oh, well, that's one way to pull a tooth out!"
       invoice.vat_reverse_charge_notes.must_equal "can't be changed when invoice was not a reverse charge"
       invoice.net_terms.must_equal 1
+      invoice.gateway_code.must_equal "Some Gateway Code"
     end
   end
 end

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -332,7 +332,8 @@ describe Subscription do
       notes = {
         customer_notes: 'Some New Customer Notes',
         terms_and_conditions: 'Some New Terms and Conditions',
-        vat_reverse_charge_notes: 'Some New Vat Reverse Charge Notes'
+        vat_reverse_charge_notes: 'Some New Vat Reverse Charge Notes',
+        gateway_code: 'Some Gateway Code'
       }
 
       subscription.update_notes(notes)
@@ -340,6 +341,7 @@ describe Subscription do
       subscription.customer_notes.must_equal notes[:customer_notes]
       subscription.terms_and_conditions.must_equal notes[:terms_and_conditions]
       subscription.vat_reverse_charge_notes.must_equal notes[:vat_reverse_charge_notes]
+      subscription.gateway_code.must_equal notes[:gateway_code]
     end
   end
 


### PR DESCRIPTION
## v2.17.4 (2018-12-11)

This brings us up to API version 2.17. There are no breaking changes.

- Add exemption_certificate to Account [PR](https://github.com/recurly/recurly-client-ruby/pull/434)
- Add gateway_code to Invoice and Subscription [PR](https://github.com/recurly/recurly-client-ruby/pull/432)
- Add transaction_status_updated_notification and updated_invoice_notification webhooks [PR](https://github.com/recurly/recurly-client-ruby/pull/433)
- Fix missing type instance variable [PR](https://github.com/recurly/recurly-client-ruby/pull/436)
- Fix README [PR](https://github.com/recurly/recurly-client-ruby/pull/437)
- Add OpenSSL version to user agent [PR](https://github.com/recurly/recurly-client-ruby/pull/438)