### PR TITLE
Subscription timeframe changes

### DIFF
--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -176,15 +176,17 @@ module Recurly
 
     # Cancel a subscription so that it will not renew.
     #
+    # @param [String] optional timeframe. Choose one of "bill_date" or "term_end"
     # @return [true, false] +true+ when successful, +false+ when unable to
     #   (e.g., the subscription is not active).
     # @example
     #   account = Account.find account_code
     #   subscription = account.subscriptions.first
     #   subscription.cancel # => true
-    def cancel
+    def cancel(timeframe = nil)
       return false unless link? :cancel
-      reload follow_link :cancel
+      params = timeframe.nil? ? {} : { 'timeframe': timeframe }
+      reload follow_link :cancel, params: params
       true
     end
 

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -184,6 +184,16 @@ describe Subscription do
       it "won't cancel an inactive subscription" do
         inactive.cancel.must_equal false
       end
+
+      it "will send the timeframe parameter if given" do
+        stub_api_request(
+          :put,
+          'subscriptions/abcdef1234567890/cancel?timeframe=term_end',
+          'subscriptions/show-200'
+        )
+
+        active.cancel('term_end').must_equal true
+      end
     end
 
     describe "#terminate" do


### PR DESCRIPTION
Adds "term_end" to the Timeframe values. This affects
Subscription#update, Subscription#preview and Subscription#cancel.

Subscription#update and Subscription#preview have been updated to no longer accept the "renewal" value for timeframe.
Instead, merchants will be able to send timeframes of "bill_date" or "term_end".
These timeframes are aligned to "current_period_ends_at" and "current_term_ends_at", respectively.

Subscription#cancel has been updated to accept the "timeframe" parameter. It accepts values of "bill_date" or "term_end".