### PR TITLE
Bump to version 2.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.5"></a>
+## v2.17.5 (2019-01-17)
+
+- Fix typo in Changelog [PR](https://github.com/recurly/recurly-client-ruby/pull/440)
+- Ensure error message for a single returned error [PR](https://github.com/recurly/recurly-client-ruby/pull/441)
+
 <a name="v2.17.4"></a>
 ## v2.17.4 (2018-12-11)
 

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 17
-    PATCH   = 4
+    PATCH   = 5
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
## v2.17.5 (2019-01-17)

- Fix typo in Changelog [PR](https://github.com/recurly/recurly-client-ruby/pull/440)
- Ensure error message for a single returned error [PR](https://github.com/recurly/recurly-client-ruby/pull/441)