### PR TITLE
Add format script and check in specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'
+script:
+  - ./scripts/test

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in recurly.gemspec
 gemspec

--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -4,16 +4,16 @@ require "recurly/request"
 require "recurly/resource"
 require "recurly/pager"
 # Include all request files
-resources = File.join(File.dirname(__FILE__), 'recurly', 'requests', '*.rb')
+resources = File.join(File.dirname(__FILE__), "recurly", "requests", "*.rb")
 Dir.glob(resources, &method(:require))
 # Include all resource files
-resources = File.join(File.dirname(__FILE__), 'recurly', 'resources', '*.rb')
+resources = File.join(File.dirname(__FILE__), "recurly", "resources", "*.rb")
 Dir.glob(resources, &method(:require))
 require "recurly/errors"
 require "recurly/client"
 
 module Recurly
-  STRICT_MODE = !ENV['RECURLY_STRICT_MODE'].nil?
+  STRICT_MODE = !ENV["RECURLY_STRICT_MODE"].nil?
   if STRICT_MODE
     puts "[Recurly] [WARNING] STRICT_MODE enabled. This should only be used for testing purposes."
   end

--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -1,12 +1,12 @@
-require 'faraday'
-require 'logger'
-require 'erb'
-require_relative './schema/json_parser'
-require_relative './client/adapter'
+require "faraday"
+require "logger"
+require "erb"
+require_relative "./schema/json_parser"
+require_relative "./client/adapter"
 
 module Recurly
   class Client
-    require_relative './client/operations'
+    require_relative "./client/operations"
 
     BASE_URL = "https://partner-api.recurly.com/"
 
@@ -95,15 +95,15 @@ module Recurly
       raise_network_error!(ex)
     end
 
-    def put(path, request_data=nil, request_class=nil, **options)
+    def put(path, request_data = nil, request_class = nil, **options)
       response = if request_data
-        request = request_class.new(request_data)
-        request.validate!
-        logger.info("PUT BODY #{JSON.dump(request_data)}")
-        run_request(:put, path, JSON.dump(request_data), headers)
-      else
-        run_request(:put, path, nil, headers)
-      end
+                   request = request_class.new(request_data)
+                   request.validate!
+                   logger.info("PUT BODY #{JSON.dump(request_data)}")
+                   run_request(:put, path, JSON.dump(request_data), headers)
+                 else
+                   run_request(:put, path, nil, headers)
+                 end
       raise_api_error!(response) unless (200...300).include?(response.status)
       JSONParser.parse(self, response.body)
     rescue Faraday::ClientError => ex
@@ -156,20 +156,20 @@ module Recurly
     end
 
     def read_headers(response)
-      @rate_limit = response.headers['x-ratelimit-limit'].to_i
-      @rate_limit_remaining = response.headers['x-ratelimit-remaining'].to_i
-      @rate_limit_reset = Time.at(response.headers['x-ratelimit-reset'].to_i).to_datetime
-      if !@_ignore_deprecation_warning && response.headers['Recurly-Deprecated']&.upcase == 'TRUE'
-        puts "[recurly-client-ruby] WARNING: Your current API version \"#{api_version}\" is deprecated and will be sunset on #{response.headers['Recurly-Sunset-Date']}"
+      @rate_limit = response.headers["x-ratelimit-limit"].to_i
+      @rate_limit_remaining = response.headers["x-ratelimit-remaining"].to_i
+      @rate_limit_reset = Time.at(response.headers["x-ratelimit-reset"].to_i).to_datetime
+      if !@_ignore_deprecation_warning && response.headers["Recurly-Deprecated"]&.upcase == "TRUE"
+        puts "[recurly-client-ruby] WARNING: Your current API version \"#{api_version}\" is deprecated and will be sunset on #{response.headers["Recurly-Sunset-Date"]}"
       end
       response
     end
 
     def headers
       {
-        'Accept' => "application/vnd.recurly.#{api_version}", # got this method from operations.rb
-        'Content-Type' => 'application/json',
-        'User-Agent' => "Recurly/#{VERSION}; #{RUBY_DESCRIPTION}"
+        "Accept" => "application/vnd.recurly.#{api_version}", # got this method from operations.rb
+        "Content-Type" => "application/json",
+        "User-Agent" => "Recurly/#{VERSION}; #{RUBY_DESCRIPTION}",
       }.merge(@extra_headers)
     end
 
@@ -205,19 +205,19 @@ module Recurly
       options = {
         url: BASE_URL,
         request: { timeout: 60, open_timeout: 50 },
-        ssl: { verify: true }
+        ssl: { verify: true },
       }
       # Let's not use the bundled cert in production yet
       # but we will use these certs for any other staging or dev environment
-      unless BASE_URL.end_with?('.recurly.com')
-        options[:ssl][:ca_file] = File.join(File.dirname(__FILE__), '../data/ca-certificates.crt')
+      unless BASE_URL.end_with?(".recurly.com")
+        options[:ssl][:ca_file] = File.join(File.dirname(__FILE__), "../data/ca-certificates.crt")
       end
 
       @conn = Faraday.new(options) do |faraday|
         if [Logger::DEBUG, Logger::INFO].include?(@log_level)
           faraday.response :logger
         end
-        faraday.basic_auth(api_key, '')
+        faraday.basic_auth(api_key, "")
         configure_net_adapter(faraday)
       end
     end

--- a/lib/recurly/client/adapter.rb
+++ b/lib/recurly/client/adapter.rb
@@ -1,9 +1,10 @@
-require 'openssl'
+require "openssl"
 
 module Recurly
   class Client
     module NetHttpPersistentAdapter
       protected
+
       def configure_net_adapter(faraday)
         faraday.adapter :net_http_persistent do |http|
           # yields Net::HTTP::Persistent
@@ -19,6 +20,7 @@ module Recurly
 
     module NetHttpAdapter
       protected
+
       def configure_net_adapter(faraday)
         faraday.adapter :net_http do |http|
           # yields Net::HTTP
@@ -29,7 +31,7 @@ module Recurly
     include NetHttpAdapter
 
     begin
-      require 'net/http/persistent'
+      require "net/http/persistent"
       include NetHttpPersistentAdapter
     rescue LoadError
     end

--- a/lib/recurly/errors.rb
+++ b/lib/recurly/errors.rb
@@ -12,7 +12,7 @@ module Recurly
       # @param error_key [String]
       # @return [Errors::APIError,Errors::NetworkError]
       def self.error_class(error_key)
-        class_name = error_key.split('_').map(&:capitalize).join
+        class_name = error_key.split("_").map(&:capitalize).join
         class_name += "Error" unless class_name.end_with?("Error")
         Errors.const_get(class_name)
       end

--- a/lib/recurly/pager.rb
+++ b/lib/recurly/pager.rb
@@ -72,11 +72,11 @@ module Recurly
     private
 
     def from_json(data)
-      @data = data['data'].map do |resource_data|
+      @data = data["data"].map do |resource_data|
         JSONParser.from_json(resource_data)
       end
-      @next = data['next']
-      @has_more = data['has_more']
+      @next = data["next"]
+      @has_more = data["has_more"]
     end
 
     def item_enumerator

--- a/lib/recurly/schema.rb
+++ b/lib/recurly/schema.rb
@@ -88,7 +88,7 @@ module Recurly
       # @return [String]
       attr_accessor :description
 
-      def initialize(name, type, options={}, description=nil)
+      def initialize(name, type, options = {}, description = nil)
         @name = name
         @type = type
         @options = options
@@ -113,9 +113,8 @@ module Recurly
     private_constant :Attribute
   end
 
-
-  require_relative './schema/schema_factory'
-  require_relative './schema/schema_validator'
-  require_relative './schema/json_deserializer'
-  require_relative './schema/request_caster'
+  require_relative "./schema/schema_factory"
+  require_relative "./schema/schema_validator"
+  require_relative "./schema/json_deserializer"
+  require_relative "./schema/request_caster"
 end

--- a/lib/recurly/schema/json_deserializer.rb
+++ b/lib/recurly/schema/json_deserializer.rb
@@ -1,4 +1,4 @@
-require 'date'
+require "date"
 
 module Recurly
   class Schema
@@ -18,7 +18,7 @@ module Recurly
       def from_json(attributes = {})
         resource = new()
         attributes.each do |attr_name, val|
-          next if attr_name == 'object'
+          next if attr_name == "object"
 
           schema_attr = self.schema.get_attribute(attr_name)
 

--- a/lib/recurly/schema/json_parser.rb
+++ b/lib/recurly/schema/json_parser.rb
@@ -1,4 +1,4 @@
-require 'json'
+require "json"
 
 module Recurly
   # This is a wrapper class to help parse responses into Recurly objects.
@@ -23,7 +23,7 @@ module Recurly
       type = if data.has_key?("error")
                "error"
              else
-               data.delete('object')
+               data.delete("object")
              end
       klazz = self.recurly_class(type)
 
@@ -52,10 +52,10 @@ module Recurly
       case type
       when nil
         nil
-      when 'list'
+      when "list"
         Pager
       else
-        type_camelized = type.split('_').map(&:capitalize).join
+        type_camelized = type.split("_").map(&:capitalize).join
         if Resources.const_defined?(type_camelized)
           klazz = Resources.const_get(type_camelized)
           if klazz.ancestors.include?(Resource)

--- a/lib/recurly/schema/request_caster.rb
+++ b/lib/recurly/schema/request_caster.rb
@@ -1,4 +1,4 @@
-require 'date'
+require "date"
 
 module Recurly
   class Schema
@@ -25,13 +25,13 @@ module Recurly
       # @param data [Hash,Resource,Request] The data to transform into a JSON Hash.
       # @param schema [Schema] The schema to use to transform the data into a JSON Hash.
       # @return [Hash] The pure Hash ready to be serialized into JSON.
-      def cast(data, schema=self.schema)
+      def cast(data, schema = self.schema)
         casted = {}
         if data.is_a?(Resource) || data.is_a?(Request)
           data = as_json(data, schema)
         end
 
-        data.each do |k,v|
+        data.each do |k, v|
           schema_attr = schema.get_attribute(k)
           norm_val = if v.respond_to?(:attributes)
                        cast(v, schema_attr.recurly_class.schema)
@@ -59,7 +59,7 @@ module Recurly
 
       def as_json(resource, schema)
         writeable_attributes = schema.attributes.reject(&:read_only?).map(&:name)
-        resource.attributes.select { |k,_| writeable_attributes.include?(k) }
+        resource.attributes.select { |k, _| writeable_attributes.include?(k) }
       end
     end
   end

--- a/lib/recurly/schema/schema_factory.rb
+++ b/lib/recurly/schema/schema_factory.rb
@@ -28,7 +28,7 @@ module Recurly
       #   acount.code = "newcode" # this method protected since read_only = true
       #   account.code
       #   #=> "mycode"
-      def define_attribute(name, type, options={})
+      def define_attribute(name, type, options = {})
         attribute = schema.add_attribute(name, type, options)
 
         # Define the reader

--- a/lib/recurly/schema/schema_validator.rb
+++ b/lib/recurly/schema/schema_validator.rb
@@ -118,7 +118,7 @@ module Recurly
           while j < m
             cost = (char1 == str2_codepoints[j]) ? 0 : 1
             x = min3(
-              d[j+1] + 1, # insertion
+              d[j + 1] + 1, # insertion
               i + 1,      # deletion
               d[j] + cost # substitution
             )
@@ -145,4 +145,3 @@ module Recurly
     end
   end
 end
-

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -1,20 +1,20 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'recurly/version'
+require "recurly/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "recurly"
-  spec.version       = Recurly::VERSION
-  spec.authors       = ["Recurly"]
-  spec.email         = ["support@recurly.com"]
+  spec.name = "recurly"
+  spec.version = Recurly::VERSION
+  spec.authors = ["Recurly"]
+  spec.email = ["support@recurly.com"]
 
-  spec.summary       = "The ruby client for Recurly's Partner API"
-  spec.description   = "The ruby client for Recurly's Partner API"
-  spec.homepage      = "https://partner-docs.recurly.com"
-  spec.license       = "MIT"
+  spec.summary = "The ruby client for Recurly's Partner API"
+  spec.description = "The ruby client for Recurly's Partner API"
+  spec.homepage = "https://partner-docs.recurly.com"
+  spec.license = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
   # spec.bindir        = "exe"
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", "~> 0.9"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "simplecov", "~> 0.16"
+  spec.add_development_dependency "rufo", "~> 0.7"
 end

--- a/scripts/format
+++ b/scripts/format
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+if [ "$1" == "--check" ]; then
+  rufo . --check
+else
+  rufo . -x
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,3 +1,14 @@
 #!/usr/bin/env bash
 
-./bin/rspec
+# First check formatting
+echo "Checking style..."
+./scripts/format --check
+if [ $? -ne 0 ]; then
+  echo "Code does not conform to style guide. To autoformat, run './scripts/format'."
+  exit 1
+else
+  echo "Style check passed"
+fi
+
+# Run tests
+rake spec

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 RSpec.describe Recurly::Client do
-  let(:subdomain) { 'test' }
-  let(:api_key) { 'recurly-good' }
+  let(:subdomain) { "test" }
+  let(:api_key) { "recurly-good" }
   subject(:client) { Recurly::Client.new(api_key: api_key, subdomain: subdomain) }
 
   context "#api_version" do
@@ -26,7 +26,7 @@ RSpec.describe Recurly::Client do
 
     describe "headers" do
       it "should include the necessary headers in each request" do
-        expected = hash_including('Accept' => /application\/vnd\.recurly/, 'Content-Type' => 'application/json', 'User-Agent' => /Recurly\//)
+        expected = hash_including("Accept" => /application\/vnd\.recurly/, "Content-Type" => "application/json", "User-Agent" => /Recurly\//)
         expect(client).to receive(:run_request).with(:get, "/sites/subdomain-test/accounts/code-benjamin-du-monde", nil, expected).and_return(response)
         _account = subject.get_account(account_id: "code-benjamin-du-monde")
       end

--- a/spec/recurly/errors_spec.rb
+++ b/spec/recurly/errors_spec.rb
@@ -1,12 +1,11 @@
 require "spec_helper"
-require 'date'
-
+require "date"
 
 RSpec.describe Recurly::Errors::APIError do
   describe ".error_class" do
     error_keys = Recurly::Errors.constants - [:APIError]
     error_keys = error_keys.map do |key|
-      key.to_s.split(/(?=[A-Z])/).map(&:downcase).join('_')
+      key.to_s.split(/(?=[A-Z])/).map(&:downcase).join("_")
     end
 
     error_keys.each do |error_key|

--- a/spec/recurly/pager_spec.rb
+++ b/spec/recurly/pager_spec.rb
@@ -1,12 +1,12 @@
 require "spec_helper"
-require 'date'
+require "date"
 
 RSpec.describe Recurly::Pager do
-  let(:subdomain) { 'test' }
-  let(:api_key) { 'recurly-good' }
+  let(:subdomain) { "test" }
+  let(:api_key) { "recurly-good" }
   let(:client) { Recurly::Client.new(api_key: api_key, subdomain: subdomain) }
-  let(:path) { '/next_url' }
-  let(:options) { {a: 1, b: DateTime.new(2020,1,1)} }
+  let(:path) { "/next_url" }
+  let(:options) { { a: 1, b: DateTime.new(2020, 1, 1) } }
   subject do
     Recurly::Pager.new(client: client, path: path, options: options)
   end

--- a/spec/recurly/request_spec.rb
+++ b/spec/recurly/request_spec.rb
@@ -1,18 +1,17 @@
 require "spec_helper"
 
 RSpec.describe Recurly::Request do
-
   let(:hash_data) do
     {
       a_string: "A String",
-      a_hash: {a: 1, b: 2},
+      a_hash: { a: 1, b: 2 },
       an_integer: 42,
       a_float: 4.2,
       a_boolean: false,
       a_datetime: DateTime.new(2020, 1, 1),
       a_string_array: %w(I am a string array),
-      a_sub_request: { a_string: "SubResource String"},
-      a_sub_request_array: [{a_string: "SubResource String"}]
+      a_sub_request: { a_string: "SubResource String" },
+      a_sub_request_array: [{ a_string: "SubResource String" }],
     }
   end
 
@@ -80,7 +79,7 @@ RSpec.describe Recurly::Request do
           expect { subject.validate! }.to raise_error(/Attribute 'a_floa' does not exist on request Recurly::Requests::MyRequest. Did you mean 'a_float'?/)
         end
         it "should raise an error with did_you_mean description" do
-          hash_data[:a_string_arra] = ['string']
+          hash_data[:a_string_arra] = ["string"]
           expect { subject.validate! }.to raise_error(ArgumentError)
           expect { subject.validate! }.to raise_error(/Attribute 'a_string_arra' does not exist on request Recurly::Requests::MyRequest. Did you mean 'a_string_array'?/)
         end
@@ -143,12 +142,12 @@ RSpec.describe Recurly::Request do
     end
     context "with mixed types" do
       it "should not cast the Resource to a Hash" do
-        hash_data[:a_sub_request] = Recurly::Requests::MySubRequest.new(a_string: 'a_string')
-        hash_data[:a_sub_request_array] = [Recurly::Requests::MySubRequest.new(a_string: 'a_string')]
+        hash_data[:a_sub_request] = Recurly::Requests::MySubRequest.new(a_string: "a_string")
+        hash_data[:a_sub_request_array] = [Recurly::Requests::MySubRequest.new(a_string: "a_string")]
         casted = Recurly::Requests::MyRequest.cast(hash_data)
         expect(casted).to_not eql(hash_data)
-        expect(casted[:a_sub_request]).to eql(a_string: 'a_string')
-        expect(casted[:a_sub_request_array]).to eql([a_string: 'a_string'])
+        expect(casted[:a_sub_request]).to eql(a_string: "a_string")
+        expect(casted[:a_sub_request_array]).to eql([a_string: "a_string"])
       end
     end
   end

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Recurly::Resource do
       {
         "object" => "my_resource",
         "a_string" => "A String",
-        "a_hash" => {"a" => 1, "b" => 2},
+        "a_hash" => { "a" => 1, "b" => 2 },
         "an_integer" => 42,
         "a_float" => 4.2,
         "a_boolean" => false,
         "a_datetime" => DateTime.new(2020, 1, 1),
         "a_string_array" => %w(I am a string array),
-        "a_sub_resource" => { "a_string" => "SubResource String", "object" => "my_sub_resource"},
-        "a_sub_resource_array" => [{"a_string" => "SubResource String", "object" => "my_sub_resource"}]
+        "a_sub_resource" => { "a_string" => "SubResource String", "object" => "my_sub_resource" },
+        "a_sub_resource_array" => [{ "a_string" => "SubResource String", "object" => "my_sub_resource" }],
       }
     end
 

--- a/spec/recurly/schema/json_parser_spec.rb
+++ b/spec/recurly/schema/json_parser_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Recurly::JSONParser do
   let(:json_data) { '{"object": "my_resource", "a_string": "A String"}' }
   let(:client) {
-    Recurly::Client.new(subdomain: 'test', api_key: 'test123')
+    Recurly::Client.new(subdomain: "test", api_key: "test123")
   }
 
   describe ".parse" do
@@ -22,14 +22,14 @@ RSpec.describe Recurly::JSONParser do
       end
     end
     context "when the resource is an error" do
-      let(:resource) { Recurly::Resources::Error.new(message: 'A String') }
+      let(:resource) { Recurly::Resources::Error.new(message: "A String") }
       let(:json_data) { '{"error": {"message": "A String"}}' }
       it { is_expected.to eq(resource) }
     end
     context "when the class can't be found" do
       let(:json_data) { '{"object": "unknown"}' }
       it "should raise an ArgumentError" do
-        expect{subject}.to raise_error(ArgumentError)
+        expect { subject }.to raise_error(ArgumentError)
       end
     end
   end
@@ -41,15 +41,15 @@ RSpec.describe Recurly::JSONParser do
       it { is_expected.to eq nil }
     end
     context "when type is list" do
-      let(:type) { 'list' }
+      let(:type) { "list" }
       it { is_expected.to eq Recurly::Pager }
     end
     context "when type is known class type" do
-      let(:type) { 'my_resource' }
+      let(:type) { "my_resource" }
       it { is_expected.to eq Recurly::Resources::MyResource }
     end
     context "when type is unknown class type" do
-      let(:type) { 'unknown' }
+      let(:type) { "unknown" }
       it { is_expected.to eq nil }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,15 @@
-require 'bundler/setup'
-require 'simplecov'
+require "bundler/setup"
+require "simplecov"
 SimpleCov.start do
   # we will ignore this generated file
   add_filter "lib/recurly/client/operations.rb"
 end
-require 'recurly'
-require_relative './test_schemas'
+require "recurly"
+require_relative "./test_schemas"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = '.rspec_status'
+  config.example_status_persistence_file_path = ".rspec_status"
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/test_schemas.rb
+++ b/spec/test_schemas.rb
@@ -27,6 +27,7 @@ end
 class Recurly::Resources::MyResourceWithClient < Recurly::Resource
   attr_accessor :client
   define_attribute :a_string, String
+
   def requires_client?; true end
 end
 
@@ -44,4 +45,3 @@ class Recurly::Resources::MyResource < Recurly::Resource
   define_attribute :a_sub_resource, :MySubResource
   define_attribute :a_sub_resource_array, Array, item_type: :MySubResource
 end
-


### PR DESCRIPTION
Adds `./script/format` and runs `./script/format --check` before running tests to ensure code is always formatted.