### PR TITLE
Allow object attributes through

### DIFF
--- a/lib/recurly/schema/resource_caster.rb
+++ b/lib/recurly/schema/resource_caster.rb
@@ -19,8 +19,6 @@ module Recurly
       def cast(attributes = {})
         resource = new()
         attributes.each do |attr_name, val|
-          next if attr_name == "object"
-
           schema_attr = self.schema.get_attribute(attr_name)
 
           if schema_attr


### PR DESCRIPTION
`object` was not being let through the parser but is needed in some cases. We will let it through for every type now.

Resolves #543