### PR TITLE
Add support for account hierarchy

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -42,6 +42,12 @@ module Recurly
     # @return [AccountBalance, nil]
     has_one :account_balance, readonly: true
 
+    # @return [Account, nil]
+    belongs_to :parent_account, class_name: :Account
+
+    # @return [Pager<Account>, []] A pager that yields Account for persisted
+    has_many :child_accounts, class_name: :Account
+
     # @return [Pager<CreditPayment>, []]
     has_many :credit_payments, class_name: :CreditPayment, readonly: true
 
@@ -57,6 +63,7 @@ module Recurly
 
     define_attribute_methods %w(
       account_code
+      parent_account_code
       state
       username
       email

--- a/spec/fixtures/accounts/hierarchy/create-201.xml
+++ b/spec/fixtures/accounts/hierarchy/create-201.xml
@@ -1,0 +1,35 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
+  <parent_account href="https://api.recurly.com/v2/accounts/1234567890"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
+  <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
+  <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+  <account_code>abcdef1234567890</account_code>
+  <parent_account_code>1234567890</parent_account_code>
+  <username>shmohawk58</username>
+  <email>larry.david@example.com</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <company_name>Home Box Office</company_name>
+  <accept_language>en-US</accept_language>
+  <hosted_login_token>18d935f06b0547ddad8cdf2490ac802e</hosted_login_token>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <vat_number>12345-67</vat_number>
+  <address>
+    <address1>123 Main St.</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94105</zip>
+    <country>US</country>
+    <phone>8015551234</phone>
+  </address>
+</account>

--- a/spec/fixtures/accounts/hierarchy/show-child-200.xml
+++ b/spec/fixtures/accounts/hierarchy/show-child-200.xml
@@ -1,0 +1,34 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
+  <parent_account href="https://api.recurly.com/v2/accounts/1234567890"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
+  <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
+  <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+  <account_code>abcdef1234567890</account_code>
+  <parent_account_code>1234567890</parent_account_code>
+  <username>shmohawk58</username>
+  <email>larry.david@example.com</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <company_name>Home Box Office</company_name>
+  <accept_language>en-US</accept_language>
+  <hosted_login_token>18d935f06b0547ddad8cdf2490ac802e</hosted_login_token>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <vat_number>12345-67</vat_number>
+  <address>
+    <address1>123 Main St.</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94105</zip>
+    <country>US</country>
+    <phone>8015551234</phone>
+  </address>
+</account>

--- a/spec/fixtures/accounts/hierarchy/show-children-200.xml
+++ b/spec/fixtures/accounts/hierarchy/show-children-200.xml
@@ -1,0 +1,49 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<accounts type="array">
+    <account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
+    <parent_account href="https://api.recurly.com/v2/accounts/1234567890"/>
+    <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+    <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
+    <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
+    <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
+    <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+    <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
+    <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+    <account_code>abcdef1234567890</account_code>
+    <parent_account_code>1234567890</parent_account_code>
+    <state>active</state>
+    <username nil="nil"></username>
+    <email nil="nil"></email>
+    <cc_emails nil="nil"></cc_emails>
+    <first_name nil="nil"></first_name>
+    <last_name nil="nil"></last_name>
+    <company_name nil="nil"></company_name>
+    <vat_number nil="nil"></vat_number>
+    <preferred_locale nil="nil"></preferred_locale>
+    <address>
+      <address1 nil="nil"></address1>
+      <address2 nil="nil"></address2>
+      <city nil="nil"></city>
+      <state nil="nil"></state>
+      <zip nil="nil"></zip>
+      <country nil="nil"></country>
+      <phone nil="nil"></phone>
+    </address>
+    <accept_language nil="nil"></accept_language>
+    <created_at type="datetime">2019-01-03T00:11:18Z</created_at>
+    <updated_at type="datetime">2019-01-03T00:33:43Z</updated_at>
+    <closed_at nil="nil"></closed_at>
+    <custom_fields type="array">
+    </custom_fields>
+    <has_live_subscription type="boolean">true</has_live_subscription>
+    <has_active_subscription type="boolean">true</has_active_subscription>
+    <has_future_subscription type="boolean">false</has_future_subscription>
+    <has_canceled_subscription type="boolean">false</has_canceled_subscription>
+    <has_past_due_invoice type="boolean">false</has_past_due_invoice>
+    <has_paused_subscription type="boolean">false</has_paused_subscription>
+    <bill_to>self</bill_to>
+  </account>
+</accounts>

--- a/spec/fixtures/accounts/hierarchy/show-parent-200.xml
+++ b/spec/fixtures/accounts/hierarchy/show-parent-200.xml
@@ -1,0 +1,47 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/1234567890">
+  <child_accounts href="https://api.recurly.com/v2/accounts/1234567890/child_accounts"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/1234567890/adjustments"/>
+  <account_balance href="https://api.recurly.com/v2/accounts/1234567890/balance"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/1234567890/invoices"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/1234567890/shipping_addresses"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/1234567890/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/1234567890/transactions"/>
+  <notes href="https://api.recurly.com/v2/accounts/1234567890/notes"/>
+  <account_code>1234567890</account_code>
+  <state>active</state>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <cc_emails nil="nil"></cc_emails>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <vat_number nil="nil"></vat_number>
+  <preferred_locale nil="nil"></preferred_locale>
+  <address>
+    <address1 nil="nil"></address1>
+    <address2 nil="nil"></address2>
+    <city nil="nil"></city>
+    <state nil="nil"></state>
+    <zip nil="nil"></zip>
+    <country nil="nil"></country>
+    <phone nil="nil"></phone>
+  </address>
+  <accept_language nil="nil"></accept_language>
+  <created_at type="datetime">2018-09-26T15:23:12Z</created_at>
+  <updated_at type="datetime">2018-12-26T15:25:20Z</updated_at>
+  <closed_at nil="nil"></closed_at>
+  <custom_fields type="array">
+  </custom_fields>
+  <has_live_subscription type="boolean">true</has_live_subscription>
+  <has_active_subscription type="boolean">true</has_active_subscription>
+  <has_future_subscription type="boolean">false</has_future_subscription>
+  <has_canceled_subscription type="boolean">false</has_canceled_subscription>
+  <has_past_due_invoice type="boolean">false</has_past_due_invoice>
+  <has_paused_subscription type="boolean">false</has_paused_subscription>
+  <bill_to>self</bill_to>
+</account>

--- a/spec/fixtures/accounts/hierarchy/update-200.xml
+++ b/spec/fixtures/accounts/hierarchy/update-200.xml
@@ -1,0 +1,35 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
+  <parent_account href="https://api.recurly.com/v2/accounts/1234567890"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
+  <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
+  <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+  <account_code>abcdef1234567890</account_code>
+  <parent_account_code>1234567890</parent_account_code>
+  <username>shmohawk58</username>
+  <email>larry.david@example.com</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <company_name>Home Box Office</company_name>
+  <accept_language>en-US</accept_language>
+  <hosted_login_token>18d935f06b0547ddad8cdf2490ac802e</hosted_login_token>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <vat_number>12345-67</vat_number>
+  <address>
+    <address1>123 Main St.</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94105</zip>
+    <country>US</country>
+    <phone>8015551234</phone>
+  </address>
+</account>

--- a/spec/fixtures/accounts/hierarchy/update-no-parent-200.xml
+++ b/spec/fixtures/accounts/hierarchy/update-no-parent-200.xml
@@ -1,0 +1,33 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
+  <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
+  <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
+  <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+  <account_code>abcdef1234567890</account_code>
+  <username>shmohawk58</username>
+  <email>larry.david@example.com</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <company_name>Home Box Office</company_name>
+  <accept_language>en-US</accept_language>
+  <hosted_login_token>18d935f06b0547ddad8cdf2490ac802e</hosted_login_token>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <vat_number>12345-67</vat_number>
+  <address>
+    <address1>123 Main St.</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94105</zip>
+    <country>US</country>
+    <phone>8015551234</phone>
+  </address>
+</account>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -341,4 +341,51 @@ XML
       account.company_name.must_equal 'My Company Inc.'
     end
   end
+
+  describe 'account hierarchy' do
+    it 'should associate parent account on child creation' do
+      stub_api_request :post, 'accounts', 'accounts/hierarchy/create-201'
+      stub_api_request :get, 'accounts/1234567890', 'accounts/hierarchy/show-parent-200'
+      account = Account.create(
+        :account_code => 'abcdef1234567890',
+        :parent_account_code => '1234567890'
+      )
+      account.parent_account.must_be_instance_of Account
+      account.parent_account.account_code.must_equal '1234567890'
+    end
+
+    it 'should add parent account via update' do
+      stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-200'
+      stub_api_request :put, 'accounts/abcdef1234567890', 'accounts/hierarchy/update-200'
+      stub_api_request :get, 'accounts/1234567890', 'accounts/hierarchy/show-parent-200'
+
+      account = Account.find 'abcdef1234567890'
+      account.parent_account_code = '1234567890'
+      account.save!
+
+      account.parent_account.must_be_instance_of Account
+      account.parent_account.account_code.must_equal '1234567890'
+    end
+
+    it 'should remove parent account via update' do
+      stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/hierarchy/show-child-200'
+      stub_api_request :put, 'accounts/abcdef1234567890', 'accounts/hierarchy/update-no-parent-200'
+
+      account = Account.find 'abcdef1234567890'
+      account.parent_account_code = ''
+      account.save!
+
+      account.parent_account.must_be_nil
+    end
+
+    it 'should list child accounts' do
+      stub_api_request :get, 'accounts/1234567890', 'accounts/hierarchy/show-parent-200'
+      stub_api_request :get, 'accounts/1234567890/child_accounts', 'accounts/hierarchy/show-children-200'
+
+      account = Account.find '1234567890'
+      account.child_accounts.must_be_instance_of Resource::Pager
+      account.child_accounts.first.must_be_instance_of Account
+      account.child_accounts.first.account_code.must_equal 'abcdef1234567890'
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for account hierarchy.


```ruby
account = Recurly::Account.create(
  :account_code => 'example-123',
  :parent_account_code => 'example-124'
)
```