### PR TITLE
Skip request property type validation for nil values

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.1
+current_version = 3.1.2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/lib/recurly/schema/schema_validator.rb
+++ b/lib/recurly/schema/schema_validator.rb
@@ -34,7 +34,7 @@ module Recurly
 
       # Validates an individual attribute
       def validate_attribute!(name, schema_attr, val)
-        unless schema_attr.is_valid?(val)
+        unless val.nil? || schema_attr.is_valid?(val)
           # If it's safely castable, the json deserializer or server
           # will take care of it for us
           unless safely_castable?(val.class, schema_attr.type)

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,3 +1,3 @@
 module Recurly
-  VERSION = "3.1.1"
+  VERSION = "3.1.2"
 end

--- a/spec/recurly/request_spec.rb
+++ b/spec/recurly/request_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Recurly::Request do
       it "should not raise an error" do
         expect { subject.validate! }.not_to raise_error
       end
+      context "with a nil value" do
+        it "should raise an error" do
+          hash_data[:a_string] = nil
+          expect { subject.validate! }.not_to raise_error(ArgumentError)
+        end
+      end
     end
     context "with incorrectly typed data" do
       context "with int instead of string" do

--- a/spec/recurly/request_spec.rb
+++ b/spec/recurly/request_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe Recurly::Request do
         expect { subject.validate! }.not_to raise_error
       end
       context "with a nil value" do
-        it "should raise an error" do
+        it "should not raise an error" do
           hash_data[:a_string] = nil
-          expect { subject.validate! }.not_to raise_error(ArgumentError)
+          expect { subject.validate! }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
Resolves #538 

The client does some light type and spell checking on requests. It should skip type-checking for nil values.

This also bumps to `3.1.2`.
