### PR TITLE
Refactor internal schema representation

### DIFF
--- a/benchmark.rb
+++ b/benchmark.rb
@@ -1,0 +1,16 @@
+require "rubygems"
+require "bundler/setup"
+require "recurly"
+require "benchmark"
+
+N = 1_000
+
+account_body = "{\"id\":\"ljvmmbjchtgs\",\"object\":\"account\",\"code\":\"9ebd49f7288@example.com\",\"parent_account_id\":null,\"bill_to\":\"self\",\"state\":\"active\",\"username\":null,\"email\":null,\"cc_emails\":null,\"preferred_locale\":null,\"first_name\":\"Benjamin\",\"last_name\":\"Du Monde\",\"company\":null,\"vat_number\":null,\"tax_exempt\":false,\"exemption_certificate\":null,\"address\":null,\"billing_info\":null,\"shipping_addresses\":[{\"object\":\"shipping_address\",\"first_name\":\"Benjamin\",\"last_name\":\"Du Monde\",\"company\":null,\"phone\":null,\"street1\":\"1 Tchoupitoulas St\",\"street2\":null,\"city\":\"New Orleans\",\"region\":\"LA\",\"postal_code\":\"70115\",\"country\":\"US\",\"nickname\":\"Home\",\"email\":null,\"vat_number\":null,\"id\":\"ljvmmbk9e1as\",\"account_id\":\"ljvmmbjchtgs\",\"created_at\":\"2019-09-19T22:45:59Z\",\"updated_at\":\"2019-09-19T22:45:59Z\"}],\"custom_fields\":[],\"hosted_login_token\":\"PSvcHow5H4HGEGKTfHXadLNoDcRaDVMK\",\"created_at\":\"2019-09-19T22:45:59Z\",\"updated_at\":\"2019-09-19T22:45:59Z\",\"deleted_at\":null}"
+
+Benchmark.bm do |benchmark|
+  benchmark.report("JSON parsing and casting\n") do
+    N.times do
+      _account = Recurly::JSONParser.parse(nil, account_body)
+    end
+  end
+end

--- a/lib/recurly/request.rb
+++ b/lib/recurly/request.rb
@@ -17,7 +17,7 @@ module Recurly
     protected
 
     def initialize(attributes = {})
-      @attributes = self.class.cast(attributes.clone)
+      @attributes = self.class.cast_request(attributes)
     end
 
     def to_s

--- a/lib/recurly/schema/request_caster.rb
+++ b/lib/recurly/schema/request_caster.rb
@@ -2,19 +2,20 @@ require "date"
 
 module Recurly
   class Schema
-    # *Note*: This class is for internal use.
+    # *Note*: This module is for internal use.
     # The RequestCaster turns mixed data into a pure Hash
     # so it can be serialized into JSON and used as the body of a request.
     # This module is to be extended by the Request class.
     module RequestCaster
+
       # This method casts the data object (of mixed types) into a Hash ready for JSON
       # serialization. The *schema* will default to the self's schema.
       # You should pass in the schema where possible. This is because objects are serialized
       # differently depending on the context in which they are being written.
       #
       # @example
-      #   Recurly::Requests::AccountUpdatable.cast(account_code: 'benjamin')
-      #   #=> {:account_code=>"benjamin"}
+      #   Recurly::Requests::AccountUpdatable.cast(code: 'benjamin')
+      #   #=> {:code=>"benjamin"}
       # @example
       #   # If you have some mixed data, like passing in an Address, it should cast that
       #   # address into a Hash based on the Schema defined in AccountUpdatable
@@ -25,26 +26,26 @@ module Recurly
       # @param data [Hash,Resource,Request] The data to transform into a JSON Hash.
       # @param schema [Schema] The schema to use to transform the data into a JSON Hash.
       # @return [Hash] The pure Hash ready to be serialized into JSON.
-      def cast(data, schema = self.schema)
+      def cast_request(data, schema = self.schema)
         casted = {}
         if data.is_a?(Resource) || data.is_a?(Request)
-          data = as_json(data, schema)
+          data = data.attributes.reject { |_k, v| v.nil? }
         end
 
         data.each do |k, v|
           schema_attr = schema.get_attribute(k)
           norm_val = if v.respond_to?(:attributes)
-                       cast(v, schema_attr.recurly_class.schema)
+                       cast_request(v, v.class.schema)
                      elsif v.is_a?(Array)
                        v.map do |elem|
                          if elem.respond_to?(:attributes)
-                           cast(elem, schema_attr.recurly_class.schema)
+                           cast_request(elem, elem.class.schema)
                          else
                            elem
                          end
                        end
-                     elsif v.is_a?(Hash) && schema_attr && schema_attr.type.is_a?(Symbol)
-                       cast(v, schema_attr.recurly_class.schema)
+                     elsif v.is_a?(Hash) && schema_attr && schema_attr.is_a?(Schema::ResourceAttribute)
+                       cast_request(v, schema_attr.recurly_class.schema)
                      else
                        v
                      end
@@ -53,13 +54,6 @@ module Recurly
         end
 
         casted
-      end
-
-      private
-
-      def as_json(resource, schema)
-        writeable_attributes = schema.attributes.reject(&:read_only?).map(&:name)
-        resource.attributes.select { |k, _| writeable_attributes.include?(k) }
       end
     end
   end

--- a/lib/recurly/schema/resource_caster.rb
+++ b/lib/recurly/schema/resource_caster.rb
@@ -2,20 +2,21 @@ require "date"
 
 module Recurly
   class Schema
-    # The purpose of this class is to turn Recurly defined
-    # JSON data into Recurly ruby objects. It's to be used
+    # The purpose of this class is to turn JSON parsed Hashes
+    # defined into Recurly ruby objects. It's to be used
     # by the Resource as an extension.
     module ResourceCaster
+
       # Gives the class the ability to initialize itself
       # given some json data.
       #
       # @example
-      #   Recurly::Resources::Account.from_json({"code" => "mycode"})
+      #   Recurly::Resources::Account.cast({"code" => "mycode"})
       #   #=> #<Recurly::Resources::Account @attributes={:code=>"mycode"}>
       #
-      # @param attributes [Hash] A primitive Hash from JSON.parse of Recurly result.
+      # @param attributes [Hash] A primitive Hash from JSON.parse of Recurly response.
       # @return [Resource] the {Resource} (ruby object) representing the passed in JSON data.
-      def from_json(attributes = {})
+      def cast(attributes = {})
         resource = new()
         attributes.each do |attr_name, val|
           next if attr_name == "object"
@@ -23,30 +24,21 @@ module Recurly
           schema_attr = self.schema.get_attribute(attr_name)
 
           if schema_attr
-            # if the Hash val is a recurly type, parse it into a Resource
-            val = if val.is_a?(Hash) && !schema_attr.is_primitive?
-                    schema_attr.recurly_class.from_json(val)
-                  elsif val.is_a?(Array)
-                    val.map do |e|
-                      if e.is_a?(Hash) && !schema_attr.is_primitive?
-                        schema_attr.recurly_class.from_json(e)
-                      else
-                        e
-                      end
-                    end
-                  elsif val && schema_attr.type == DateTime && val.is_a?(String)
-                    DateTime.parse(val)
-                  else
+            val = if val.nil?
                     val
+                  elsif schema_attr.is_valid?(val)
+                    schema_attr.cast(val)
+                  else
+                    if Recurly::STRICT_MODE
+                      msg = "#{self.class}##{attr_name} does not have the right type. Value: #{val.inspect} was expected to be a #{schema_attr}"
+                      raise ArgumentError, msg
+                    end
                   end
 
             writer = "#{attr_name}="
-
             resource.send(writer, val)
-          else
-            if Recurly::STRICT_MODE
-              raise ArgumentError, "#{resource.class.name} encountered json attribute #{attr_name.inspect}: #{val.inspect} but it's unknown to it's schema"
-            end
+          elsif Recurly::STRICT_MODE
+            raise ArgumentError, "#{resource.class.name} encountered json attribute #{attr_name.inspect}: #{val.inspect} but it's unknown to it's schema"
           end
         end
         resource

--- a/lib/recurly/schema/schema_factory.rb
+++ b/lib/recurly/schema/schema_factory.rb
@@ -41,8 +41,6 @@ module Recurly
           self.attributes[name] = val
         end
 
-        protected "#{name}=" if attribute.read_only?
-
         self
       end
     end

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Recurly::Client do
       end
 
       it "should return a the created account for create_account" do
-        body = { account_code: "benjamin-du-monde" }
+        body = { code: "benjamin-du-monde" }
         req = Recurly::HTTP::Request.new(:post, "/accounts", JSON.dump(body))
         expect(client).to receive(:run_request).with(req, any_args).and_return(response)
         account = subject.create_account(body: body)

--- a/spec/recurly/request_spec.rb
+++ b/spec/recurly/request_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Recurly::Request do
   describe "#cast" do
     context "with primitive Hash type" do
       it "should not transform the same Hash" do
-        casted = Recurly::Requests::MyRequest.cast(hash_data)
+        casted = Recurly::Requests::MyRequest.cast_request(hash_data)
         expect(casted).to eql(hash_data)
       end
     end
@@ -144,7 +144,7 @@ RSpec.describe Recurly::Request do
       it "should not cast the Resource to a Hash" do
         hash_data[:a_sub_request] = Recurly::Requests::MySubRequest.new(a_string: "a_string")
         hash_data[:a_sub_request_array] = [Recurly::Requests::MySubRequest.new(a_string: "a_string")]
-        casted = Recurly::Requests::MyRequest.cast(hash_data)
+        casted = Recurly::Requests::MyRequest.cast_request(hash_data)
         expect(casted).to_not eql(hash_data)
         expect(casted[:a_sub_request]).to eql(a_string: "a_string")
         expect(casted[:a_sub_request_array]).to eql([a_string: "a_string"])

--- a/spec/recurly/resource_spec.rb
+++ b/spec/recurly/resource_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Recurly::Resource do
       }
     end
 
-    subject! { Recurly::Resources::MyResource.from_json(json_data) }
+    subject! { Recurly::Resources::MyResource.cast(json_data) }
 
     describe "#attributes" do
       let(:attributes) { subject.attributes }
@@ -25,22 +25,6 @@ RSpec.describe Recurly::Resource do
       it "returns a Hash" do
         attributes.is_a? Hash
       end
-
-      # TODO expecting to turn hash elements into keys
-      # TODO expecting use overridden == for resources
-      # it "returns the expected Hash" do
-      #   expect(attributes).to eq({
-      #     a_string: "A String",
-      #     a_hash: {a: 1, b: 2},
-      #     an_integer: 42,
-      #     a_float: 4.2,
-      #     a_boolean: false,
-      #     a_datetime: DateTime.new(2020, 1, 1),
-      #     a_string_array: %w(I am a string array),
-      #     a_sub_resource: Recurly::Resources::MySubResource.from_json({ "a_string" => "SubResource String" }),
-      #     a_sub_resource_array: [Recurly::Resources::MySubResource.from_json({"a_string" => "SubResource String"})]
-      #   })
-      # end
     end
 
     describe "attributes methods" do
@@ -49,7 +33,7 @@ RSpec.describe Recurly::Resource do
       end
       # TODO expecting to turn hash elements into keys
       # it "should respond to a_hash" do
-      #   expect(subject.send(:a_hash)).to eq({a: 1, b: 2})
+      #   expect(subject.send(:a_hash)).to eq({ a: 1, b: 2 })
       # end
       it "should respond to an_integer" do
         expect(subject.send(:an_integer)).to eq(42)
@@ -67,10 +51,10 @@ RSpec.describe Recurly::Resource do
         expect(subject.send(:a_string_array)).to eq(%w(I am a string array))
       end
       it "should respond to a_sub_resource" do
-        expect(subject.send(:a_sub_resource)).to eq(Recurly::Resources::MySubResource.from_json({ "a_string" => "SubResource String" }))
+        expect(subject.send(:a_sub_resource)).to eq(Recurly::Resources::MySubResource.cast({ "a_string" => "SubResource String" }))
       end
       it "should respond to a_sub_resource_array" do
-        expect(subject.send(:a_sub_resource_array)).to eq([Recurly::Resources::MySubResource.from_json({ "a_string" => "SubResource String" })])
+        expect(subject.send(:a_sub_resource_array)).to eq([Recurly::Resources::MySubResource.cast({ "a_string" => "SubResource String" })])
       end
     end
   end
@@ -94,7 +78,7 @@ RSpec.describe Recurly::Resource do
         end
 
         it "should be buildable from json data" do
-          expect(res_class.from_json({})).to be_instance_of(res_class)
+          expect(res_class.cast({})).to be_instance_of(res_class)
         end
       end
     end


### PR DESCRIPTION
This restructures the schema representation to a similar style I took with the node client: https://github.com/recurly/recurly-client-node/blob/e4f03fc1e831aeb773a574dd9823255ab746ee93/lib/recurly/schemas.js

It makes the code cleaner and easier to test, and also means a lot fewer conditionals and checks at runtime so it's more performant as well.

Here's before and after on the JSON parsing / casting of a response:

```
       user     system      total        real
  0.210000   0.000000   0.210000 (  0.212076)
```
```
       user     system      total        real
  0.130000   0.000000   0.130000 (  0.133469)
```
