### PR TITLE
Changes for Vertex customers

### DIFF
--- a/lib/recurly/adjustment.rb
+++ b/lib/recurly/adjustment.rb
@@ -54,6 +54,7 @@ module Recurly
       credit_reason_code
       original_adjustment_uuid
       shipping_address_id
+      surcharge_in_cents
     )
     alias to_param uuid
 

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -109,6 +109,7 @@ module Recurly
       dunning_events_count
       final_dunning_event
       gateway_code
+      surcharge_in_cents
     )
     alias to_param invoice_number_with_prefix
 

--- a/lib/recurly/juris_detail.rb
+++ b/lib/recurly/juris_detail.rb
@@ -7,6 +7,7 @@ module Recurly
       tax_in_cents
       sub_type
       jurisdiction_name
+      classification
     )
 
     embedded! true

--- a/lib/recurly/tax_type.rb
+++ b/lib/recurly/tax_type.rb
@@ -5,6 +5,7 @@ module Recurly
       tax_in_cents
       type
       juris_details
+      tax_classification
     )
 
     embedded! true

--- a/spec/fixtures/adjustments/show-200-taxed.xml
+++ b/spec/fixtures/adjustments/show-200-taxed.xml
@@ -25,6 +25,7 @@ Content-Type: application/xml; charset=utf-8
       <type>General Sales and Use Tax</type>
       <juris_details type="array">
         <juris_detail>
+          <classification>tax</classification>
           <jurisdiction>STATE</jurisdiction>
           <jurisdiction_name nil="nil"></jurisdiction_name>
           <tax_in_cents type="integer">115</tax_in_cents>
@@ -32,6 +33,7 @@ Content-Type: application/xml; charset=utf-8
           <rate type="float">0.056</rate>
         </juris_detail>
         <juris_detail>
+          <classification>tax</classification>
           <jurisdiction>COUNTY</jurisdiction>
           <jurisdiction_name nil="nil"></jurisdiction_name>
           <tax_in_cents type="integer">10</tax_in_cents>
@@ -39,6 +41,7 @@ Content-Type: application/xml; charset=utf-8
           <rate type="float">0.005</rate>
         </juris_detail>
         <juris_detail>
+          <classification>tax</classification>
           <jurisdiction>DISTRICT</jurisdiction>
           <jurisdiction_name nil="nil"></jurisdiction_name>
           <tax_in_cents type="integer">103</tax_in_cents>

--- a/spec/fixtures/adjustments/show-200.xml
+++ b/spec/fixtures/adjustments/show-200.xml
@@ -23,6 +23,7 @@ Content-Type: application/xml; charset=utf-8
   <currency>USD</currency>
   <product_code>basic</product_code>
   <revenue_schedule_type>evenly</revenue_schedule_type>
+  <surcharge_in_cents type="integer">100</surcharge_in_cents>
   <tax_details type="array">
     <tax_detail>
       <name>california</name>

--- a/spec/fixtures/invoices/show-200-taxed.xml
+++ b/spec/fixtures/invoices/show-200-taxed.xml
@@ -23,17 +23,17 @@ Content-Type: application/xml; charset=utf-8
   <refund_geo_code>ABC123</refund_geo_code>
   <tax_types type="array">
     <tax_type>
-      <type>STATE</type>
+      <tax_classification>surcharge</tax_classification>
       <tax_in_cents type="integer">115</tax_in_cents>
       <description>Sales Tax</description>
     </tax_type>
     <tax_type>
-      <type>COUNTY</type>
+      <tax_classification>surcharge</tax_classification>
       <tax_in_cents type="integer">10</tax_in_cents>
       <description>Sales Tax</description>
     </tax_type>
     <tax_type>
-      <type>DISTRICT</type>
+      <tax_classification>surcharge</tax_classification>
       <tax_in_cents type="integer">103</tax_in_cents>
       <description>Sales Tax</description>
     </tax_type>

--- a/spec/fixtures/invoices/show-200.xml
+++ b/spec/fixtures/invoices/show-200.xml
@@ -31,6 +31,7 @@ Content-Type: application/xml; charset=utf-8
   <subtotal_after_discount_in_cents type="integer">300</subtotal_after_discount_in_cents>
   <attempt_next_collection_at nil="nil"></attempt_next_collection_at>
   <recovery_reason nil="nil"></recovery_reason>
+  <surcharge_in_cents type="integer">100</surcharge_in_cents>
   <tax_types nil="nil"></tax_types>
   <line_items>
     <adjustment href="https://api.recurly.com/v2/adjustments/charge" type="charge">

--- a/spec/recurly/adjustment_spec.rb
+++ b/spec/recurly/adjustment_spec.rb
@@ -24,6 +24,7 @@ describe Adjustment do
       adjustment.tax_rate.must_equal 0.0875
       adjustment.revenue_schedule_type.must_equal 'evenly'
       adjustment.proration_rate.must_equal 0.5
+      adjustment.surcharge_in_cents.must_equal 100
 
       tax_details = adjustment.tax_details
       tax_details.length.must_equal 2
@@ -69,6 +70,7 @@ describe Adjustment do
       tax_type.juris_details.length.must_equal 3
 
       juris_detail = tax_type.juris_details.first
+      juris_detail.classification.must_equal 'tax'
       juris_detail.jurisdiction.must_equal 'STATE'
       juris_detail.tax_in_cents[:USD].must_equal 115
       juris_detail.rate.must_equal 0.056

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -32,6 +32,12 @@ describe Invoice do
       invoice.credit_payments.first.must_be_instance_of CreditPayment
     end
 
+    it 'should have surcharge_in_cents' do
+      stub_api_request :get, 'invoices/1000', 'invoices/show-200'
+      invoice = Invoice.find('1000')
+      invoice.surcharge_in_cents.must_equal 100
+    end
+
     it 'includes the invoice number prefix' do
       stub_api_request :get, 'invoices/invoice-with-prefix', 'invoices/show-200-prefix'
 
@@ -61,7 +67,7 @@ describe Invoice do
 
         tax_type = tax_types.first
         tax_type.must_be_instance_of TaxType
-        tax_type.type.must_equal 'STATE'
+        tax_type.tax_classification.must_equal 'surcharge'
         tax_type.tax_in_cents[:USD].must_equal 115
         tax_type.description.must_equal 'Sales Tax'
       end


### PR DESCRIPTION
This change only applies to customers with a Vertex integration (taxes).

Added fields
============

- `Adjustment#surcharge_in_cents`
- `Invoice#surcharge_in_cents`
- `TaxType#tax_classification`
- `JurisDetail#classification`

Removed Field
============

- `Invoice#tax_types[].type` on invoice and preview invoice endpoints.

Removes TaxType#type for invoices only, not adjustments. This is a breaking change but only for Vertex users. All other users can ignore this change.