### PR TITLE
Bump to version 2.17.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.9"></a>
+## v2.17.9 (2019-05-14)
+
+- Add support for fraud session ID [PR](https://github.com/recurly/recurly-client-ruby/pull/471)
+
 <a name="v2.17.8"></a>
 ## v2.17.8 (2019-03-12)
 

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 17
-    PATCH   = 8
+    PATCH   = 9
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
## v2.17.9 (2019-05-14)

- Add support for fraud session ID [PR](https://github.com/recurly/recurly-client-ruby/pull/471)