### PR TITLE
Release version 2.18.0 / API version 2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.0"></a>
+## v2.18.0 (2019-08-21)
+
+This bumps us to API version 2.22.
+
+* MOTO transactions [PR](//github.com/recurly/recurly-client-ruby/pull/493)
+* Changes for Vertex customers [PR](https://github.com/recurly/recurly-client-ruby/pull/491)
+
+There is one breaking change. It only applies to Vertex users so will not likely affect you.
+`Invoice#tax_types[].type` on invoice and preview invoice endpoints is no longer returned.
+
+
 <a name="v2.17.11"></a>
 ## v2.17.11 (2019-06-27)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.17'
+gem 'recurly', '~> 2.18'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -94,6 +94,7 @@ module Recurly
       has_past_due_invoice
       has_paused_subscription
       preferred_locale
+      transaction_type
     )
     alias to_param account_code
 

--- a/lib/recurly/adjustment.rb
+++ b/lib/recurly/adjustment.rb
@@ -54,6 +54,7 @@ module Recurly
       credit_reason_code
       original_adjustment_uuid
       shipping_address_id
+      surcharge_in_cents
     )
     alias to_param uuid
 

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -17,7 +17,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.21'
+    RECURLY_API_VERSION = '2.22'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -35,6 +35,7 @@ module Recurly
       gateway_code
       fraud_session_id
       three_d_secure_action_result_token_id
+      transaction_type
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES
 
     # @return ["credit_card", "paypal", "amazon", "bank_account", "roku", nil] The type of billing info.

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -109,6 +109,7 @@ module Recurly
       dunning_events_count
       final_dunning_event
       gateway_code
+      surcharge_in_cents
     )
     alias to_param invoice_number_with_prefix
 

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -143,11 +143,20 @@ module Recurly
 
     # Initiate a collection attempt on an invoice.
     #
+    # @example
+    #   # Optionally set transaction type
+    #   invoice.force_collect(transaction_type: 'moto')
+    #
+    # @param options [Hash] Optional set of details to send to collect endpoint.
     # @return [true, false] +true+ when successful, +false+ when unable to
     #   (e.g., the invoice is no longer open).
-    def force_collect
+    def force_collect(options = {})
       return false unless link? :force_collect
-      reload follow_link :force_collect
+      http_opts = {}
+      if options[:transaction_type]
+        http_opts[:body] = transaction_type_xml(options[:transaction_type])
+      end
+      reload follow_link(:force_collect, http_opts)
       true
     end
 
@@ -264,6 +273,12 @@ module Recurly
         adj_node.add_element 'quantity', line_item[:quantity]
         adj_node.add_element 'prorate', line_item[:prorate]
       end
+      builder.to_s
+    end
+
+    def transaction_type_xml(transaction_type)
+      builder = XML.new("<invoice/>")
+      builder.add_element 'transaction_type', transaction_type.to_s
       builder.to_s
     end
 

--- a/lib/recurly/juris_detail.rb
+++ b/lib/recurly/juris_detail.rb
@@ -7,6 +7,7 @@ module Recurly
       tax_in_cents
       sub_type
       jurisdiction_name
+      classification
     )
 
     embedded! true

--- a/lib/recurly/purchase.rb
+++ b/lib/recurly/purchase.rb
@@ -140,6 +140,7 @@ module Recurly
       vat_reverse_charge_notes
       shipping_address_id
       gateway_code
+      transaction_type
     )
 
     class << self

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -97,6 +97,7 @@ module Recurly
       total_amount_in_cents
       resume_at
       gateway_code
+      transaction_type
     )
     alias to_param uuid
 

--- a/lib/recurly/tax_type.rb
+++ b/lib/recurly/tax_type.rb
@@ -5,6 +5,7 @@ module Recurly
       tax_in_cents
       type
       juris_details
+      tax_classification
     )
 
     embedded! true

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,8 +1,8 @@
 module Recurly
   module Version
     MAJOR   = 2
-    MINOR   = 17
-    PATCH   = 11
+    MINOR   = 18
+    PATCH   = 0
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze

--- a/spec/fixtures/adjustments/show-200-taxed.xml
+++ b/spec/fixtures/adjustments/show-200-taxed.xml
@@ -25,6 +25,7 @@ Content-Type: application/xml; charset=utf-8
       <type>General Sales and Use Tax</type>
       <juris_details type="array">
         <juris_detail>
+          <classification>tax</classification>
           <jurisdiction>STATE</jurisdiction>
           <jurisdiction_name nil="nil"></jurisdiction_name>
           <tax_in_cents type="integer">115</tax_in_cents>
@@ -32,6 +33,7 @@ Content-Type: application/xml; charset=utf-8
           <rate type="float">0.056</rate>
         </juris_detail>
         <juris_detail>
+          <classification>tax</classification>
           <jurisdiction>COUNTY</jurisdiction>
           <jurisdiction_name nil="nil"></jurisdiction_name>
           <tax_in_cents type="integer">10</tax_in_cents>
@@ -39,6 +41,7 @@ Content-Type: application/xml; charset=utf-8
           <rate type="float">0.005</rate>
         </juris_detail>
         <juris_detail>
+          <classification>tax</classification>
           <jurisdiction>DISTRICT</jurisdiction>
           <jurisdiction_name nil="nil"></jurisdiction_name>
           <tax_in_cents type="integer">103</tax_in_cents>

--- a/spec/fixtures/adjustments/show-200.xml
+++ b/spec/fixtures/adjustments/show-200.xml
@@ -23,6 +23,7 @@ Content-Type: application/xml; charset=utf-8
   <currency>USD</currency>
   <product_code>basic</product_code>
   <revenue_schedule_type>evenly</revenue_schedule_type>
+  <surcharge_in_cents type="integer">100</surcharge_in_cents>
   <tax_details type="array">
     <tax_detail>
       <name>california</name>

--- a/spec/fixtures/invoices/show-200-taxed.xml
+++ b/spec/fixtures/invoices/show-200-taxed.xml
@@ -23,17 +23,17 @@ Content-Type: application/xml; charset=utf-8
   <refund_geo_code>ABC123</refund_geo_code>
   <tax_types type="array">
     <tax_type>
-      <type>STATE</type>
+      <tax_classification>surcharge</tax_classification>
       <tax_in_cents type="integer">115</tax_in_cents>
       <description>Sales Tax</description>
     </tax_type>
     <tax_type>
-      <type>COUNTY</type>
+      <tax_classification>surcharge</tax_classification>
       <tax_in_cents type="integer">10</tax_in_cents>
       <description>Sales Tax</description>
     </tax_type>
     <tax_type>
-      <type>DISTRICT</type>
+      <tax_classification>surcharge</tax_classification>
       <tax_in_cents type="integer">103</tax_in_cents>
       <description>Sales Tax</description>
     </tax_type>

--- a/spec/fixtures/invoices/show-200.xml
+++ b/spec/fixtures/invoices/show-200.xml
@@ -31,6 +31,7 @@ Content-Type: application/xml; charset=utf-8
   <subtotal_after_discount_in_cents type="integer">300</subtotal_after_discount_in_cents>
   <attempt_next_collection_at nil="nil"></attempt_next_collection_at>
   <recovery_reason nil="nil"></recovery_reason>
+  <surcharge_in_cents type="integer">100</surcharge_in_cents>
   <tax_types nil="nil"></tax_types>
   <line_items>
     <adjustment href="https://api.recurly.com/v2/adjustments/charge" type="charge">

--- a/spec/recurly/adjustment_spec.rb
+++ b/spec/recurly/adjustment_spec.rb
@@ -24,6 +24,7 @@ describe Adjustment do
       adjustment.tax_rate.must_equal 0.0875
       adjustment.revenue_schedule_type.must_equal 'evenly'
       adjustment.proration_rate.must_equal 0.5
+      adjustment.surcharge_in_cents.must_equal 100
 
       tax_details = adjustment.tax_details
       tax_details.length.must_equal 2
@@ -69,6 +70,7 @@ describe Adjustment do
       tax_type.juris_details.length.must_equal 3
 
       juris_detail = tax_type.juris_details.first
+      juris_detail.classification.must_equal 'tax'
       juris_detail.jurisdiction.must_equal 'STATE'
       juris_detail.tax_in_cents[:USD].must_equal 115
       juris_detail.rate.must_equal 0.056

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -167,6 +167,15 @@ describe Invoice do
     end
   end
 
+  describe "#force_collect" do
+    it "must call /collect with body" do
+      stub_api_request :get, 'invoices/1000', 'invoices/show-200'
+      stub_api_request :put, 'invoices/created-invoice/collect', 'invoices/show-200-updated'
+      invoice = Invoice.find(1000)
+      invoice.force_collect(transaction_type: 'moto')
+    end
+  end
+
   describe "#save" do
     it "must update an invoice" do
       stub_api_request :get, 'invoices/1000', 'invoices/show-200'

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -32,6 +32,12 @@ describe Invoice do
       invoice.credit_payments.first.must_be_instance_of CreditPayment
     end
 
+    it 'should have surcharge_in_cents' do
+      stub_api_request :get, 'invoices/1000', 'invoices/show-200'
+      invoice = Invoice.find('1000')
+      invoice.surcharge_in_cents.must_equal 100
+    end
+
     it 'includes the invoice number prefix' do
       stub_api_request :get, 'invoices/invoice-with-prefix', 'invoices/show-200-prefix'
 
@@ -61,7 +67,7 @@ describe Invoice do
 
         tax_type = tax_types.first
         tax_type.must_be_instance_of TaxType
-        tax_type.type.must_equal 'STATE'
+        tax_type.tax_classification.must_equal 'surcharge'
         tax_type.tax_in_cents[:USD].must_equal 115
         tax_type.description.must_equal 'Sales Tax'
       end

--- a/spec/recurly/purchase_spec.rb
+++ b/spec/recurly/purchase_spec.rb
@@ -4,6 +4,7 @@ describe Purchase do
   let(:purchase) do
     Purchase.new(
       account: {account_code: 'account123'},
+      transaction_type: 'moto',
       adjustments: [
         {
           product_code: 'product_code',


### PR DESCRIPTION
## v2.18.0 (2019-08-21)

This bumps us to API version 2.22.

* MOTO transactions #493
* Changes for Vertex customers #491

There is one breaking change. It only applies to Vertex users so will not likely affect you.
`Invoice#tax_types[].type` on invoice and preview invoice endpoints is no longer returned.
