### PR TITLE
Reference reactivate href in xml

### DIFF
--- a/lib/recurly/item.rb
+++ b/lib/recurly/item.rb
@@ -24,12 +24,9 @@ module Recurly
       attrs
     end
 
-    # method should be changed to use a link once it is added to api
-    # example:
-    #   return false unless link? :reactivate
-    #   reload follow_link :reactivate
     def reactivate
-      reload API.put("#{uri}/reactivate")
+      return false unless link? :reactivate
+      reload follow_link :reactivate
       true
     end
 


### PR DESCRIPTION
Reconfigure `Item#reactivate` to reference reactivate link. Replaces https://github.com/recurly/recurly-client-ruby/blob/ab65ccb3514ec6cfe52c52d5e76888f19ddcc138/lib/recurly/item.rb#L31-L34.