### PR TITLE
Only set strict mode when env explicitly true

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -10,7 +10,7 @@ require "recurly/errors"
 require "recurly/client"
 
 module Recurly
-  STRICT_MODE = !ENV["RECURLY_STRICT_MODE"].nil?
+  STRICT_MODE = ENV["RECURLY_STRICT_MODE"] && ENV["RECURLY_STRICT_MODE"].downcase == "true"
   if STRICT_MODE
     puts "[Recurly] [WARNING] STRICT_MODE enabled. This should only be used for testing purposes."
   end


### PR DESCRIPTION
Forces you to be explicit when setting strict mode. This means you can set RECURLY_STRICT_MODE=false and it will be disabled. This is for testing only and has no effect on users.