### PR TITLE
Release 2.18.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.18.3
+current_version = 2.18.4
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Unreleased
 
 <a name="v2.18.4"></a>
-## v2.18.4 (2019-10-21)
+## v2.18.4 (2019-11-21)
 
 This bumps us to API version 2.24.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.4"></a>
+## v2.18.4 (2019-10-21)
+
+This bumps us to API version 2.24.
+
+* Add Item class [PR] (https://github.com/recurly/recurly-client-ruby/pull/527)
+* Hardcode reactivate function for Item class [PR] (https://github.com/recurly/recurly-client-ruby/pull/531)
+
 <a name="v2.18.3"></a>
 ## v2.18.3 (2019-10-22)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.18.3'
+gem 'recurly', '~> 2.18.4'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,6 +1,6 @@
 module Recurly
   module Version
-    VERSION = "2.18.3"
+    VERSION = "2.18.4"
 
     class << self
       def inspect


### PR DESCRIPTION
Release 2.18.4

This bumps us to API version 2.24.

* Add Item class [PR] (https://github.com/recurly/recurly-client-ruby/pull/527)
* Hardcode reactivate function for Item class [PR] (https://github.com/recurly/recurly-client-ruby/pull/531)