### PR TITLE
Add support for Account Acquisition

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -7,6 +7,7 @@ module Recurly
   require 'recurly/shipping_address'
   require 'recurly/billing_info'
   require 'recurly/custom_field'
+  require 'recurly/account_acquisition'
   require 'recurly/account'
   require 'recurly/account_balance'
   require 'recurly/add_on'

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -48,6 +48,9 @@ module Recurly
     # @return [[CustomField], []]
     has_many :custom_fields, class_name: :CustomField, readonly: false
 
+    # @return [AccountAcquisition, nil]
+    has_one :account_acquisition, class_name: :AccountAcquisition, readonly: false
+
     # Get's the first redemption given a coupon code
     # @deprecated Use #{redemptions} instead
     # @param coupon_code [String] The coupon code for the redemption

--- a/lib/recurly/account_acquisition.rb
+++ b/lib/recurly/account_acquisition.rb
@@ -1,0 +1,19 @@
+module Recurly
+  # Recurly Documentation: https://dev.recurly.com/docs/create-account-acquisition
+  class AccountAcquisition < Resource
+    # @return [Account]
+    belongs_to :account
+
+    define_attribute_methods %w(
+      cost_in_cents
+      currency
+      channel
+      subchannel
+      campaign
+    )
+
+    # Acquisitions are only writeable and readable through {Account} instances.
+    embedded!
+    private_class_method :find
+  end
+end

--- a/spec/fixtures/account_acquisition/show-200.xml
+++ b/spec/fixtures/account_acquisition/show-200.xml
@@ -1,0 +1,14 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account_acquisition href="https://api.recurly.com/v2/accounts/abcdef1234567890/acquisition">
+  <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <cost_in_cents type="integer">299</cost_in_cents>
+  <currency>USD</currency>
+  <channel>blog</channel>
+  <subchannel>Whitepaper Blog Post</subchannel>
+  <campaign>mailchimp67a904de95.0914d8f4b4</campaign>
+  <created_at type="datetime">2019-02-11T20:48:54Z</created_at>
+  <updated_at type="datetime">2019-02-11T21:15:09Z</updated_at>
+</account_acquisition>

--- a/spec/fixtures/accounts/show-200.xml
+++ b/spec/fixtures/accounts/show-200.xml
@@ -4,6 +4,7 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
   <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+  <account_acquisition href="https://api.recurly.com/v2/accounts/abcdef1234567890/acquisition"/>
   <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
   <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
   <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -341,4 +341,19 @@ XML
       account.company_name.must_equal 'My Company Inc.'
     end
   end
+
+  describe "account acquisition" do
+    let(:account) {
+      stub_api_request :get, 'accounts/abcdef1234567890', 'accounts/show-200'
+      stub_api_request :get, 'accounts/abcdef1234567890/acquisition', 'account_acquisition/show-200'
+      Account.find 'abcdef1234567890'
+    }
+
+    it 'is able to retrieve and parse acquisition' do
+      acquisition = account.account_acquisition
+      acquisition.cost_in_cents.must_equal 299
+      acquisition.channel.must_equal "blog"
+      acquisition.campaign.must_equal "mailchimp67a904de95.0914d8f4b4"
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for [Account Acquisition](https://docs.recurly.com/docs/account-acquisition-data).

Create script:
```ruby
acct = Recurly::Account.find 'x'

acct.account_acquisition = {
  cost_in_cents: 300,
  currency: "USD",
  channel: "marketing_content",
  subchannel: "The coolest content we have made them sign up!",
  campaign: "mailchimp67a904de95.0914d8f4b4"
}

acct.save!
```
Lookup an account acquisition:
```ruby
acct = Recurly::Account.find 'x'
acquisition = acct.account_acquisition
puts acquisition
```
Update:
```ruby
acct = Recurly::Account.find 'x'

acct.account_acquisition.cost_in_cents = 299
acct.account_acquisition.subchannel = "The 2nd coolest content we have made them sign up!"

acct.account_acquisition.save!
```
Delete:
```ruby
acct = Recurly::Account.find 'x'
if acquisition = acct.account_acquisition
  acquisition.destroy
end
```