### PR TITLE
Release version 2.17.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.17.11"></a>
+## v2.17.11 (2019-06-27)
+
+This brings us up to API version 2.21. There are no breaking changes.
+
+- Add support for 3DS authenticated transactions [PR](https://github.com/recurly/recurly-client-ruby/pull/479)
+
 <a name="v2.17.10"></a>
 ## v2.17.10 (2019-05-21)
 

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -17,7 +17,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.20'
+    RECURLY_API_VERSION = '2.21'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -34,6 +34,7 @@ module Recurly
       gateway_token
       gateway_code
       fraud_session_id
+      three_d_secure_action_result_token_id
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES
 
     # @return ["credit_card", "paypal", "amazon", "bank_account", "roku", nil] The type of billing info.

--- a/lib/recurly/transaction/errors.rb
+++ b/lib/recurly/transaction/errors.rb
@@ -85,12 +85,20 @@ module Recurly
     class DuplicateError < DeclinedError
     end
 
+    # Raised when a 3DS result token is needed to complete a transaction
+    class ThreeDSecureError < DeclinedError
+      def three_d_secure_action_token_id
+        xml.text '/errors/transaction_error/three_d_secure_action_token_id'
+      end
+    end
+
     class << Error
       CATEGORY_MAP = Hash.new DeclinedError
       CATEGORY_MAP.update(
-        'communication' => RetryableError,
-        'configuration' => ConfigurationError,
-        'duplicate'     => DuplicateError
+        'communication'             => RetryableError,
+        'configuration'             => ConfigurationError,
+        'duplicate'                 => DuplicateError,
+        '3d_secure_action_required' => ThreeDSecureError
       )
 
       def validate! exception, transaction

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -2,7 +2,7 @@ module Recurly
   module Version
     MAJOR   = 2
     MINOR   = 17
-    PATCH   = 10
+    PATCH   = 11
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
<a name="v2.17.11"></a>
## v2.17.11 (2019-06-27)

This brings us up to API version 2.21. There are no breaking changes.

- Add support for 3DS authenticated transactions [PR](https://github.com/recurly/recurly-client-ruby/pull/479)