### PR TITLE
Implement bump script

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,21 @@
+[bumpversion]
+current_version = 3.0.0.beta.6
+parse = (?P<major>\d+)
+        \.(?P<minor>\d+)
+        \.(?P<patch>\d+)
+        (\.(?P<release>[a-z]+)\.(?P<build>\d+))?
+
+serialize = 
+	{major}.{minor}.{patch}.{release}.{build}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+values = 
+	beta
+
+[bumpversion:part:build]
+
+[bumpversion:file:lib/recurly/version.rb]
+
+[bumpversion:file:docs/README.md]
+

--- a/scripts/bump
+++ b/scripts/bump
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+bump2version "$@"


### PR DESCRIPTION
Allows automation of bumping versions. Will bump the versions for the library as well as any other files that need to be updated (such as READMEs). Example uses:

```
./scripts/bump patch
./scripts/bump minor
./scripts/bump major
./scripts/bump build
```

Use dry run to dump config and see the plan:

```
./scripts/bump build --dry-run --verbose 
current_version=3.0.0.beta.6
parse=(?P<major>\d+)
\.(?P<minor>\d+)
\.(?P<patch>\d+)
(\.(?P<release>[a-z]+)\.(?P<build>\d+))?
serialize=
{major}.{minor}.{patch}.{release}.{build}
{major}.{minor}.{patch}
new_version=3.0.0.beta.7
```

**Note**: Requires bump2version which will be included in playground image:

```
pip3 install bump2version
```