### PR TITLE
Release 2.18.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,12 +1,12 @@
 [bumpversion]
-current_version = 2.18.2
+current_version = 2.18.3
 parse = (?P<major>\d+)
-        \.(?P<minor>\d+)
-        \.(?P<patch>\d+)
-
+	\.(?P<minor>\d+)
+	\.(?P<patch>\d+)
 serialize = 
 	{major}.{minor}.{patch}
 
 [bumpversion:file:lib/recurly/version.rb]
 
 [bumpversion:file:README.md]
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.3"></a>
+## v2.18.3 (2019-10-22)
+
+* Subscription timeframe changes [PR] (https://github.com/recurly/recurly-client-ruby/pull/492)
+* Add shipping address to purchase object [PR] (https://github.com/recurly/recurly-client-ruby/pull/522)
+
 <a name="v2.18.2"></a>
 ## v2.18.2 (2019-09-27)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.18.2'
+gem 'recurly', '~> 2.18.3'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,6 +1,6 @@
 module Recurly
   module Version
-    VERSION = "2.18.2"
+    VERSION = "2.18.3"
 
     class << self
       def inspect


### PR DESCRIPTION
Release 2.18.3

* Subscription timeframe changes [PR] (https://github.com/recurly/recurly-client-ruby/pull/492)
* Add shipping address to purchase object [PR] (https://github.com/recurly/recurly-client-ruby/pull/522)