### PR TITLE
Add note about OpenSSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ For now, we are still running the tests on 2.0 and below but without `nokogiri` 
 no longer supported on 1.9 or 2.0 and has patched known vulnerabilities since dropping support.
 If you must run one of these rubies (this includes jruby1.7), you must use rexml and not nokogiri.
 
+## OpenSSL Support
+
+Please ensure that you are using a supported version of OpenSSL. The [release strategy](https://www.openssl.org/policies/releasestrat.html) lists EOL dates of older versions.
+You can view the latest versions of OpenSSL [here](https://www.openssl.org/). Note that the Recurly API may not work properly with old, unsupported versions of OpenSSL.
+For security reasons, it is strongly encouraged to use the latest version of OpenSSL.
+
 ## Usage
 
 Instructions and examples are available on


### PR DESCRIPTION
This adds a note about OpenSSL support to the README. I was unable to find a direct source from the Ruby language website or the openssl gem about which versions of openssl are supported, so I linked to OpenSSL directly. 

Honestly, I would prefer that our users use a supported version of OpenSSL rather than the minimum required by their language version, so perhaps we should include these links in the other OpenSSL notes as well.