### PR TITLE
Loosen version restriction on faraday

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -126,14 +126,14 @@ module Recurly
       response = HTTP::Response.new(faraday_resp, request)
       raise_api_error!(response) unless (200...300).include?(response.status)
       resource = if response.body
-                   if BINARY_TYPES.include?(response.content_type)
-                     FileParser.parse(response.body)
-                   else
-                     JSONParser.parse(self, response.body)
-                   end
-                 else
-                   Resources::Empty.new
-                 end
+          if BINARY_TYPES.include?(response.content_type)
+            FileParser.parse(response.body)
+          else
+            JSONParser.parse(self, response.body)
+          end
+        else
+          Resources::Empty.new
+        end
       # Keep this interface "private"
       resource.instance_variable_set(:@response, response)
       resource
@@ -141,15 +141,15 @@ module Recurly
 
     def raise_network_error!(ex)
       error_class = case ex
-                    when Faraday::TimeoutError
-                      Errors::TimeoutError
-                    when Faraday::ConnectionFailed
-                      Errors::ConnectionFailedError
-                    when Faraday::SSLError
-                      Errors::SSLError
-                    else
-                      Errors::NetworkError
-                    end
+        when Faraday::TimeoutError
+          Errors::TimeoutError
+        when Faraday::ConnectionFailed
+          Errors::ConnectionFailedError
+        when Faraday::SSLError
+          Errors::SSLError
+        else
+          Errors::NetworkError
+        end
 
       raise error_class, ex.message
     end

--- a/lib/recurly/schema/json_parser.rb
+++ b/lib/recurly/schema/json_parser.rb
@@ -27,10 +27,10 @@ module Recurly
     # @return [Error,Resource]
     def self.from_json(data)
       type = if data.has_key?("error")
-               "error_may_have_transaction"
-             else
-               data["object"]
-             end
+          "error_may_have_transaction"
+        else
+          data["object"]
+        end
       klazz = self.recurly_class(type)
 
       unless klazz

--- a/lib/recurly/schema/request_caster.rb
+++ b/lib/recurly/schema/request_caster.rb
@@ -35,20 +35,20 @@ module Recurly
         data.each do |k, v|
           schema_attr = schema.get_attribute(k)
           norm_val = if v.respond_to?(:attributes)
-                       cast_request(v, v.class.schema)
-                     elsif v.is_a?(Array)
-                       v.map do |elem|
-                         if elem.respond_to?(:attributes)
-                           cast_request(elem, elem.class.schema)
-                         else
-                           elem
-                         end
-                       end
-                     elsif v.is_a?(Hash) && schema_attr && schema_attr.is_a?(Schema::ResourceAttribute)
-                       cast_request(v, schema_attr.recurly_class.schema)
-                     else
-                       v
-                     end
+              cast_request(v, v.class.schema)
+            elsif v.is_a?(Array)
+              v.map do |elem|
+                if elem.respond_to?(:attributes)
+                  cast_request(elem, elem.class.schema)
+                else
+                  elem
+                end
+              end
+            elsif v.is_a?(Hash) && schema_attr && schema_attr.is_a?(Schema::ResourceAttribute)
+              cast_request(v, schema_attr.recurly_class.schema)
+            else
+              v
+            end
 
           casted[k] = norm_val
         end

--- a/lib/recurly/schema/resource_caster.rb
+++ b/lib/recurly/schema/resource_caster.rb
@@ -23,15 +23,15 @@ module Recurly
 
           if schema_attr
             val = if val.nil?
-                    val
-                  elsif schema_attr.is_valid?(val)
-                    schema_attr.cast(val)
-                  else
-                    if Recurly::STRICT_MODE
-                      msg = "#{self.class}##{attr_name} does not have the right type. Value: #{val.inspect} was expected to be a #{schema_attr}"
-                      raise ArgumentError, msg
-                    end
-                  end
+                val
+              elsif schema_attr.is_valid?(val)
+                schema_attr.cast(val)
+              else
+                if Recurly::STRICT_MODE
+                  msg = "#{self.class}##{attr_name} does not have the right type. Value: #{val.inspect} was expected to be a #{schema_attr}"
+                  raise ArgumentError, msg
+                end
+              end
 
             writer = "#{attr_name}="
             resource.send(writer, val)

--- a/lib/recurly/schema/schema_validator.rb
+++ b/lib/recurly/schema/schema_validator.rb
@@ -39,11 +39,11 @@ module Recurly
           # will take care of it for us
           unless safely_castable?(val.class, schema_attr.type)
             expected = case schema_attr
-                       when Schema::ArrayAttribute
-                         "Array of #{schema_attr.type}s"
-                       else
-                         schema_attr.type
-                       end
+              when Schema::ArrayAttribute
+                "Array of #{schema_attr.type}s"
+              else
+                schema_attr.type
+              end
 
             raise ArgumentError, "Attribute '#{name}' on the resource #{self.class.name} is type #{val.class} but should be a #{expected}"
           end
@@ -73,10 +73,10 @@ module Recurly
       def safely_castable?(from_type, to_type)
         # TODO we can drop this switch when 2.3 support is dropped
         int_class = if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.0")
-                      :Integer
-                    else
-                      :Fixnum
-                    end
+            :Integer
+          else
+            :Fixnum
+          end
         int_class = Kernel.const_get(int_class)
 
         case [from_type, to_type]

--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", ">= 0.8.11", "< 0.16"
+  spec.add_dependency "faraday", ">= 0.8.11", "< 1.0.0"
 
   spec.add_development_dependency "net-http-persistent", "~> 2.9.4"
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
Resolves #548

Allows consumers of library to use newer versions of Faraday (but still restricting use of 1.0.0).