### PR TITLE
Remove the site-id constraint from Client

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,21 +24,18 @@ initialized clients.
 This makes multithreaded environments simpler and provides one location where every
 operation can be found (rather than having them spread out among classes).
 
-`Recurly::Client#new` initializes a new client. It requires an API key and a site id:
+`Recurly::Client#new` initializes a new client. It only requires an API key:
 
 ```ruby
 API_KEY = '83749879bbde395b5fe0cc1a5abf8e5'
-SITE_ID = 'dqzlv9shi7wa'
-client = Recurly::Client.new(site_id: SITE_ID, api_key: API_KEY)
-# You may use the subdomain instead of the site_id if you do not know the site_id
-client = Recurly::Client.new(subdomain: 'mysite-prod', api_key: API_KEY)
+client = Recurly::Client.new(api_key: API_KEY)
 sub = client.get_subscription(subscription_id: 'abcd123456')
 ```
 
 You can also pass the initializer a block. This will give you a client scoped for just that block:
 
 ```ruby
-Recurly::Client.new(subdomain: 'mysite-prod', api_key: API_KEY) do |client|
+Recurly::Client.new(api_key: API_KEY) do |client|
   sub = client.get_subscription(subscription_id: 'abcd123456')
 end
 ```
@@ -46,15 +43,11 @@ end
 If you plan on using the client for more than one site, you should initialize a new client for each site.
 
 ```ruby
-# Give a `site_id`
-client = Recurly::Client.new(api_key: API_KEY, site_id: SITE_ID)
-# Or use the subdomain
-client = Recurly::Client.new(api_key: API_KEY, subdomain: 'mysite-dev') 
-
+client = Recurly::Client.new(api_key: API_KEY1) 
 sub = client.get_subscription(subscription_id: 'abcd123456')
 
 # you should create a new client to connect to another site
-client = Recurly::Client.new(api_key: API_KEY, subdomain: 'mysite-prod') 
+client = Recurly::Client.new(api_key: API_KEY2) 
 sub = client.get_subscription(subscription_id: 'abcd7890')
 ```
 
@@ -166,7 +159,7 @@ You will normally be working with {Recurly::Errors::APIError}. You can catch spe
 
 ```ruby
 begin
-  client = Recurly::Client.new(site_id: SITE_ID, api_key: API_KEY)
+  client = Recurly::Client.new(api_key: API_KEY)
   code = "iexistalready"
   plan_data = {
     code: code,

--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -46,8 +46,9 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_site get_site api documenation}
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Site] A site.
-    def get_site()
+    def get_site(site_id:)
       path = interpolate_path("/sites/{site_id}", site_id: site_id)
       get(path)
     end
@@ -84,6 +85,7 @@ module Recurly
     #   +canceled+, or +future+ state.
     #
     # @param past_due [String] Filter for accounts with an invoice in the +past_due+ state.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Account>] A list of the site's accounts.
     # @example
     #   accounts = @client.list_accounts(limit: 200)
@@ -92,7 +94,7 @@ module Recurly
     #   end
     #
     def list_accounts(**options)
-      path = interpolate_path("/sites/{site_id}/accounts", site_id: site_id)
+      path = interpolate_path("/accounts")
       pager(path, **options)
     end
 
@@ -101,6 +103,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/create_account create_account api documenation}
     #
     # @param body [Requests::AccountCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AccountCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -138,9 +141,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def create_account(body:)
-      path = interpolate_path("/sites/{site_id}/accounts", site_id: site_id)
-      post(path, body, Requests::AccountCreate)
+    def create_account(body:, **options)
+      path = interpolate_path("/accounts")
+      post(path, body, Requests::AccountCreate, **options)
     end
 
     # Fetch an account
@@ -148,6 +151,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_account get_account api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -159,9 +163,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_account(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}", site_id: site_id, account_id: account_id)
-      get(path)
+    def get_account(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}", account_id: account_id)
+      get(path, **options)
     end
 
     # Modify an account
@@ -170,6 +174,7 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param body [Requests::AccountUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AccountUpdate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -188,9 +193,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def update_account(account_id:, body:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}", site_id: site_id, account_id: account_id)
-      put(path, body, Requests::AccountUpdate)
+    def update_account(account_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}", account_id: account_id)
+      put(path, body, Requests::AccountUpdate, **options)
     end
 
     # Deactivate an account
@@ -198,6 +203,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/deactivate_account deactivate_account api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -209,9 +215,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def deactivate_account(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}", site_id: site_id, account_id: account_id)
-      delete(path)
+    def deactivate_account(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}", account_id: account_id)
+      delete(path, **options)
     end
 
     # Fetch an account's acquisition data
@@ -219,6 +225,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_account_acquisition get_account_acquisition api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::AccountAcquisition] An account's acquisition data.
     # @example
     #   begin
@@ -230,9 +237,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_account_acquisition(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/acquisition", site_id: site_id, account_id: account_id)
-      get(path)
+    def get_account_acquisition(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/acquisition", account_id: account_id)
+      get(path, **options)
     end
 
     # Update an account's acquisition data
@@ -241,10 +248,11 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param body [Requests::AccountAcquisitionUpdatable] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AccountAcquisitionUpdatable}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::AccountAcquisition] An account's updated acquisition data.
-    def update_account_acquisition(account_id:, body:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/acquisition", site_id: site_id, account_id: account_id)
-      put(path, body, Requests::AccountAcquisitionUpdatable)
+    def update_account_acquisition(account_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}/acquisition", account_id: account_id)
+      put(path, body, Requests::AccountAcquisitionUpdatable, **options)
     end
 
     # Remove an account's acquisition data
@@ -252,6 +260,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/remove_account_acquisition remove_account_acquisition api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Empty] Acquisition data was succesfully deleted.
     # @example
     #   begin
@@ -263,9 +272,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def remove_account_acquisition(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/acquisition", site_id: site_id, account_id: account_id)
-      delete(path)
+    def remove_account_acquisition(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/acquisition", account_id: account_id)
+      delete(path, **options)
     end
 
     # Reactivate an inactive account
@@ -273,6 +282,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/reactivate_account reactivate_account api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -284,9 +294,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def reactivate_account(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/reactivate", site_id: site_id, account_id: account_id)
-      put(path)
+    def reactivate_account(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/reactivate", account_id: account_id)
+      put(path, **options)
     end
 
     # Fetch an account's balance and past due status
@@ -294,6 +304,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_account_balance get_account_balance api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::AccountBalance] An account's balance.
     # @example
     #   begin
@@ -305,9 +316,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_account_balance(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/balance", site_id: site_id, account_id: account_id)
-      get(path)
+    def get_account_balance(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/balance", account_id: account_id)
+      get(path, **options)
     end
 
     # Fetch an account's billing information
@@ -315,6 +326,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_billing_info get_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::BillingInfo] An account's billing information.
     # @example
     #   begin
@@ -326,9 +338,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_billing_info(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/billing_info", site_id: site_id, account_id: account_id)
-      get(path)
+    def get_billing_info(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/billing_info", account_id: account_id)
+      get(path, **options)
     end
 
     # Set an account's billing information
@@ -337,6 +349,7 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param body [Requests::BillingInfoCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::BillingInfoCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::BillingInfo] Updated billing information.
     # @example
     #   begin
@@ -355,9 +368,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def update_billing_info(account_id:, body:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/billing_info", site_id: site_id, account_id: account_id)
-      put(path, body, Requests::BillingInfoCreate)
+    def update_billing_info(account_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}/billing_info", account_id: account_id)
+      put(path, body, Requests::BillingInfoCreate, **options)
     end
 
     # Remove an account's billing information
@@ -365,6 +378,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/remove_billing_info remove_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Empty] Billing information deleted
     # @example
     #   begin
@@ -376,9 +390,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def remove_billing_info(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/billing_info", site_id: site_id, account_id: account_id)
-      delete(path)
+    def remove_billing_info(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/billing_info", account_id: account_id)
+      delete(path, **options)
     end
 
     # Show the coupon redemptions for an account
@@ -408,6 +422,7 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::CouponRedemption>] A list of the the coupon redemptions on an account.
     # @example
     #   redemptions = @client.list_account_coupon_redemptions(
@@ -419,7 +434,7 @@ module Recurly
     #   end
     #
     def list_account_coupon_redemptions(account_id:, **options)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/coupon_redemptions", site_id: site_id, account_id: account_id)
+      path = interpolate_path("/accounts/{account_id}/coupon_redemptions", account_id: account_id)
       pager(path, **options)
     end
 
@@ -428,6 +443,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_active_coupon_redemption get_active_coupon_redemption api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::CouponRedemption] An active coupon redemption on an account.
     # @example
     #   begin
@@ -439,9 +455,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_active_coupon_redemption(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/coupon_redemptions/active", site_id: site_id, account_id: account_id)
-      get(path)
+    def get_active_coupon_redemption(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/coupon_redemptions/active", account_id: account_id)
+      get(path, **options)
     end
 
     # Generate an active coupon redemption on an account
@@ -450,6 +466,7 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param body [Requests::CouponRedemptionCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::CouponRedemptionCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::CouponRedemption] Returns the new coupon redemption.
     # @example
     #   begin
@@ -468,9 +485,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def create_coupon_redemption(account_id:, body:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/coupon_redemptions/active", site_id: site_id, account_id: account_id)
-      post(path, body, Requests::CouponRedemptionCreate)
+    def create_coupon_redemption(account_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}/coupon_redemptions/active", account_id: account_id)
+      post(path, body, Requests::CouponRedemptionCreate, **options)
     end
 
     # Delete the active coupon redemption from an account
@@ -478,6 +495,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/remove_coupon_redemption remove_coupon_redemption api documenation}
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::CouponRedemption] Coupon redemption deleted.
     # @example
     #   begin
@@ -489,9 +507,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def remove_coupon_redemption(account_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/coupon_redemptions/active", site_id: site_id, account_id: account_id)
-      delete(path)
+    def remove_coupon_redemption(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/coupon_redemptions/active", account_id: account_id)
+      delete(path, **options)
     end
 
     # List an account's credit payments
@@ -511,6 +529,7 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::CreditPayment>] A list of the account's credit payments.
     # @example
     #   payments = @client.list_account_credit_payments(
@@ -522,7 +541,7 @@ module Recurly
     #   end
     #
     def list_account_credit_payments(account_id:, **options)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/credit_payments", site_id: site_id, account_id: account_id)
+      path = interpolate_path("/accounts/{account_id}/credit_payments", account_id: account_id)
       pager(path, **options)
     end
 
@@ -561,6 +580,7 @@ module Recurly
     #   - +type=non-legacy+, only charge and credit invoices will be returned.
     #   - +type=legacy+, only legacy invoices will be returned.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Invoice>] A list of the account's invoices.
     # @example
     #   invoices = @client.list_account_invoices(
@@ -572,7 +592,7 @@ module Recurly
     #   end
     #
     def list_account_invoices(account_id:, **options)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/invoices", site_id: site_id, account_id: account_id)
+      path = interpolate_path("/accounts/{account_id}/invoices", account_id: account_id)
       pager(path, **options)
     end
 
@@ -582,6 +602,7 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param body [Requests::InvoiceCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::InvoiceCollection] Returns the new invoices.
     # @example
     #   begin
@@ -600,9 +621,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def create_invoice(account_id:, body:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/invoices", site_id: site_id, account_id: account_id)
-      post(path, body, Requests::InvoiceCreate)
+    def create_invoice(account_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}/invoices", account_id: account_id)
+      post(path, body, Requests::InvoiceCreate, **options)
     end
 
     # Preview new invoice for pending line items
@@ -611,6 +632,7 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param body [Requests::InvoiceCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::InvoiceCollection] Returns the invoice previews.
     # @example
     #   begin
@@ -629,9 +651,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def preview_invoice(account_id:, body:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/invoices/preview", site_id: site_id, account_id: account_id)
-      post(path, body, Requests::InvoiceCreate)
+    def preview_invoice(account_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}/invoices/preview", account_id: account_id)
+      post(path, body, Requests::InvoiceCreate, **options)
     end
 
     # List an account's line items
@@ -666,6 +688,7 @@ module Recurly
     # @param original [String] Filter by original field.
     # @param state [String] Filter by state field.
     # @param type [String] Filter by type field.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::LineItem>] A list of the account's line items.
     # @example
     #   line_items = @client.list_account_line_items(
@@ -677,7 +700,7 @@ module Recurly
     #   end
     #
     def list_account_line_items(account_id:, **options)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/line_items", site_id: site_id, account_id: account_id)
+      path = interpolate_path("/accounts/{account_id}/line_items", account_id: account_id)
       pager(path, **options)
     end
 
@@ -687,6 +710,7 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param body [Requests::LineItemCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::LineItemCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::LineItem] Returns the new line item.
     # @example
     #   begin
@@ -706,9 +730,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def create_line_item(account_id:, body:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/line_items", site_id: site_id, account_id: account_id)
-      post(path, body, Requests::LineItemCreate)
+    def create_line_item(account_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}/line_items", account_id: account_id)
+      post(path, body, Requests::LineItemCreate, **options)
     end
 
     # Fetch a list of an account's notes
@@ -728,6 +752,7 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::AccountNote>] A list of an account's notes.
     # @example
     #   account_notes = @client.list_account_notes(account_id: account_id, limit: 200)
@@ -736,7 +761,7 @@ module Recurly
     #   end
     #
     def list_account_notes(account_id:, **options)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/notes", site_id: site_id, account_id: account_id)
+      path = interpolate_path("/accounts/{account_id}/notes", account_id: account_id)
       pager(path, **options)
     end
 
@@ -746,6 +771,7 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param account_note_id [String] Account Note ID.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::AccountNote] An account note.
     # @example
     #   begin
@@ -760,9 +786,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_account_note(account_id:, account_note_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/notes/{account_note_id}", site_id: site_id, account_id: account_id, account_note_id: account_note_id)
-      get(path)
+    def get_account_note(account_id:, account_note_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/notes/{account_note_id}", account_id: account_id, account_note_id: account_note_id)
+      get(path, **options)
     end
 
     # Fetch a list of an account's shipping addresses
@@ -794,6 +820,7 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::ShippingAddress>] A list of an account's shipping addresses.
     # @example
     #   shipping_addresses = @client.list_shipping_addresses(
@@ -805,7 +832,7 @@ module Recurly
     #   end
     #
     def list_shipping_addresses(account_id:, **options)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/shipping_addresses", site_id: site_id, account_id: account_id)
+      path = interpolate_path("/accounts/{account_id}/shipping_addresses", account_id: account_id)
       pager(path, **options)
     end
 
@@ -815,10 +842,11 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param body [Requests::ShippingAddressCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::ShippingAddressCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::ShippingAddress] Returns the new shipping address.
-    def create_shipping_address(account_id:, body:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/shipping_addresses", site_id: site_id, account_id: account_id)
-      post(path, body, Requests::ShippingAddressCreate)
+    def create_shipping_address(account_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}/shipping_addresses", account_id: account_id)
+      post(path, body, Requests::ShippingAddressCreate, **options)
     end
 
     # Fetch an account's shipping address
@@ -827,6 +855,7 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param shipping_address_id [String] Shipping Address ID.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::ShippingAddress] A shipping address.
     # @example
     #   begin
@@ -841,9 +870,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_shipping_address(account_id:, shipping_address_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/shipping_addresses/{shipping_address_id}", site_id: site_id, account_id: account_id, shipping_address_id: shipping_address_id)
-      get(path)
+    def get_shipping_address(account_id:, shipping_address_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", account_id: account_id, shipping_address_id: shipping_address_id)
+      get(path, **options)
     end
 
     # Update an account's shipping address
@@ -853,6 +882,7 @@ module Recurly
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param shipping_address_id [String] Shipping Address ID.
     # @param body [Requests::ShippingAddressUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::ShippingAddressUpdate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::ShippingAddress] The updated shipping address.
     # @example
     #   begin
@@ -873,9 +903,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def update_shipping_address(account_id:, shipping_address_id:, body:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/shipping_addresses/{shipping_address_id}", site_id: site_id, account_id: account_id, shipping_address_id: shipping_address_id)
-      put(path, body, Requests::ShippingAddressUpdate)
+    def update_shipping_address(account_id:, shipping_address_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", account_id: account_id, shipping_address_id: shipping_address_id)
+      put(path, body, Requests::ShippingAddressUpdate, **options)
     end
 
     # Remove an account's shipping address
@@ -884,6 +914,7 @@ module Recurly
     #
     # @param account_id [String] Account ID or code (use prefix: +code-+, e.g. +code-bob+).
     # @param shipping_address_id [String] Shipping Address ID.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Empty] Shipping address deleted.
     # @example
     #   begin
@@ -898,9 +929,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def remove_shipping_address(account_id:, shipping_address_id:)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/shipping_addresses/{shipping_address_id}", site_id: site_id, account_id: account_id, shipping_address_id: shipping_address_id)
-      delete(path)
+    def remove_shipping_address(account_id:, shipping_address_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", account_id: account_id, shipping_address_id: shipping_address_id)
+      delete(path, **options)
     end
 
     # List an account's subscriptions
@@ -938,6 +969,7 @@ module Recurly
     #   - When +state=in_trial+, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
     #   - When +state=live+, only subscriptions that are in an active, canceled, or future state or are in trial will be returned.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Subscription>] A list of the account's subscriptions.
     # @example
     #   subscriptions = @client.list_account_subscriptions(
@@ -949,7 +981,7 @@ module Recurly
     #   end
     #
     def list_account_subscriptions(account_id:, **options)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/subscriptions", site_id: site_id, account_id: account_id)
+      path = interpolate_path("/accounts/{account_id}/subscriptions", account_id: account_id)
       pager(path, **options)
     end
 
@@ -984,6 +1016,7 @@ module Recurly
     #
     # @param type [String] Filter by type field. The value +payment+ will return both +purchase+ and +capture+ transactions.
     # @param success [String] Filter by success field.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Transaction>] A list of the account's transactions.
     # @example
     #   transactions = @client.list_account_transactions(
@@ -995,7 +1028,7 @@ module Recurly
     #   end
     #
     def list_account_transactions(account_id:, **options)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/transactions", site_id: site_id, account_id: account_id)
+      path = interpolate_path("/accounts/{account_id}/transactions", account_id: account_id)
       pager(path, **options)
     end
 
@@ -1032,6 +1065,7 @@ module Recurly
     #   +canceled+, or +future+ state.
     #
     # @param past_due [String] Filter for accounts with an invoice in the +past_due+ state.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Account>] A list of an account's child accounts.
     # @example
     #   child_accounts = @client.list_child_accounts(
@@ -1043,7 +1077,7 @@ module Recurly
     #   end
     #
     def list_child_accounts(account_id:, **options)
-      path = interpolate_path("/sites/{site_id}/accounts/{account_id}/accounts", site_id: site_id, account_id: account_id)
+      path = interpolate_path("/accounts/{account_id}/accounts", account_id: account_id)
       pager(path, **options)
     end
 
@@ -1075,6 +1109,7 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::AccountAcquisition>] A list of the site's account acquisition data.
     # @example
     #   acquisitions = @client.list_account_acquisition(limit: 200)
@@ -1083,7 +1118,7 @@ module Recurly
     #   end
     #
     def list_account_acquisition(**options)
-      path = interpolate_path("/sites/{site_id}/acquisitions", site_id: site_id)
+      path = interpolate_path("/acquisitions")
       pager(path, **options)
     end
 
@@ -1115,6 +1150,7 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Coupon>] A list of the site's coupons.
     # @example
     #   coupons = @client.list_coupons(limit: 200)
@@ -1123,7 +1159,7 @@ module Recurly
     #   end
     #
     def list_coupons(**options)
-      path = interpolate_path("/sites/{site_id}/coupons", site_id: site_id)
+      path = interpolate_path("/coupons")
       pager(path, **options)
     end
 
@@ -1132,6 +1168,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/create_coupon create_coupon api documenation}
     #
     # @param body [Requests::CouponCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::CouponCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Coupon] A new coupon.
     # @example
     #   begin
@@ -1156,9 +1193,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def create_coupon(body:)
-      path = interpolate_path("/sites/{site_id}/coupons", site_id: site_id)
-      post(path, body, Requests::CouponCreate)
+    def create_coupon(body:, **options)
+      path = interpolate_path("/coupons")
+      post(path, body, Requests::CouponCreate, **options)
     end
 
     # Fetch a coupon
@@ -1166,6 +1203,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_coupon get_coupon api documenation}
     #
     # @param coupon_id [String] Coupon ID or code (use prefix: +code-+, e.g. +code-10off+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Coupon] A coupon.
     # @example
     #   begin
@@ -1177,9 +1215,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_coupon(coupon_id:)
-      path = interpolate_path("/sites/{site_id}/coupons/{coupon_id}", site_id: site_id, coupon_id: coupon_id)
-      get(path)
+    def get_coupon(coupon_id:, **options)
+      path = interpolate_path("/coupons/{coupon_id}", coupon_id: coupon_id)
+      get(path, **options)
     end
 
     # Update an active coupon
@@ -1188,10 +1226,11 @@ module Recurly
     #
     # @param coupon_id [String] Coupon ID or code (use prefix: +code-+, e.g. +code-10off+).
     # @param body [Requests::CouponUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::CouponUpdate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Coupon] The updated coupon.
-    def update_coupon(coupon_id:, body:)
-      path = interpolate_path("/sites/{site_id}/coupons/{coupon_id}", site_id: site_id, coupon_id: coupon_id)
-      put(path, body, Requests::CouponUpdate)
+    def update_coupon(coupon_id:, body:, **options)
+      path = interpolate_path("/coupons/{coupon_id}", coupon_id: coupon_id)
+      put(path, body, Requests::CouponUpdate, **options)
     end
 
     # List unique coupon codes associated with a bulk coupon
@@ -1223,9 +1262,10 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::UniqueCouponCode>] A list of unique coupon codes that were generated
     def list_unique_coupon_codes(coupon_id:, **options)
-      path = interpolate_path("/sites/{site_id}/coupons/{coupon_id}/unique_coupon_codes", site_id: site_id, coupon_id: coupon_id)
+      path = interpolate_path("/coupons/{coupon_id}/unique_coupon_codes", coupon_id: coupon_id)
       pager(path, **options)
     end
 
@@ -1245,6 +1285,7 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::CreditPayment>] A list of the site's credit payments.
     # @example
     #   payments = @client.list_credit_payments(limit: 200)
@@ -1253,7 +1294,7 @@ module Recurly
     #   end
     #
     def list_credit_payments(**options)
-      path = interpolate_path("/sites/{site_id}/credit_payments", site_id: site_id)
+      path = interpolate_path("/credit_payments")
       pager(path, **options)
     end
 
@@ -1262,10 +1303,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_credit_payment get_credit_payment api documenation}
     #
     # @param credit_payment_id [String] Credit Payment ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::CreditPayment] A credit payment.
-    def get_credit_payment(credit_payment_id:)
-      path = interpolate_path("/sites/{site_id}/credit_payments/{credit_payment_id}", site_id: site_id, credit_payment_id: credit_payment_id)
-      get(path)
+    def get_credit_payment(credit_payment_id:, **options)
+      path = interpolate_path("/credit_payments/{credit_payment_id}", credit_payment_id: credit_payment_id)
+      get(path, **options)
     end
 
     # List a site's custom field definitions
@@ -1296,6 +1338,7 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::CustomFieldDefinition>] A list of the site's custom field definitions.
     # @example
     #   custom_fields = @client.list_custom_field_definitions(limit: 200)
@@ -1304,7 +1347,7 @@ module Recurly
     #   end
     #
     def list_custom_field_definitions(**options)
-      path = interpolate_path("/sites/{site_id}/custom_field_definitions", site_id: site_id)
+      path = interpolate_path("/custom_field_definitions")
       pager(path, **options)
     end
 
@@ -1313,10 +1356,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_custom_field_definition get_custom_field_definition api documenation}
     #
     # @param custom_field_definition_id [String] Custom Field Definition ID
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::CustomFieldDefinition] An custom field definition.
-    def get_custom_field_definition(custom_field_definition_id:)
-      path = interpolate_path("/sites/{site_id}/custom_field_definitions/{custom_field_definition_id}", site_id: site_id, custom_field_definition_id: custom_field_definition_id)
-      get(path)
+    def get_custom_field_definition(custom_field_definition_id:, **options)
+      path = interpolate_path("/custom_field_definitions/{custom_field_definition_id}", custom_field_definition_id: custom_field_definition_id)
+      get(path, **options)
     end
 
     # List a site's invoices
@@ -1353,6 +1397,7 @@ module Recurly
     #   - +type=non-legacy+, only charge and credit invoices will be returned.
     #   - +type=legacy+, only legacy invoices will be returned.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Invoice>] A list of the site's invoices.
     # @example
     #   invoices = @client.list_invoices(limit: 200)
@@ -1361,7 +1406,7 @@ module Recurly
     #   end
     #
     def list_invoices(**options)
-      path = interpolate_path("/sites/{site_id}/invoices", site_id: site_id)
+      path = interpolate_path("/invoices")
       pager(path, **options)
     end
 
@@ -1370,6 +1415,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_invoice get_invoice api documenation}
     #
     # @param invoice_id [String] Invoice ID or number (use prefix: +number-+, e.g. +number-1000+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Invoice] An invoice.
     # @example
     #   begin
@@ -1381,9 +1427,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_invoice(invoice_id:)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}", site_id: site_id, invoice_id: invoice_id)
-      get(path)
+    def get_invoice(invoice_id:, **options)
+      path = interpolate_path("/invoices/{invoice_id}", invoice_id: invoice_id)
+      get(path, **options)
     end
 
     # Update an invoice
@@ -1392,10 +1438,11 @@ module Recurly
     #
     # @param invoice_id [String] Invoice ID or number (use prefix: +number-+, e.g. +number-1000+).
     # @param body [Requests::InvoiceUpdatable] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceUpdatable}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Invoice] An invoice.
-    def put_invoice(invoice_id:, body:)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}", site_id: site_id, invoice_id: invoice_id)
-      put(path, body, Requests::InvoiceUpdatable)
+    def put_invoice(invoice_id:, body:, **options)
+      path = interpolate_path("/invoices/{invoice_id}", invoice_id: invoice_id)
+      put(path, body, Requests::InvoiceUpdatable, **options)
     end
 
     # Collect a pending or past due, automatic invoice
@@ -1403,6 +1450,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/collect_invoice collect_invoice api documenation}
     #
     # @param invoice_id [String] Invoice ID or number (use prefix: +number-+, e.g. +number-1000+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Invoice] The updated invoice.
     # @example
     #   begin
@@ -1414,9 +1462,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def collect_invoice(invoice_id:)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}/collect", site_id: site_id, invoice_id: invoice_id)
-      put(path)
+    def collect_invoice(invoice_id:, **options)
+      path = interpolate_path("/invoices/{invoice_id}/collect", invoice_id: invoice_id)
+      put(path, **options)
     end
 
     # Mark an open invoice as failed
@@ -1424,6 +1472,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/fail_invoice fail_invoice api documenation}
     #
     # @param invoice_id [String] Invoice ID or number (use prefix: +number-+, e.g. +number-1000+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Invoice] The updated invoice.
     # @example
     #   begin
@@ -1435,9 +1484,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def fail_invoice(invoice_id:)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}/mark_failed", site_id: site_id, invoice_id: invoice_id)
-      put(path)
+    def fail_invoice(invoice_id:, **options)
+      path = interpolate_path("/invoices/{invoice_id}/mark_failed", invoice_id: invoice_id)
+      put(path, **options)
     end
 
     # Mark an open invoice as successful
@@ -1445,6 +1494,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/mark_invoice_successful mark_invoice_successful api documenation}
     #
     # @param invoice_id [String] Invoice ID or number (use prefix: +number-+, e.g. +number-1000+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Invoice] The updated invoice.
     # @example
     #   begin
@@ -1456,9 +1506,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def mark_invoice_successful(invoice_id:)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}/mark_successful", site_id: site_id, invoice_id: invoice_id)
-      put(path)
+    def mark_invoice_successful(invoice_id:, **options)
+      path = interpolate_path("/invoices/{invoice_id}/mark_successful", invoice_id: invoice_id)
+      put(path, **options)
     end
 
     # Reopen a closed, manual invoice
@@ -1466,6 +1516,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/reopen_invoice reopen_invoice api documenation}
     #
     # @param invoice_id [String] Invoice ID or number (use prefix: +number-+, e.g. +number-1000+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Invoice] The updated invoice.
     # @example
     #   begin
@@ -1477,9 +1528,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def reopen_invoice(invoice_id:)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}/reopen", site_id: site_id, invoice_id: invoice_id)
-      put(path)
+    def reopen_invoice(invoice_id:, **options)
+      path = interpolate_path("/invoices/{invoice_id}/reopen", invoice_id: invoice_id)
+      put(path, **options)
     end
 
     # List an invoice's line items
@@ -1514,9 +1565,10 @@ module Recurly
     # @param original [String] Filter by original field.
     # @param state [String] Filter by state field.
     # @param type [String] Filter by type field.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::LineItem>] A list of the invoice's line items.
     def list_invoice_line_items(invoice_id:, **options)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}/line_items", site_id: site_id, invoice_id: invoice_id)
+      path = interpolate_path("/invoices/{invoice_id}/line_items", invoice_id: invoice_id)
       pager(path, **options)
     end
 
@@ -1547,6 +1599,7 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::CouponRedemption>] A list of the the coupon redemptions associated with the invoice.
     # @example
     #   coupon_redemptions = @client.list_invoice_coupon_redemptions(
@@ -1558,7 +1611,7 @@ module Recurly
     #   end
     #
     def list_invoice_coupon_redemptions(invoice_id:, **options)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}/coupon_redemptions", site_id: site_id, invoice_id: invoice_id)
+      path = interpolate_path("/invoices/{invoice_id}/coupon_redemptions", invoice_id: invoice_id)
       pager(path, **options)
     end
 
@@ -1567,10 +1620,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/list_related_invoices list_related_invoices api documenation}
     #
     # @param invoice_id [String] Invoice ID or number (use prefix: +number-+, e.g. +number-1000+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Invoice>] A list of the credit or charge invoices associated with the invoice.
-    def list_related_invoices(invoice_id:)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}/related_invoices", site_id: site_id, invoice_id: invoice_id)
-      pager(path)
+    def list_related_invoices(invoice_id:, **options)
+      path = interpolate_path("/invoices/{invoice_id}/related_invoices", invoice_id: invoice_id)
+      pager(path, **options)
     end
 
     # Refund an invoice
@@ -1579,6 +1633,7 @@ module Recurly
     #
     # @param invoice_id [String] Invoice ID or number (use prefix: +number-+, e.g. +number-1000+).
     # @param body [Requests::InvoiceRefund] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceRefund}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Invoice] Returns the new credit invoice.
     # @example
     #   begin
@@ -1597,9 +1652,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def refund_invoice(invoice_id:, body:)
-      path = interpolate_path("/sites/{site_id}/invoices/{invoice_id}/refund", site_id: site_id, invoice_id: invoice_id)
-      post(path, body, Requests::InvoiceRefund)
+    def refund_invoice(invoice_id:, body:, **options)
+      path = interpolate_path("/invoices/{invoice_id}/refund", invoice_id: invoice_id)
+      post(path, body, Requests::InvoiceRefund, **options)
     end
 
     # List a site's line items
@@ -1633,9 +1688,10 @@ module Recurly
     # @param original [String] Filter by original field.
     # @param state [String] Filter by state field.
     # @param type [String] Filter by type field.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::LineItem>] A list of the site's line items.
     def list_line_items(**options)
-      path = interpolate_path("/sites/{site_id}/line_items", site_id: site_id)
+      path = interpolate_path("/line_items")
       pager(path, **options)
     end
 
@@ -1644,6 +1700,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_line_item get_line_item api documenation}
     #
     # @param line_item_id [String] Line Item ID.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::LineItem] A line item.
     # @example
     #   begin
@@ -1655,9 +1712,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_line_item(line_item_id:)
-      path = interpolate_path("/sites/{site_id}/line_items/{line_item_id}", site_id: site_id, line_item_id: line_item_id)
-      get(path)
+    def get_line_item(line_item_id:, **options)
+      path = interpolate_path("/line_items/{line_item_id}", line_item_id: line_item_id)
+      get(path, **options)
     end
 
     # Delete an uninvoiced line item
@@ -1665,6 +1722,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/remove_line_item remove_line_item api documenation}
     #
     # @param line_item_id [String] Line Item ID.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Empty] Line item deleted.
     # @example
     #   begin
@@ -1678,9 +1736,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def remove_line_item(line_item_id:)
-      path = interpolate_path("/sites/{site_id}/line_items/{line_item_id}", site_id: site_id, line_item_id: line_item_id)
-      delete(path)
+    def remove_line_item(line_item_id:, **options)
+      path = interpolate_path("/line_items/{line_item_id}", line_item_id: line_item_id)
+      delete(path, **options)
     end
 
     # List a site's plans
@@ -1712,6 +1770,7 @@ module Recurly
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
     # @param state [String] Filter by state.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Plan>] A list of plans.
     # @example
     #   plans = @client.list_plans(limit: 200)
@@ -1720,7 +1779,7 @@ module Recurly
     #   end
     #
     def list_plans(**options)
-      path = interpolate_path("/sites/{site_id}/plans", site_id: site_id)
+      path = interpolate_path("/plans")
       pager(path, **options)
     end
 
@@ -1729,6 +1788,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/create_plan create_plan api documenation}
     #
     # @param body [Requests::PlanCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::PlanCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Plan] A plan.
     # @example
     #   begin
@@ -1757,9 +1817,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def create_plan(body:)
-      path = interpolate_path("/sites/{site_id}/plans", site_id: site_id)
-      post(path, body, Requests::PlanCreate)
+    def create_plan(body:, **options)
+      path = interpolate_path("/plans")
+      post(path, body, Requests::PlanCreate, **options)
     end
 
     # Fetch a plan
@@ -1767,6 +1827,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_plan get_plan api documenation}
     #
     # @param plan_id [String] Plan ID or code (use prefix: +code-+, e.g. +code-gold+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Plan] A plan.
     # @example
     #   begin
@@ -1778,9 +1839,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_plan(plan_id:)
-      path = interpolate_path("/sites/{site_id}/plans/{plan_id}", site_id: site_id, plan_id: plan_id)
-      get(path)
+    def get_plan(plan_id:, **options)
+      path = interpolate_path("/plans/{plan_id}", plan_id: plan_id)
+      get(path, **options)
     end
 
     # Update a plan
@@ -1789,10 +1850,11 @@ module Recurly
     #
     # @param plan_id [String] Plan ID or code (use prefix: +code-+, e.g. +code-gold+).
     # @param body [Requests::PlanUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::PlanUpdate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Plan] A plan.
-    def update_plan(plan_id:, body:)
-      path = interpolate_path("/sites/{site_id}/plans/{plan_id}", site_id: site_id, plan_id: plan_id)
-      put(path, body, Requests::PlanUpdate)
+    def update_plan(plan_id:, body:, **options)
+      path = interpolate_path("/plans/{plan_id}", plan_id: plan_id)
+      put(path, body, Requests::PlanUpdate, **options)
     end
 
     # Remove a plan
@@ -1800,10 +1862,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/remove_plan remove_plan api documenation}
     #
     # @param plan_id [String] Plan ID or code (use prefix: +code-+, e.g. +code-gold+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Plan] Plan deleted
-    def remove_plan(plan_id:)
-      path = interpolate_path("/sites/{site_id}/plans/{plan_id}", site_id: site_id, plan_id: plan_id)
-      delete(path)
+    def remove_plan(plan_id:, **options)
+      path = interpolate_path("/plans/{plan_id}", plan_id: plan_id)
+      delete(path, **options)
     end
 
     # List a plan's add-ons
@@ -1836,6 +1899,7 @@ module Recurly
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
     # @param state [String] Filter by state.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::AddOn>] A list of add-ons.
     # @example
     #   add_ons = @client.list_plan_add_ons(
@@ -1847,7 +1911,7 @@ module Recurly
     #   end
     #
     def list_plan_add_ons(plan_id:, **options)
-      path = interpolate_path("/sites/{site_id}/plans/{plan_id}/add_ons", site_id: site_id, plan_id: plan_id)
+      path = interpolate_path("/plans/{plan_id}/add_ons", plan_id: plan_id)
       pager(path, **options)
     end
 
@@ -1857,10 +1921,11 @@ module Recurly
     #
     # @param plan_id [String] Plan ID or code (use prefix: +code-+, e.g. +code-gold+).
     # @param body [Requests::AddOnCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AddOnCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::AddOn] An add-on.
-    def create_plan_add_on(plan_id:, body:)
-      path = interpolate_path("/sites/{site_id}/plans/{plan_id}/add_ons", site_id: site_id, plan_id: plan_id)
-      post(path, body, Requests::AddOnCreate)
+    def create_plan_add_on(plan_id:, body:, **options)
+      path = interpolate_path("/plans/{plan_id}/add_ons", plan_id: plan_id)
+      post(path, body, Requests::AddOnCreate, **options)
     end
 
     # Fetch a plan's add-on
@@ -1869,6 +1934,7 @@ module Recurly
     #
     # @param plan_id [String] Plan ID or code (use prefix: +code-+, e.g. +code-gold+).
     # @param add_on_id [String] Add-on ID or code (use prefix: +code-+, e.g. +code-gold+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::AddOn] An add-on.
     # @example
     #   begin
@@ -1882,9 +1948,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_plan_add_on(plan_id:, add_on_id:)
-      path = interpolate_path("/sites/{site_id}/plans/{plan_id}/add_ons/{add_on_id}", site_id: site_id, plan_id: plan_id, add_on_id: add_on_id)
-      get(path)
+    def get_plan_add_on(plan_id:, add_on_id:, **options)
+      path = interpolate_path("/plans/{plan_id}/add_ons/{add_on_id}", plan_id: plan_id, add_on_id: add_on_id)
+      get(path, **options)
     end
 
     # Update an add-on
@@ -1894,10 +1960,11 @@ module Recurly
     # @param plan_id [String] Plan ID or code (use prefix: +code-+, e.g. +code-gold+).
     # @param add_on_id [String] Add-on ID or code (use prefix: +code-+, e.g. +code-gold+).
     # @param body [Requests::AddOnUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AddOnUpdate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::AddOn] An add-on.
-    def update_plan_add_on(plan_id:, add_on_id:, body:)
-      path = interpolate_path("/sites/{site_id}/plans/{plan_id}/add_ons/{add_on_id}", site_id: site_id, plan_id: plan_id, add_on_id: add_on_id)
-      put(path, body, Requests::AddOnUpdate)
+    def update_plan_add_on(plan_id:, add_on_id:, body:, **options)
+      path = interpolate_path("/plans/{plan_id}/add_ons/{add_on_id}", plan_id: plan_id, add_on_id: add_on_id)
+      put(path, body, Requests::AddOnUpdate, **options)
     end
 
     # Remove an add-on
@@ -1906,10 +1973,11 @@ module Recurly
     #
     # @param plan_id [String] Plan ID or code (use prefix: +code-+, e.g. +code-gold+).
     # @param add_on_id [String] Add-on ID or code (use prefix: +code-+, e.g. +code-gold+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::AddOn] Add-on deleted
-    def remove_plan_add_on(plan_id:, add_on_id:)
-      path = interpolate_path("/sites/{site_id}/plans/{plan_id}/add_ons/{add_on_id}", site_id: site_id, plan_id: plan_id, add_on_id: add_on_id)
-      delete(path)
+    def remove_plan_add_on(plan_id:, add_on_id:, **options)
+      path = interpolate_path("/plans/{plan_id}/add_ons/{add_on_id}", plan_id: plan_id, add_on_id: add_on_id)
+      delete(path, **options)
     end
 
     # List a site's add-ons
@@ -1941,9 +2009,10 @@ module Recurly
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
     # @param state [String] Filter by state.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::AddOn>] A list of add-ons.
     def list_add_ons(**options)
-      path = interpolate_path("/sites/{site_id}/add_ons", site_id: site_id)
+      path = interpolate_path("/add_ons")
       pager(path, **options)
     end
 
@@ -1952,10 +2021,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_add_on get_add_on api documenation}
     #
     # @param add_on_id [String] Add-on ID or code (use prefix: +code-+, e.g. +code-gold+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::AddOn] An add-on.
-    def get_add_on(add_on_id:)
-      path = interpolate_path("/sites/{site_id}/add_ons/{add_on_id}", site_id: site_id, add_on_id: add_on_id)
-      get(path)
+    def get_add_on(add_on_id:, **options)
+      path = interpolate_path("/add_ons/{add_on_id}", add_on_id: add_on_id)
+      get(path, **options)
     end
 
     # List a site's subscriptions
@@ -1992,6 +2062,7 @@ module Recurly
     #   - When +state=in_trial+, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
     #   - When +state=live+, only subscriptions that are in an active, canceled, or future state or are in trial will be returned.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Subscription>] A list of the site's subscriptions.
     # @example
     #   subscriptions = @client.list_subscriptions(limit: 200)
@@ -2000,7 +2071,7 @@ module Recurly
     #   end
     #
     def list_subscriptions(**options)
-      path = interpolate_path("/sites/{site_id}/subscriptions", site_id: site_id)
+      path = interpolate_path("/subscriptions")
       pager(path, **options)
     end
 
@@ -2009,6 +2080,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/create_subscription create_subscription api documenation}
     #
     # @param body [Requests::SubscriptionCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2031,9 +2103,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def create_subscription(body:)
-      path = interpolate_path("/sites/{site_id}/subscriptions", site_id: site_id)
-      post(path, body, Requests::SubscriptionCreate)
+    def create_subscription(body:, **options)
+      path = interpolate_path("/subscriptions")
+      post(path, body, Requests::SubscriptionCreate, **options)
     end
 
     # Fetch a subscription
@@ -2041,6 +2113,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_subscription get_subscription api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2054,9 +2127,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_subscription(subscription_id:)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}", site_id: site_id, subscription_id: subscription_id)
-      get(path)
+    def get_subscription(subscription_id:, **options)
+      path = interpolate_path("/subscriptions/{subscription_id}", subscription_id: subscription_id)
+      get(path, **options)
     end
 
     # Modify a subscription
@@ -2065,6 +2138,7 @@ module Recurly
     #
     # @param subscription_id [String] Subscription ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
     # @param body [Requests::SubscriptionUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionUpdate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2083,9 +2157,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def modify_subscription(subscription_id:, body:)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}", site_id: site_id, subscription_id: subscription_id)
-      put(path, body, Requests::SubscriptionUpdate)
+    def modify_subscription(subscription_id:, body:, **options)
+      path = interpolate_path("/subscriptions/{subscription_id}", subscription_id: subscription_id)
+      put(path, body, Requests::SubscriptionUpdate, **options)
     end
 
     # Terminate a subscription
@@ -2103,6 +2177,7 @@ module Recurly
     #
     #   You may also terminate a subscription with no refund and then manually refund specific invoices.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Subscription] An expired subscription.
     # @example
     #   begin
@@ -2117,7 +2192,7 @@ module Recurly
     #   end
     #
     def terminate_subscription(subscription_id:, **options)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}", site_id: site_id, subscription_id: subscription_id)
+      path = interpolate_path("/subscriptions/{subscription_id}", subscription_id: subscription_id)
       delete(path, **options)
     end
 
@@ -2126,6 +2201,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/cancel_subscription cancel_subscription api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Subscription] A canceled or failed subscription.
     # @example
     #   begin
@@ -2139,9 +2215,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def cancel_subscription(subscription_id:)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/cancel", site_id: site_id, subscription_id: subscription_id)
-      put(path)
+    def cancel_subscription(subscription_id:, **options)
+      path = interpolate_path("/subscriptions/{subscription_id}/cancel", subscription_id: subscription_id)
+      put(path, **options)
     end
 
     # Reactivate a canceled subscription
@@ -2149,6 +2225,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/reactivate_subscription reactivate_subscription api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Subscription] An active subscription.
     # @example
     #   begin
@@ -2162,9 +2239,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def reactivate_subscription(subscription_id:)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/reactivate", site_id: site_id, subscription_id: subscription_id)
-      put(path)
+    def reactivate_subscription(subscription_id:, **options)
+      path = interpolate_path("/subscriptions/{subscription_id}/reactivate", subscription_id: subscription_id)
+      put(path, **options)
     end
 
     # Pause subscription
@@ -2173,6 +2250,7 @@ module Recurly
     #
     # @param subscription_id [String] Subscription ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
     # @param body [Requests::SubscriptionPause] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionPause}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2190,9 +2268,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def pause_subscription(subscription_id:, body:)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/pause", site_id: site_id, subscription_id: subscription_id)
-      put(path, body, Requests::SubscriptionPause)
+    def pause_subscription(subscription_id:, body:, **options)
+      path = interpolate_path("/subscriptions/{subscription_id}/pause", subscription_id: subscription_id)
+      put(path, body, Requests::SubscriptionPause, **options)
     end
 
     # Resume subscription
@@ -2200,6 +2278,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/resume_subscription resume_subscription api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2213,9 +2292,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def resume_subscription(subscription_id:)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/resume", site_id: site_id, subscription_id: subscription_id)
-      put(path)
+    def resume_subscription(subscription_id:, **options)
+      path = interpolate_path("/subscriptions/{subscription_id}/resume", subscription_id: subscription_id)
+      put(path, **options)
     end
 
     # Fetch a subscription's pending change
@@ -2223,6 +2302,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_subscription_change get_subscription_change api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::SubscriptionChange] A subscription's pending change.
     # @example
     #   begin
@@ -2236,9 +2316,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_subscription_change(subscription_id:)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/change", site_id: site_id, subscription_id: subscription_id)
-      get(path)
+    def get_subscription_change(subscription_id:, **options)
+      path = interpolate_path("/subscriptions/{subscription_id}/change", subscription_id: subscription_id)
+      get(path, **options)
     end
 
     # Create a new subscription change
@@ -2247,6 +2327,7 @@ module Recurly
     #
     # @param subscription_id [String] Subscription ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
     # @param body [Requests::SubscriptionChangeCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionChangeCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::SubscriptionChange] A subscription change.
     # @example
     #   begin
@@ -2265,9 +2346,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def create_subscription_change(subscription_id:, body:)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/change", site_id: site_id, subscription_id: subscription_id)
-      post(path, body, Requests::SubscriptionChangeCreate)
+    def create_subscription_change(subscription_id:, body:, **options)
+      path = interpolate_path("/subscriptions/{subscription_id}/change", subscription_id: subscription_id)
+      post(path, body, Requests::SubscriptionChangeCreate, **options)
     end
 
     # Delete the pending subscription change
@@ -2275,6 +2356,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/remove_subscription_change remove_subscription_change api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Empty] Subscription change was deleted.
     # @example
     #   begin
@@ -2288,9 +2370,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def remove_subscription_change(subscription_id:)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/change", site_id: site_id, subscription_id: subscription_id)
-      delete(path)
+    def remove_subscription_change(subscription_id:, **options)
+      path = interpolate_path("/subscriptions/{subscription_id}/change", subscription_id: subscription_id)
+      delete(path, **options)
     end
 
     # List a subscription's invoices
@@ -2328,6 +2410,7 @@ module Recurly
     #   - +type=non-legacy+, only charge and credit invoices will be returned.
     #   - +type=legacy+, only legacy invoices will be returned.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Invoice>] A list of the subscription's invoices.
     # @example
     #   invoices = @client.list_subscription_invoices(
@@ -2339,7 +2422,7 @@ module Recurly
     #   end
     #
     def list_subscription_invoices(subscription_id:, **options)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/invoices", site_id: site_id, subscription_id: subscription_id)
+      path = interpolate_path("/subscriptions/{subscription_id}/invoices", subscription_id: subscription_id)
       pager(path, **options)
     end
 
@@ -2375,6 +2458,7 @@ module Recurly
     # @param original [String] Filter by original field.
     # @param state [String] Filter by state field.
     # @param type [String] Filter by type field.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::LineItem>] A list of the subscription's line items.
     # @example
     #   line_items = @client.list_subscription_line_items(
@@ -2386,7 +2470,7 @@ module Recurly
     #   end
     #
     def list_subscription_line_items(subscription_id:, **options)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/line_items", site_id: site_id, subscription_id: subscription_id)
+      path = interpolate_path("/subscriptions/{subscription_id}/line_items", subscription_id: subscription_id)
       pager(path, **options)
     end
 
@@ -2417,6 +2501,7 @@ module Recurly
     # @param end_time [DateTime] Filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::CouponRedemption>] A list of the the coupon redemptions on a subscription.
     # @example
     #   coupon_redemptions = @client.list_subscription_coupon_redemptions(
@@ -2428,7 +2513,7 @@ module Recurly
     #   end
     #
     def list_subscription_coupon_redemptions(subscription_id:, **options)
-      path = interpolate_path("/sites/{site_id}/subscriptions/{subscription_id}/coupon_redemptions", site_id: site_id, subscription_id: subscription_id)
+      path = interpolate_path("/subscriptions/{subscription_id}/coupon_redemptions", subscription_id: subscription_id)
       pager(path, **options)
     end
 
@@ -2462,6 +2547,7 @@ module Recurly
     #
     # @param type [String] Filter by type field. The value +payment+ will return both +purchase+ and +capture+ transactions.
     # @param success [String] Filter by success field.
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Pager<Resources::Transaction>] A list of the site's transactions.
     # @example
     #   transactions = @client.list_transactions(limit: 200)
@@ -2470,7 +2556,7 @@ module Recurly
     #   end
     #
     def list_transactions(**options)
-      path = interpolate_path("/sites/{site_id}/transactions", site_id: site_id)
+      path = interpolate_path("/transactions")
       pager(path, **options)
     end
 
@@ -2479,6 +2565,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_transaction get_transaction api documenation}
     #
     # @param transaction_id [String] Transaction ID or UUID (use prefix: +uuid-+, e.g. +uuid-123457890+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::Transaction] A transaction.
     # @example
     #   begin
@@ -2490,9 +2577,9 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_transaction(transaction_id:)
-      path = interpolate_path("/sites/{site_id}/transactions/{transaction_id}", site_id: site_id, transaction_id: transaction_id)
-      get(path)
+    def get_transaction(transaction_id:, **options)
+      path = interpolate_path("/transactions/{transaction_id}", transaction_id: transaction_id)
+      get(path, **options)
     end
 
     # Fetch a unique coupon code
@@ -2500,10 +2587,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/get_unique_coupon_code get_unique_coupon_code api documenation}
     #
     # @param unique_coupon_code_id [String] Unique Coupon Code ID or code (use prefix: +code-+, e.g. +code-abc-8dh2-def+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::UniqueCouponCode] A unique coupon code.
-    def get_unique_coupon_code(unique_coupon_code_id:)
-      path = interpolate_path("/sites/{site_id}/unique_coupon_codes/{unique_coupon_code_id}", site_id: site_id, unique_coupon_code_id: unique_coupon_code_id)
-      get(path)
+    def get_unique_coupon_code(unique_coupon_code_id:, **options)
+      path = interpolate_path("/unique_coupon_codes/{unique_coupon_code_id}", unique_coupon_code_id: unique_coupon_code_id)
+      get(path, **options)
     end
 
     # Deactivate a unique coupon code
@@ -2511,10 +2599,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/deactivate_unique_coupon_code deactivate_unique_coupon_code api documenation}
     #
     # @param unique_coupon_code_id [String] Unique Coupon Code ID or code (use prefix: +code-+, e.g. +code-abc-8dh2-def+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::UniqueCouponCode] A unique coupon code.
-    def deactivate_unique_coupon_code(unique_coupon_code_id:)
-      path = interpolate_path("/sites/{site_id}/unique_coupon_codes/{unique_coupon_code_id}", site_id: site_id, unique_coupon_code_id: unique_coupon_code_id)
-      delete(path)
+    def deactivate_unique_coupon_code(unique_coupon_code_id:, **options)
+      path = interpolate_path("/unique_coupon_codes/{unique_coupon_code_id}", unique_coupon_code_id: unique_coupon_code_id)
+      delete(path, **options)
     end
 
     # Restore a unique coupon code
@@ -2522,10 +2611,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/reactivate_unique_coupon_code reactivate_unique_coupon_code api documenation}
     #
     # @param unique_coupon_code_id [String] Unique Coupon Code ID or code (use prefix: +code-+, e.g. +code-abc-8dh2-def+).
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::UniqueCouponCode] A unique coupon code.
-    def reactivate_unique_coupon_code(unique_coupon_code_id:)
-      path = interpolate_path("/sites/{site_id}/unique_coupon_codes/{unique_coupon_code_id}/restore", site_id: site_id, unique_coupon_code_id: unique_coupon_code_id)
-      put(path)
+    def reactivate_unique_coupon_code(unique_coupon_code_id:, **options)
+      path = interpolate_path("/unique_coupon_codes/{unique_coupon_code_id}/restore", unique_coupon_code_id: unique_coupon_code_id)
+      put(path, **options)
     end
 
     # Create a new purchase
@@ -2533,6 +2623,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/create_purchase create_purchase api documenation}
     #
     # @param body [Requests::PurchaseCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::PurchaseCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::InvoiceCollection] Returns the new invoices
     # @example
     #   begin
@@ -2561,9 +2652,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def create_purchase(body:)
-      path = interpolate_path("/sites/{site_id}/purchases", site_id: site_id)
-      post(path, body, Requests::PurchaseCreate)
+    def create_purchase(body:, **options)
+      path = interpolate_path("/purchases")
+      post(path, body, Requests::PurchaseCreate, **options)
     end
 
     # Preview a new purchase
@@ -2571,6 +2662,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2018-08-09#operation/preview_purchase preview_purchase api documenation}
     #
     # @param body [Requests::PurchaseCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::PurchaseCreate}
+    # @param site_id [String] Site ID or subdomain (use prefix: +subdomain-+, e.g. +subdomain-recurly+).
     # @return [Resources::InvoiceCollection] Returns preview of the new invoices
     # @example
     #   begin
@@ -2599,9 +2691,9 @@ module Recurly
     #     puts "ValidationError: #{e.recurly_error.params}"
     #   end
     #
-    def preview_purchase(body:)
-      path = interpolate_path("/sites/{site_id}/purchases/preview", site_id: site_id)
-      post(path, body, Requests::PurchaseCreate)
+    def preview_purchase(body:, **options)
+      path = interpolate_path("/purchases/preview")
+      post(path, body, Requests::PurchaseCreate, **options)
     end
   end
 end

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 bundle install --binstubs --quiet
 ./bin/yard --quiet

--- a/scripts/format
+++ b/scripts/format
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+
 if [ "$1" == "--check" ]; then
   ./bin/rufo . --check
 else

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # First check formatting
 echo "Checking style..."


### PR DESCRIPTION
A client no longer needs to provide the site id, it can be inferred from
the API key. It's now optional when initializing the client.

I also added a way to optionally pass it into any operation. This will
set us up for when we have oauth and one authenticated client can
access many sites.