### PR TITLE
Update recurly.gemspec

### DIFF
--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -7,11 +7,11 @@ Gem::Specification.new do |spec|
   spec.name = "recurly"
   spec.version = Recurly::VERSION
   spec.authors = ["Recurly"]
-  spec.email = ["support@recurly.com"]
+  spec.email = ["dx@recurly.com"]
 
-  spec.summary = "The ruby client for Recurly's Partner API"
-  spec.description = "The ruby client for Recurly's Partner API"
-  spec.homepage = "https://partner-docs.recurly.com"
+  spec.summary = "The ruby client for Recurly's V3 API"
+  spec.description = "The ruby client for Recurly's V3 API"
+  spec.homepage = "https://github.com/recurly/recurly-client-ruby"
   spec.license = "MIT"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", ">= 0.8.11", "<= 1.0.0"
+  spec.add_dependency "faraday", ">= 0.8.11", "< 0.16"
 
   spec.add_development_dependency "net-http-persistent", "~> 2.9.4"
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
Using version of faraday above 0.16.0 seems to cause the tests
to fail. I will investigate. for now, locking down the version so the tests will pass again.

Also removing mention of partner-api