### PR TITLE
Release 2.18.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.18.1
+current_version = 2.18.2
 parse = (?P<major>\d+)
         \.(?P<minor>\d+)
         \.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.2"></a>
+## v2.18.2 (2019-09-27)
+
+* Fix account acquisition href problems [PR](https://github.com/recurly/recurly-client-ruby/pull/508)
+* V2 bump script [PR](https://github.com/recurly/recurly-client-ruby/pull/509)
+* Update travis options [PR](https://github.com/recurly/recurly-client-ruby/pull/512)
+* Reference Ruby support page [PR](https://github.com/recurly/recurly-client-ruby/pull/513)
+* Include OpenSSL::OPENSSL_LIBRARY_VERSION [PR](https://github.com/recurly/recurly-client-ruby/pull/514)
+
 <a name="v2.18.1"></a>
 ## v2.18.1 (2019-09-13)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.18.1'
+gem 'recurly', '~> 2.18.2'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,6 +1,6 @@
 module Recurly
   module Version
-    VERSION = "2.18.1"
+    VERSION = "2.18.2"
 
     class << self
       def inspect


### PR DESCRIPTION
* Fix account acquisition href problems [PR](https://github.com/recurly/recurly-client-ruby/pull/508)
* V2 bump script [PR](https://github.com/recurly/recurly-client-ruby/pull/509)
* Update travis options [PR](https://github.com/recurly/recurly-client-ruby/pull/512)
* Reference Ruby support page [PR](https://github.com/recurly/recurly-client-ruby/pull/513)
* Include OpenSSL::OPENSSL_LIBRARY_VERSION [PR](https://github.com/recurly/recurly-client-ruby/pull/514)