### PR TITLE
Release 2.18.7

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.18.6
+current_version = 2.18.7
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.7"></a>
+## v2.18.7 (2020-2-20)
+
+This bumps us to API version 2.25.
+
+* Add external_sku to Adjustment (included in API version 2.24) [PR](https://github.com/recurly/recurly-client-ruby/pull/551)
+* Add convert_trial() to Subscription [PR](https://github.com/recurly/recurly-client-ruby/pull/553)
+
 <a name="v2.18.6"></a>
 ## v2.18.6 (2019-12-18)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.18.6'
+gem 'recurly', '~> 2.18.7'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,6 +1,6 @@
 module Recurly
   module Version
-    VERSION = "2.18.6"
+    VERSION = "2.18.7"
 
     class << self
       def inspect


### PR DESCRIPTION
This bumps us to API version 2.25.

* Add external_sku to Adjustment (included in API version 2.24) (https://github.com/recurly/recurly-client-ruby/pull/551)
* Add convert_trial() to Subscription (https://github.com/recurly/recurly-client-ruby/pull/553)