### PR TITLE
Fix NoMethodError thrown by Resource.invalid!

### DIFF
--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -1068,7 +1068,7 @@ module Recurly
       else
         child, k, v = attribute_path.shift.scan(/[^\[\]=]+/)
         if c = k ? self[child].find { |d| d[k] == v } : self[child]
-          c.invalid! attribute_path, error
+          c.invalid! attribute_path, error if c.methods.include? :invalid!
           e = errors[child] << 'is invalid' and e.uniq!
         end
       end

--- a/spec/fixtures/plans/show-422.xml
+++ b/spec/fixtures/plans/show-422.xml
@@ -1,0 +1,8 @@
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+  <error field="plan.unit_amount_in_cents.BRL" symbol="inclusion">is not accepted by the site</error>
+  <error field="plan.setup_fee_in_cents.BRL" symbol="inclusion">is not accepted by the site</error>
+</errors>

--- a/spec/fixtures/purchases/invoice-422.xml
+++ b/spec/fixtures/purchases/invoice-422.xml
@@ -4,4 +4,5 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <errors>
   <error field="purchase.adjustments[0].unit_amount_in_cents" symbol="not_a_number">is not a number</error>
+  <error field="purchase.subscriptions[0].subscription_add_ons.add_on" symbol="">is invalid</error>
 </errors>

--- a/spec/recurly/plan_spec.rb
+++ b/spec/recurly/plan_spec.rb
@@ -48,4 +48,18 @@ XML
       plan.must_be_instance_of Plan
     end
   end
+
+  describe ".save!" do
+    it "must raise an Invalid error when currency is not enabled on the site" do
+      stub_api_request :get, 'plans/gold', 'plans/show-200'
+      stub_api_request :put, 'plans/gold', 'plans/show-422'
+
+      plan = Plan.find 'gold'
+      plan.unit_amount_in_cents['BRL'] = 329_00
+      proc{plan.save!}.must_raise Resource::Invalid
+
+      plan.errors['unit_amount_in_cents'].must_equal ["is invalid"]
+      plan.errors['setup_fee_in_cents'].must_equal ["is invalid"]
+    end
+  end
 end

--- a/spec/recurly/purchase_spec.rb
+++ b/spec/recurly/purchase_spec.rb
@@ -10,6 +10,15 @@ describe Purchase do
           unit_amount_in_cents: 1_000,
           quantity: 1
         }
+      ],
+      subscriptions: [
+        {
+          plan_code: 'plan_code',
+          subscription_add_ons: [
+            add_on_code: 'add_on_code',
+            unit_amount_in_cents: 200
+          ]
+        }
       ]
     )
   end
@@ -28,6 +37,7 @@ describe Purchase do
       proc {Purchase.invoice!(purchase)}.must_raise Resource::Invalid
       # ensure error details are mapped back
       purchase.adjustments.first.errors["unit_amount_in_cents"].must_equal ["is not a number"]
+      purchase.subscriptions.first.errors["subscription_add_ons"].must_equal ["is invalid"]
     end
     it "should raise a Transaction::Error error when transaction fails" do
       stub_api_request(:post, 'purchases', 'purchases/invoice-declined-422')


### PR DESCRIPTION
Fixes #400 

A `NoMethodError` was being thrown when the `invalid!` method was being called on children of a Resource that are not indeed Resources themselves. There were two examples of this found in the wild:
1) When a purchase was made with a subscription that had an invalid subscription add on, the subscription add on object is a `Pager`, not a `Resource`, and therefore had no `invalid!` method.

2) When a plan was updated with an invalid currency, the `plan.unit_amount_in_cents` is a `Recurly::Money` rather than a `Resource`, and therefore does not have an `invalid!` method.

The library previously assumed that all children of `Resource`s are also `Resource`s. This PR fixes a particular instance of this assumption.

The included specs are similar to the actual reports from #400. The code change was also tested against the actual API and expected behavior was exhibited. Below, please see my test scripts for manual testing:

Purchase with bad add on:
```ruby
# Assumes a plan called "gold" is set up on the account
require_relative './stub'

require 'securerandom'

purchase = Recurly::Purchase.new({
  currency: 'USD',
  collection_method: :automatic,
  po_number: '98675',
  account: {
    account_code: SecureRandom.uuid,
    billing_info: {
      first_name: 'Aaron',
      last_name: 'Du Monde',
      address1: '400 Alabama St',
      city: 'San Francisco',
      state: 'CA',
      zip: '94110',
      country: 'US',
      number: '4111-1111-1111-1111',
      month: 12,
      year: 2019,
    },
  },
  subscriptions: [
    {
      plan_code: "gold",
      subscription_add_ons: [
        add_on_code: 'invalid_code',
        unit_amount_in_cents: 200
      ]
    }
  ]
})

begin
  collection = Recurly::Purchase.invoice!(purchase)
  puts collection.inspect
rescue Recurly::Resource::Invalid => e
  puts e.inspect
  # Invalid data
rescue Recurly::Transaction::Error => e
  puts e.inspect
  # Transaction error
  # e.transaction
  # e.transaction_error_code
end
```
Plan with currency that is not configured on the site:
```ruby
require_relative './stub'
# Assumes that "silver" is a valid plan on the site
# Assumes that currency "BRL" is not configured on the site

plan_code = "silver"
plan = Recurly::Plan.find(plan_code)
plan.unit_amount_in_cents['BRL'] = 329_00
plan.save!
```

