### PR TITLE
Add convert_trial() to Subscription

### DIFF
--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -18,7 +18,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.24'
+    RECURLY_API_VERSION = '2.25'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/spec/fixtures/subscriptions/convert-trial-200.xml
+++ b/spec/fixtures/subscriptions/convert-trial-200.xml
@@ -1,0 +1,46 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890">
+  <account href="https://api.recurly.com/v2/accounts/7747ed3b-1771-4a03-b32a-503e9d65d3ad"/>
+  <shipping_address href="https://api.recurly.com/v2/accounts/7747ed3b-1771-4a03-b32a-503e9d65d3ad/shipping_addresses/2444483678776240546"/>
+  <invoice href="https://api.recurly.com/v2/invoices/5333"/>
+  <plan href="https://api.recurly.com/v2/plans/muwlysa6u3">
+    <plan_code>muwlysa6u3</plan_code>
+    <name>muWlYSa6U3</name>
+  </plan>
+  <revenue_schedule_type>evenly</revenue_schedule_type>
+  <uuid>abcdef1234567890</uuid>
+  <state>active</state>
+  <unit_amount_in_cents type="integer">6</unit_amount_in_cents>
+  <currency>USD</currency>
+  <quantity type="integer">1</quantity>
+  <activated_at type="datetime">2018-03-27T17:52:42Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <updated_at type="datetime">2018-03-27T17:58:14Z</updated_at>
+  <total_billing_cycles nil="nil"></total_billing_cycles>
+  <remaining_billing_cycles nil="nil"></remaining_billing_cycles>
+  <current_period_started_at type="datetime">2020-02-10T20:38:21Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2020-03-10T20:38:21Z</current_period_ends_at>
+  <trial_started_at type="datetime">2020-02-10T20:38:17Z</trial_started_at>
+  <trial_ends_at type="datetime">2020-02-10T20:38:21Z</trial_ends_at>
+  <terms_and_conditions nil="nil"></terms_and_conditions>
+  <customer_notes nil="nil"></customer_notes>
+  <started_with_gift type="boolean">false</started_with_gift>
+  <converted_at nil="nil"></converted_at>
+  <imported_trial type="boolean">false</imported_trial>
+  <paused_at type="datetime">2019-04-27T17:52:42Z</paused_at>
+  <remaining_pause_cycles nil="nil"/>
+  <no_billing_info_reason></no_billing_info_reason>
+  <po_number nil="nil"></po_number>
+  <net_terms type="integer">0</net_terms>
+  <collection_method>automatic</collection_method>
+  <subscription_add_ons type="array">
+  </subscription_add_ons>
+  <a name="cancel" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/cancel" method="put"/>
+  <a name="terminate" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/terminate" method="put"/>
+  <a name="postpone" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/postpone" method="put"/>
+  <a name="notes" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/notes" method="put"/>
+</subscription>

--- a/spec/fixtures/subscriptions/show-200-trial.xml
+++ b/spec/fixtures/subscriptions/show-200-trial.xml
@@ -1,0 +1,54 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890">
+  <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <redemptions href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/redemptions" />
+  <shipping_address href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/shipping_address" />
+  <invoice href="https://api.recurly.com/v2/invoices/created-invoice"/>
+  <plan href="https://api.recurly.com/v2/plans/plan_code">
+    <plan_code>plan_code</plan_code>
+    <name>A Man, a Plan, a Canal: Panama</name>
+  </plan>
+  <uuid>abcdef1234567890</uuid>
+  <state>active</state>
+  <quantity type="integer">1</quantity>
+  <net_terms type="integer">10</net_terms>
+  <collection_method>manual</collection_method>
+  <po_number>1000</po_number>
+  <started_with_gift type="boolean">false</started_with_gift>
+  <converted_at nil="nil"></converted_at>
+  <total_amount_in_cents type="integer">1000</total_amount_in_cents>
+  <activated_at type="datetime">2011-04-30T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2020-02-10T20:38:21Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2020-03-10T20:38:21Z</current_period_ends_at>
+  <trial_started_at type="datetime">2020-02-10T20:38:17Z</trial_started_at>
+  <trial_ends_at type="datetime">2020-03-10T20:38:21Z</trial_ends_at>
+  <gateway_code>Gateway Code</gateway_code>
+  <revenue_schedule_type>evenly</revenue_schedule_type>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+      <add_on_type>usage</add_on_type>
+      <measured_unit href="https://api.recurly.com/v2/measured_units/388159600349677344"/>
+      <usage href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/add_ons/marketing_email/usage"/>
+      <add_on_code>marketing_email</add_on_code>
+      <unit_amount_in_cents type="integer">5</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
+      <usage_type>price</usage_type>
+      <usage_percentage nil="nil"/>
+    </subscription_add_on>
+  </subscription_add_ons>
+  <custom_fields type="array">
+    <custom_field>
+      <name>sub_field1</name>
+      <value>sub-value-1</value>
+    </custom_field>
+  </custom_fields>
+  <a name="cancel" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/cancel" method="put"/>
+  <a name="terminate" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/terminate" method="put"/>
+  <a name="notes" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/notes" method="put"/>
+</subscription>

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -335,6 +335,30 @@ describe Subscription do
     end
   end
 
+  describe 'convert trial' do
+    before do
+      stub_api_request :get, 'subscriptions/abcdef1234567890', 'subscriptions/show-200-trial'
+      stub_api_request :put, 'https://api.recurly.com/v2/subscriptions/abcdef1234567890/convert_trial', 'subscriptions/convert-trial-200'
+    end
+    
+    it "should convert trial to paid subscription is valid 3ds token is provided" do
+      sub = Recurly::Subscription.find('abcdef1234567890')
+      sub.convert_trial("token").must_equal true
+      sub.trial_ends_at.must_equal sub.current_period_started_at
+    end
+
+    it "should convert trial with billing info but without valid 3ds token" do
+      sub = Recurly::Subscription.find('abcdef1234567890')
+      sub.convert_trial().must_equal true
+    end
+
+    it "should convert trial to paid subscription when transaction_type is moto" do
+      sub = Recurly::Subscription.find('abcdef1234567890')
+      sub.convert_trial_moto().must_equal true
+      sub.trial_ends_at.must_equal sub.current_period_started_at
+    end
+  end
+
   describe 'notes' do
     it 'previews new subscriptions' do
       stub_api_request :get, 'subscriptions/abcdef1234567890', 'subscriptions/show-200'


### PR DESCRIPTION
To convert trial to paid subscription with 3ds token:
```ruby
subscription.convert_trial(token)
```

To convert trial for non-3ds where subscription has billing info:
```ruby
subscription.convert_trial
```

To convert trial to paid subscription when `transaction_type = moto`:
```ruby
subscription.convert_trial_moto
```



