### PR TITLE
Make the set_options method public

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -69,6 +69,15 @@ module Recurly
       end
     end
 
+    def set_options(options)
+      @log_level = options[:log_level] || Logger::WARN
+      @logger = Logger.new(STDOUT)
+      @logger.level = @log_level
+
+      # TODO this is undocumented until we finalize it
+      @extra_headers = options[:headers] || {}
+    end
+
     protected
 
     def pager(path, **options)
@@ -215,15 +224,6 @@ module Recurly
         faraday.basic_auth(api_key, '')
         configure_net_adapter(faraday)
       end
-    end
-
-    def set_options(options)
-      @log_level = options[:log_level] || Logger::WARN
-      @logger = Logger.new(STDOUT)
-      @logger.level = @log_level
-
-      # TODO this is undocumented until we finalize it
-      @extra_headers = options[:headers] || {}
     end
   end
 end


### PR DESCRIPTION
I got the `collect_invoice.rb` script working, but it requires a certain header added to the request. This is a first iteration ("just get it working" kind of thing), so I'm open to other strategies. However, if we want that script to pass, we'll need that header so we need a way to set custom headers on the client somehow. This was the way that seemed built in, so it was minimal work to just make it public.