### PR TITLE
CurrencyArrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,33 @@ rescue Recurly::Errors::NotFoundError => e
 end
 ```
 
+### CurrencyArrays
+
+Pricings in the API are often presented as an array of objects. As a convenience, this library will turn these into
+a CurrencyArray. This class is a subclass of Array that allows you to index by currency. Example, consider this plan with
+a currencies attribute:
+
+```ruby
+plan
+#=> #<Recurly::Resources::Plan:0x0000556b25c2ca28
+#=> @attributes=
+#=>  {
+#=>  #...
+#=>  :currencies=>[#<Recurly::Requests::PlanPricing:0x0000556b25c21538 @attributes={:currency=>"USD", :setup_fee=>1000.0, :unit_amount=>234.0}>],
+#=>  #...
+#=>  }>
+```
+
+You can now fetch a PlanPricing by currency rather than searching the array or knowing the index:
+
+```ruby
+plan.currencies[:usd].unit_amount # 234.0
+plan.currencies[:USD].unit_amount # 234.0
+plan.currencies["USD"].unit_amount # 234.0
+# positional index still works
+plan.currencies[0].unit_amount # 234.0
+```
+
 ### Contributing
 
 Please see our [Contributing Guide](CONTRIBUTING.md).

--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -1,4 +1,5 @@
 require "recurly/version"
+require "recurly/currency_array"
 require "recurly/schema"
 require "recurly/request"
 require "recurly/resource"

--- a/lib/recurly/currency_array.rb
+++ b/lib/recurly/currency_array.rb
@@ -1,0 +1,16 @@
+module Recurly
+  #
+  # A special subclass of Array which allows
+  # indexing by currency. Only works if the item
+  # type response to `currency`.
+  class CurrencyArray < Array
+    def [](key)
+      if key.is_a?(Symbol) || key.is_a?(String)
+        key = key.to_s.upcase
+        self.find { |c| c.currency.upcase == key }
+      else
+        super key
+      end
+    end
+  end
+end

--- a/lib/recurly/schema.rb
+++ b/lib/recurly/schema.rb
@@ -53,21 +53,6 @@ module Recurly
       end
     end
 
-    # Describes a list attribute type
-    class List
-      # The type of the elements of the list
-      # @return [Symbol]
-      attr_accessor :item_type
-
-      def initialize(item_type)
-        @item_type = item_type
-      end
-
-      def to_s
-        "List<#{item_type}>"
-      end
-    end
-
     # Describes and attribute for a schema.
     class Attribute
       # The name of the attribute.
@@ -100,16 +85,15 @@ module Recurly
       end
 
       def recurly_class
-        Schema.get_recurly_class(type == Array ? options[:item_type] : type)
+        Schema.get_recurly_class(options[:item_type] || type)
       end
 
       def is_primitive?
-        t = type == Array ? options[:item_type] : type
+        t = options[:item_type] || type
         t.is_a?(Class) || t == :Boolean
       end
     end
 
-    private_constant :List
     private_constant :Attribute
   end
 

--- a/lib/recurly/schema/json_deserializer.rb
+++ b/lib/recurly/schema/json_deserializer.rb
@@ -27,12 +27,19 @@ module Recurly
             val = if val.is_a?(Hash) && !schema_attr.is_primitive?
                     schema_attr.recurly_class.from_json(val)
                   elsif val.is_a?(Array)
-                    val.map do |e|
+                    items = val.map do |e|
                       if e.is_a?(Hash) && !schema_attr.is_primitive?
                         schema_attr.recurly_class.from_json(e)
                       else
                         e
                       end
+                    end
+                    # If the item type has a "currency" key, let's assume we can
+                    # safely index by currency and return a CurrencyArray
+                    if !schema_attr.is_primitive? && schema_attr.recurly_class.schema.get_attribute(:currency)
+                      CurrencyArray.new(items)
+                    else
+                      items
                     end
                   elsif val && schema_attr.type == DateTime && val.is_a?(String)
                     DateTime.parse(val)

--- a/lib/recurly/schema/schema_validator.rb
+++ b/lib/recurly/schema/schema_validator.rb
@@ -83,6 +83,8 @@ module Recurly
         int_class = Kernel.const_get(int_class)
 
         case [from_type, to_type]
+        when [Array, CurrencyArray]
+          true
         when [Symbol, String]
           true
         when [int_class, Float]

--- a/spec/recurly/currency_array_spec.rb
+++ b/spec/recurly/currency_array_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe Recurly::CurrencyArray do
+  subject do
+    Recurly::CurrencyArray.new([
+      Recurly::Resources::MyPricing.new(currency: "USD", amount: 123),
+      Recurly::Resources::MyPricing.new(currency: "EUR", amount: 456),
+    ])
+  end
+
+  it "is a normal Array" do
+    expect(subject).to be_a Array
+    expect(subject.length).to eq 2
+  end
+
+  it "can be indexed by currency" do
+    expect(subject[:usd].amount).to eq 123
+    expect(subject[:USD].amount).to eq 123
+    expect(subject["USD"].amount).to eq 123
+    expect(subject[:eur].amount).to eq 456
+    expect(subject[:EUR].amount).to eq 456
+    expect(subject["EUR"].amount).to eq 456
+  end
+end

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -73,6 +73,39 @@ RSpec.describe Recurly::Resource do
         expect(subject.send(:a_sub_resource_array)).to eq([Recurly::Resources::MySubResource.from_json({ "a_string" => "SubResource String" })])
       end
     end
+
+    context "with currencies" do
+      let(:json_data) {
+        {
+          "pricing" => [
+            {
+              "currency" => "USD",
+              "amount" => 123,
+            },
+            {
+              "currency" => "EUR",
+              "amount" => 456,
+            },
+          ],
+        }
+      }
+
+      describe "pricing" do
+        it "should be a CurrencyArray" do
+          expect(subject.pricing).to be_instance_of Recurly::CurrencyArray
+        end
+      end
+      describe "a_string_array" do
+        it "should not be a CurrencyArray" do
+          expect(subject.a_string_array).to_not be_instance_of Recurly::CurrencyArray
+        end
+      end
+      describe "a_sub_resource_array" do
+        it "should not be a CurrencyArray" do
+          expect(subject.a_sub_resource_array).to_not be_instance_of Recurly::CurrencyArray
+        end
+      end
+    end
   end
 
   context "resource type" do

--- a/spec/test_schemas.rb
+++ b/spec/test_schemas.rb
@@ -44,4 +44,13 @@ class Recurly::Resources::MyResource < Recurly::Resource
   # Sub Resources
   define_attribute :a_sub_resource, :MySubResource
   define_attribute :a_sub_resource_array, Array, item_type: :MySubResource
+
+  # Special CurrencyArray
+  define_attribute :pricing, Array, item_type: :MyPricing
+end
+
+# These must be in the Recurly::Resources namespace
+class Recurly::Resources::MyPricing < Recurly::Resource
+  define_attribute :currency, String
+  define_attribute :amount, Integer
 end


### PR DESCRIPTION
Pricings in the API are often presented as an array of objects. As a convenience, this library will turn these into
a CurrencyArray. This class is a subclass of Array that allows you to index by currency. Example, consider this plan with
a currencies attribute:

```ruby
plan
#=> #<Recurly::Resources::Plan:0x0000556b25c2ca28
#=> @attributes=
#=>  {
#=>  #...
#=>  :currencies=>[#<Recurly::Requests::PlanPricing:0x0000556b25c21538 @attributes={:currency=>"USD", :setup_fee=>1000.0, :unit_amount=>234.0}>],
#=>  #...
#=>  }>
```

You can now fetch a PlanPricing by currency rather than searching the array or knowing the index:

```ruby
plan.currencies[:usd].unit_amount # 234.0
plan.currencies[:USD].unit_amount # 234.0
plan.currencies["USD"].unit_amount # 234.0
# positional index still works
plan.currencies[0].unit_amount # 234.0
```
