### PR TITLE
Fix account acquisition href problems

### DIFF
--- a/lib/recurly/account_acquisition.rb
+++ b/lib/recurly/account_acquisition.rb
@@ -12,6 +12,14 @@ module Recurly
       campaign
     )
 
+    def self.member_name
+      "acquisition"
+    end
+
+    def self.xml_root_key
+      "account_acquisition"
+    end
+
     # Acquisitions are only writeable and readable through {Account} instances.
     embedded!
     private_class_method :find

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -198,6 +198,11 @@ module Recurly
         [collection_path, uuid].compact.join '/'
       end
 
+      # @return [String] The root key for this resource's xml document
+      def xml_root_key
+        self.member_name
+      end
+
       # @return [Array] Per attribute, defines readers, writers, boolean and
       #   change-tracking methods.
       # @param attribute_names [Array] An array of attribute names.
@@ -557,7 +562,7 @@ module Recurly
             define_method "build_#{member_name}" do |*args|
               attributes = args.shift || {}
               self[member_name] = associated.send(
-                :new, attributes.merge(:uri => "#{path}/#{member_name}")
+                :new, attributes.merge(:uri => "#{path}/#{associated.member_name}")
               ).tap { |child| child.attributes[self.class.member_name] = self }
             end
             define_method "create_#{member_name}" do |*args|
@@ -812,7 +817,7 @@ module Recurly
     #   Recurly::Account.new(:account_code => 'code').to_xml
     #   # => "<account><account_code>code</account_code></account>"
     def to_xml(options = {})
-      builder = options[:builder] || XML.new("<#{self.class.member_name}/>")
+      builder = options[:builder] || XML.new("<#{self.class.xml_root_key}/>")
       xml_keys.each { |key|
         value = respond_to?(key) ? send(key) : self[key]
         node = builder.add_element key


### PR DESCRIPTION
Fixes #487 

This client was trying to guess paths and xml keys for AccountAcquisition.
This resulted in 404s when trying to save account acquisitions:

```
<errors>
  <error>No route matches [POST] "/v2/accounts/8c712547f23%40example.com/account_acquisition"</error>
</errors>
```

Added overrides for those 2 things. You should be able to build, save,
and update account aquisitions now.

### Testing

This fixes the case as described in #487 

```ruby
# on a newly created account without an existing account acquisition
account.build_account_acquisition
account.account_acquisition.channel = acquisition_params[:channel]
account.account_acquisition.subchannel = acquisition_params[:subchannel]
account.account_acquisition.campaign = acquisition_params[:campaign]
account.account_acquisition.save!
```