### PR TITLE
Add 3DS tokens to transaction error and billing info

### DIFF
--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -34,6 +34,7 @@ module Recurly
       gateway_token
       gateway_code
       fraud_session_id
+      three_d_secure_action_result_token_id
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES
 
     # @return ["credit_card", "paypal", "amazon", "bank_account", "roku", nil] The type of billing info.

--- a/lib/recurly/transaction/errors.rb
+++ b/lib/recurly/transaction/errors.rb
@@ -85,12 +85,20 @@ module Recurly
     class DuplicateError < DeclinedError
     end
 
+    # Raised when a 3DS result token is needed to complete a transaction
+    class ThreeDSecureError < DeclinedError
+      def three_d_secure_action_token_id
+        xml.text '/errors/transaction_error/three_d_secure_action_token_id'
+      end
+    end
+
     class << Error
       CATEGORY_MAP = Hash.new DeclinedError
       CATEGORY_MAP.update(
-        'communication' => RetryableError,
-        'configuration' => ConfigurationError,
-        'duplicate'     => DuplicateError
+        'communication'             => RetryableError,
+        'configuration'             => ConfigurationError,
+        'duplicate'                 => DuplicateError,
+        '3d_secure_action_required' => ThreeDSecureError
       )
 
       def validate! exception, transaction


### PR DESCRIPTION
This allows the client to use the new 3DSecure features of the API. This involves a 2 step flow with RecurlyJS, see https://github.com/recurly/recurly-js/pull/527 for technical details on that side of this process.

Script 1: Attempt to update a billing info with a credit card that requires 3DS authentication:
```ruby
account = Recurly::Account.find('x')
account.billing_info = {
  :first_name         => 'Verena',
  :last_name          => 'Example',
  :address1           => '123 Paper Street',
  :city               => 'Los Angeles',
  :state              => 'CA',
  :zip                => '95312',
  :country            => 'US',
  :phone              => '555-555-5555',
  :number             => '4000000000003220',
  :verification_value => '123'
}

begin
  account.billing_info.save!
rescue Recurly::Transaction::ThreeDSecureError => e
  puts e.three_d_secure_action_token_id # get the id to give to RJS
end
```

The `ThreeDSecureError` will contain a `three_d_secure_action_token_id`, which needs to be passed to RJS for authentication. Upon successful authentication, RJS will return a result token, which can then be passed with the billing info.

Script 2: Update the billing info using 3DS:
```ruby
account = Recurly::Account.find('x')
account.billing_info = {
  :first_name         => 'Verena',
  :last_name          => 'Example',
  :address1           => '123 Paper Street',
  :city               => 'Los Angeles',
  :state              => 'CA',
  :zip                => '95312',
  :country            => 'US',
  :phone              => '213-555-5555',
  :number             => '4000000000003220',
  :verification_value => '123',
  :three_d_secure_action_result_token_id => 'So7IeX6R0vkEegtTmge4cA' # value from RJS
}

account.billing_info.save
```

This flow still applies when passing a `billing_info` object to the `/accounts`, `/subscriptions`, and `/purchases` endpoints.