### PR TITLE
Ensure error message for a single returned error

### DIFF
--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -1038,9 +1038,17 @@ module Recurly
     def apply_errors(exception)
       @response = exception.response
       document = XML.new exception.response.body
-      document.each_element 'error' do |el|
-        attribute_path = el.attribute('field').value.split '.'
-        invalid! attribute_path[1, attribute_path.length], el.text
+
+      if document.root.name == 'error'
+        # Single error is returned from the API
+        attribute_path = document['symbol'].text.split '.'
+        invalid! [attribute_path[1]], document['description'].text
+      else
+        # Array of errors was returned by the API
+        document.each_element 'error' do |el|
+          attribute_path = el.attribute('field').value.split '.'
+          invalid! attribute_path[1, attribute_path.length], el.text
+        end
       end
     end
 

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -35,7 +35,8 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'yard', '~> 0.9.9'
     s.add_development_dependency 'redcarpet', '~> 3.4', '>= 3.4.0'
     s.add_development_dependency 'racc', '~> 1'
-    s.add_development_dependency 'pry', '~> 0'
+    s.add_development_dependency 'pry', '< 0.11.0', '>= 0.9.10'
+    s.add_development_dependency 'pry-nav', '~> 0.2.4'
 
   end
 end

--- a/spec/fixtures/subscriptions/create-422.xml
+++ b/spec/fixtures/subscriptions/create-422.xml
@@ -1,0 +1,8 @@
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+  <symbol>subscription.account</symbol>
+  <description>Cannot purchase on canceled account</description>
+</error>

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -146,6 +146,12 @@ XML
         stub_api_request(:post, 'resources') { XML[422] }
         proc { resource.create! }.must_raise Resource::Invalid
       end
+
+      it "must have an exception message when invalid" do
+        stub_api_request(:post, 'resources', 'subscriptions/create-422')
+        error = proc { resource.create! }.must_raise Resource::Invalid
+        error.message.must_equal 'account Cannot purchase on canceled account'
+      end
     end
 
     describe ".from_xml" do


### PR DESCRIPTION
When there is a single error returned from the API, the message attribute is blank. An example XML response from the API happens when you create a subscription on an account that has been closed:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<error>
  <symbol>subscription.account</symbol>
  <description>Cannot purchase on canceled account</description>
</error>
```

Because the `apply_errors` method assumes this should be an array of `errors` instead of a single error, it does not properly assign a message to the exception that is raised. So the following script would fail to provide a message:

```ruby
begin
  subscription = Recurly::Subscription.create!(
    :plan_code => 'gold',
    :currency  => 'USD',
    :account   => {
      :account_code => 'some-closed-account',
    }
  )
rescue Recurly::Resource::Invalid => e
  puts e.message # should be a helpful error message
end
```