### PR TITLE
Add Amazon Region to Billing Info

### DIFF
--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -5,7 +5,7 @@ module Recurly
   class BillingInfo < Resource
     BANK_ACCOUNT_ATTRIBUTES = %w(name_on_account account_type last_four routing_number).freeze
     CREDIT_CARD_ATTRIBUTES = %w(number verification_value card_type year month first_six last_four).freeze
-    AMAZON_ATTRIBUTES = %w(amazon_billing_agreement_id).freeze
+    AMAZON_ATTRIBUTES = %w(amazon_billing_agreement_id amazon_region).freeze
     PAYPAL_ATTRIBUTES = %w(paypal_billing_agreement_id).freeze
     ROKU_ATTRIBUTES = %w(roku_billing_agreement_id last_four).freeze
 


### PR DESCRIPTION
Adds an additional attribute `amazon_region` to the billing info object.

```ruby
account = Recurly::Account.find('a')
account.billing_info = {
  :first_name         => 'John',
  :last_name          => 'Jacob Jinglheimer Schmidt',
  :address1           => '123 Paper Street',
  :city               => 'Los Angeles',
  :state              => 'CA',
  :zip                => '95312',
  :country            => 'US',
  :phone              => '213-555-5555',
  :amazon_billing_agreement_id => 'C02-2000965-4255444',
  :amazon_region      => 'uk'
}

account.billing_info.save!
```