### PR TITLE
Url Encode Path items

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'logger'
+require 'erb'
 require_relative './schema/json_parser'
 require_relative './client/adapter'
 
@@ -174,6 +175,8 @@ module Recurly
 
     def interpolate_path(path, **options)
       options.each do |k, v|
+        # Check to see that we are passing the correct data types
+        # This prevents a confusing error if the user passes in a non-primitive by mistake
         unless [String, Symbol, Integer, Float].include?(v.class)
           message = "We cannot build the url with the given argument #{k}=#{v.inspect}."
           if k =~ /_id$/
@@ -181,6 +184,8 @@ module Recurly
           end
           raise ArgumentError, message
         end
+        # We need to encode the values for the url
+        options[k] = ERB::Util.url_encode(v.to_s)
       end
       path = path.gsub("{", "%{")
       path % options

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -154,4 +154,25 @@ RSpec.describe Recurly::Client do
       end
     end
   end
+
+  context "with url param needing encoding" do
+    let(:response) do
+      resp = double()
+      allow(resp).to receive(:body) do
+        "{ \"object\": \"account\" }"
+      end
+      allow(resp).to receive(:status) do
+        200
+      end
+      resp
+    end
+
+    describe "#get" do
+      it "should return an account object for get_account even if code has spaces" do
+        expect(client).to receive(:run_request).with(:get, "/sites/subdomain-test/accounts/code-benjamin%20du%20monde", nil, any_args).and_return(response)
+        account = subject.get_account(account_id: "code-benjamin du monde")
+        expect(account).to be_instance_of Recurly::Resources::Account
+      end
+    end
+  end
 end


### PR DESCRIPTION
The items used in `interpolate_path` need to be encoded for the url. Example to demonstrate the problem:

```ruby
  # creates the account fine
  account_code = create_account(code: "benjamin.dumonde@example.com spacehere").code
  # will fail see this as a valid url
  account = @client.get_account(account_id: "code-#{account_code}")
  puts "Got Account #{account}"
```