### PR TITLE
MOTO transactions

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -94,6 +94,7 @@ module Recurly
       has_past_due_invoice
       has_paused_subscription
       preferred_locale
+      transaction_type
     )
     alias to_param account_code
 

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -35,6 +35,7 @@ module Recurly
       gateway_code
       fraud_session_id
       three_d_secure_action_result_token_id
+      transaction_type
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES
 
     # @return ["credit_card", "paypal", "amazon", "bank_account", "roku", nil] The type of billing info.

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -142,11 +142,20 @@ module Recurly
 
     # Initiate a collection attempt on an invoice.
     #
+    # @example
+    #   # Optionally set transaction type
+    #   invoice.force_collect(transaction_type: 'moto')
+    #
+    # @param options [Hash] Optional set of details to send to collect endpoint.
     # @return [true, false] +true+ when successful, +false+ when unable to
     #   (e.g., the invoice is no longer open).
-    def force_collect
+    def force_collect(options = {})
       return false unless link? :force_collect
-      reload follow_link :force_collect
+      http_opts = {}
+      if options[:transaction_type]
+        http_opts[:body] = transaction_type_xml(options[:transaction_type])
+      end
+      reload follow_link(:force_collect, http_opts)
       true
     end
 
@@ -263,6 +272,12 @@ module Recurly
         adj_node.add_element 'quantity', line_item[:quantity]
         adj_node.add_element 'prorate', line_item[:prorate]
       end
+      builder.to_s
+    end
+
+    def transaction_type_xml(transaction_type)
+      builder = XML.new("<invoice/>")
+      builder.add_element 'transaction_type', transaction_type.to_s
       builder.to_s
     end
 

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -140,6 +140,7 @@ module Recurly
       vat_reverse_charge_notes
       shipping_address_id
       gateway_code
+      transaction_type
     )
 
     class << self

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -97,6 +97,7 @@ module Recurly
       total_amount_in_cents
       resume_at
       gateway_code
+      transaction_type
     )
     alias to_param uuid
 

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -161,6 +161,15 @@ describe Invoice do
     end
   end
 
+  describe "#force_collect" do
+    it "must call /collect with body" do
+      stub_api_request :get, 'invoices/1000', 'invoices/show-200'
+      stub_api_request :put, 'invoices/created-invoice/collect', 'invoices/show-200-updated'
+      invoice = Invoice.find(1000)
+      invoice.force_collect(transaction_type: 'moto')
+    end
+  end
+
   describe "#save" do
     it "must update an invoice" do
       stub_api_request :get, 'invoices/1000', 'invoices/show-200'

--- a/spec/recurly/purchase_spec.rb
+++ b/spec/recurly/purchase_spec.rb
@@ -4,6 +4,7 @@ describe Purchase do
   let(:purchase) do
     Purchase.new(
       account: {account_code: 'account123'},
+      transaction_type: 'moto',
       adjustments: [
         {
           product_code: 'product_code',


### PR DESCRIPTION
As a part of PSD2, there is an exemption to exclude MOTO transactions from SCA scope.
In order to pass this indicator to the gateways, merchants need a mechanism via API
to inform Recurly of these transactions. These transactions will be initiated from
within a merchants customer service / support admin portal UI, where the customer
is not authenticated to be able to complete an SCA flow.

This is exposed to the programmer as `transaction_type` on many of the resources. Set the value to `moto` to mark the transaction as MOTO. Ex use with purchases:

```ruby
purchase = Recurly::Purchase.new({
  currency: 'USD',
  transaction_type: 'moto',
  account: {
    account_code: "existingaccount",
  }
  subscriptions: [{ plan_code: "gold" }]
})
collection = Recurly::Purchase.invoice!(purchase)
```