### PR TITLE
Add fraud_session_id to billing_info

### DIFF
--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -33,6 +33,7 @@ module Recurly
       external_hpp_type
       gateway_token
       gateway_code
+      fraud_session_id
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES
 
     # @return ["credit_card", "paypal", "amazon", "bank_account", "roku", nil] The type of billing info.


### PR DESCRIPTION
This adds a `fraud_session_id` to the `billing_info` object so that this ID can be sent to Kount for merchants who are using that service for fraud prevention.