### PR TITLE
Convert Array params to CSV strings

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.2.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/lib/recurly/pager.rb
+++ b/lib/recurly/pager.rb
@@ -6,7 +6,7 @@ module Recurly
     def initialize(client:, path:, options: {})
       @client = client
       @path = path
-      @options = options
+      @options = map_array_params(options)
       @next = build_path(@path, @options)
     end
 
@@ -111,6 +111,16 @@ module Recurly
         path
       else
         "#{path}?#{URI.encode_www_form(options)}"
+      end
+    end
+
+    # Converts array parameters to CSV strings to maintain consistency with
+    # how the server expects the request to be formatted while providing the
+    # developer with an array type to maintain developer happiness!
+    def map_array_params(params)
+      @options = params.map do |key, param|
+        new_param = param.is_a?(Array) ? param.join(",") : param
+        [key, new_param]
       end
     end
   end

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,3 +1,3 @@
 module Recurly
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end


### PR DESCRIPTION
Fixes an issue with requesting a list of resources with specific `ids`. The server expects a CSV string of ids, but the api spec specifies that the `ids` should be specified as an array. 

This fix maintains developer happiness by maintaining the ability to specify an array of ids that are transformed to a CSV string when the request is sent to the server.