### PR TITLE
Bump to version 2.17.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.7"></a>
+## v2.17.7 (2019-03-07)
+
+- Add support for Account Acquisition [PR](https://github.com/recurly/recurly-client-ruby/pull/450)
+- Fix link to supported versions section of README [PR](https://github.com/recurly/recurly-client-ruby/pull/454)
+- Fix NoMethodError thrown by Resource.invalid! [PR](https://github.com/recurly/recurly-client-ruby/pull/455)
+
 <a name="v2.17.6"></a>
 ## v2.17.6 (2019-02-19)
 

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 17
-    PATCH   = 6
+    PATCH   = 7
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
## v2.17.7 (2019-03-07)

- Add support for Account Acquisition [PR](https://github.com/recurly/recurly-client-ruby/pull/450)
- Fix link to supported versions section of README [PR](https://github.com/recurly/recurly-client-ruby/pull/454)
- Fix NoMethodError thrown by Resource.invalid! [PR](https://github.com/recurly/recurly-client-ruby/pull/455)
