### PR TITLE
Release version 2.17.6 / API version 2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.6"></a>
+## v2.17.6 (2019-02-19)
+
+This brings us up to API version 2.18. There are no breaking changes.
+
+- Add support for Amazon Regions [PR](https://github.com/recurly/recurly-client-ruby/pull/445)
+
 <a name="v2.17.5"></a>
 ## v2.17.5 (2019-01-17)
 

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -17,7 +17,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.17'
+    RECURLY_API_VERSION = '2.18'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -5,7 +5,7 @@ module Recurly
   class BillingInfo < Resource
     BANK_ACCOUNT_ATTRIBUTES = %w(name_on_account account_type last_four routing_number).freeze
     CREDIT_CARD_ATTRIBUTES = %w(number verification_value card_type year month first_six last_four).freeze
-    AMAZON_ATTRIBUTES = %w(amazon_billing_agreement_id).freeze
+    AMAZON_ATTRIBUTES = %w(amazon_billing_agreement_id amazon_region).freeze
     PAYPAL_ATTRIBUTES = %w(paypal_billing_agreement_id).freeze
     ROKU_ATTRIBUTES = %w(roku_billing_agreement_id last_four).freeze
 

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 17
-    PATCH   = 5
+    PATCH   = 6
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
## v2.17.6 (2019-02-19)

This brings us up to API version 2.18. There are no breaking changes.

- Add support for Amazon Regions [PR](https://github.com/recurly/recurly-client-ruby/pull/445)