### PR TITLE
Fix link to supported versions section of README

### DIFF
--- a/lib/recurly/xml.rb
+++ b/lib/recurly/xml.rb
@@ -91,7 +91,7 @@ if defined? Nokogiri
     You are attempting to use an insecure version of
     nokogiri on an insecure version of ruby. Please see
     the documentation on supported versions for more information:
-    https://github.com/recurly/recurly-client-ruby#supported-versions
+    https://github.com/recurly/recurly-client-ruby#supported-ruby-versions
 
   MSG
   if RUBY_VERSION < "2.1.0"


### PR DESCRIPTION
When upgrading to a new version of this gem I received the following
message

```
    You are attempting to use an insecure version of
    nokogiri on an insecure version of ruby. Please see
    the documentation on supported versions for more
    information:
    https://github.com/recurly/recurly-client-ruby#supported-versions
```

The anchor `#supported-versions` is incorrect (possibly an older version
of the README.

Here we correct the link with the proper anchor:
[`https://github.com/0xtobit/recurly-client-ruby#supported-ruby-versions`](https://github.com/0xtobit/recurly-client-ruby#supported-ruby-versions)