### PR TITLE
Disable searching ancestors when looking up constants

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/lib/recurly/schema.rb
+++ b/lib/recurly/schema.rb
@@ -42,11 +42,11 @@ module Recurly
       raise ArgumentError, "#{type.inspect} must be a symbol but is a #{type.class}" unless type.is_a?(Symbol)
 
       if type == :Address
-        Resources::Address
-      elsif Requests.const_defined?(type)
-        Requests.const_get(type)
-      elsif Recurly::Resources.const_defined?(type)
-        Resources.const_get(type)
+        Recurly::Resources::Address
+      elsif Recurly::Requests.const_defined?(type, false)
+        Recurly::Requests.const_get(type, false)
+      elsif Recurly::Resources.const_defined?(type, false)
+        Recurly::Resources.const_get(type, false)
       else
         raise ArgumentError, "Recurly type '#{type}' is unknown"
       end

--- a/lib/recurly/schema/json_parser.rb
+++ b/lib/recurly/schema/json_parser.rb
@@ -61,17 +61,10 @@ module Recurly
         Resources::Page
       else
         type_camelized = type.split("_").map(&:capitalize).join
-        if Resources.const_defined?(type_camelized)
-          klazz = Resources.const_get(type_camelized)
-          if klazz.ancestors.include?(Resource)
-            klazz
-          else
-            if Recurly::STRICT_MODE
-              raise ArgumentError, "Could not find Recurly Resource responsible for key #{type}"
-            else
-              nil
-            end
-          end
+        if Resources.const_defined?(type_camelized, false)
+          Resources.const_get(type_camelized, false)
+        elsif Recurly::STRICT_MODE
+          raise ArgumentError, "Could not find Recurly Resource responsible for key #{type}"
         end
       end
     end

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,3 +1,3 @@
 module Recurly
-  VERSION = "3.1.0"
+  VERSION = "3.1.1"
 end


### PR DESCRIPTION
Resolves #536

The `const_defined?` and `const_get` methods will search the full ancestor tree and will provide a result for the top most matching constant when the `inherit` parameter is true. This causes issues when an application has constants defined on the top level scope that share names with Recurly constants.

The issue was verified to exist using the `bin/pry` script:
```ruby
[1] pry(main)> require 'recurly'
=> true
[2] pry(main)> Recurly::Schema.get_recurly_class(:Invoice)
=> Recurly::Resources::Invoice
[3] pry(main)> class Invoice; end
=> nil
[4] pry(main)> Recurly::Schema.get_recurly_class(:Invoice)
=> Invoice
```

After the change, the same test produces the correct result:
```ruby
[1] pry(main)> require 'recurly'
=> true
[2] pry(main)> Recurly::Schema.get_recurly_class(:Invoice)
=> Recurly::Resources::Invoice
[3] pry(main)> class Invoice; end
=> nil
[4] pry(main)> Recurly::Schema.get_recurly_class(:Invoice)
=> Recurly::Resources::Invoice
```
