### PR TITLE
Add item_code to AddOn

### DIFF
--- a/lib/recurly/add_on.rb
+++ b/lib/recurly/add_on.rb
@@ -5,6 +5,7 @@ module Recurly
 
     define_attribute_methods %w(
       add_on_code
+      item_code
       name
       accounting_code
       default_quantity

--- a/spec/fixtures/plans/item_backed_add_ons/index-200.xml
+++ b/spec/fixtures/plans/item_backed_add_ons/index-200.xml
@@ -1,0 +1,25 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<add_ons type="array">
+  <add_on href="https://api.recurly.com/v2/plans/orchidreset/add_ons/marfa_brunch">
+    <plan href="https://api.recurly.com/v2/plans/orchidreset"/>
+    <item href="https://api.recurly.com/v2/items/marfa_brunch"/>
+    <item_state>active</item_state>
+    <add_on_code>marfa_brunch</add_on_code>
+    <name>Marfa Brunch</name>
+    <default_quantity type="integer">1</default_quantity>
+    <display_quantity_on_hosted_page type="boolean">false</display_quantity_on_hosted_page>
+    <tax_code nil="nil"></tax_code>
+    <unit_amount_in_cents>
+      <USD type="integer">20</USD>
+    </unit_amount_in_cents>
+    <accounting_code nil="nil"></accounting_code>
+    <add_on_type>fixed</add_on_type>
+    <optional type="boolean">true</optional>
+    <revenue_schedule_type>never</revenue_schedule_type>
+    <created_at type="datetime">2020-03-06T22:42:40Z</created_at>
+    <updated_at type="datetime">2020-03-06T22:42:40Z</updated_at>
+  </add_on>
+</add_ons>

--- a/spec/fixtures/plans/show-200-item-backed.xml
+++ b/spec/fixtures/plans/show-200-item-backed.xml
@@ -1,0 +1,39 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<plan href="https://api.recurly.com/v2/plans/orchidreset">
+  <add_ons href="https://api.recurly.com/v2/plans/orchidreset/add_ons"/>
+  <plan_code>orchidreset</plan_code>
+  <name>Orchid Reset</name>
+  <description nil="nil"></description>
+  <success_url nil="nil"></success_url>
+  <cancel_url nil="nil"></cancel_url>
+  <display_donation_amounts type="boolean">false</display_donation_amounts>
+  <display_quantity type="boolean">false</display_quantity>
+  <display_phone_number type="boolean">false</display_phone_number>
+  <bypass_hosted_confirmation type="boolean">false</bypass_hosted_confirmation>
+  <unit_name>unit</unit_name>
+  <payment_page_tos_link nil="nil"></payment_page_tos_link>
+  <plan_interval_length type="integer">1</plan_interval_length>
+  <plan_interval_unit>months</plan_interval_unit>
+  <trial_interval_length type="integer">1</trial_interval_length>
+  <trial_interval_unit>days</trial_interval_unit>
+  <total_billing_cycles type="integer">1</total_billing_cycles>
+  <accounting_code nil="nil"></accounting_code>
+  <setup_fee_accounting_code nil="nil"></setup_fee_accounting_code>
+  <created_at type="datetime">2020-03-06T22:42:39Z</created_at>
+  <updated_at type="datetime">2020-03-06T22:42:39Z</updated_at>
+  <auto_renew type="boolean">true</auto_renew>
+  <revenue_schedule_type>evenly</revenue_schedule_type>
+  <setup_fee_revenue_schedule_type>evenly</setup_fee_revenue_schedule_type>
+  <trial_requires_billing_info type="boolean">true</trial_requires_billing_info>
+  <tax_exempt type="boolean">false</tax_exempt>
+  <tax_code nil="nil"></tax_code>
+  <unit_amount_in_cents>
+    <USD type="integer">1000</USD>
+  </unit_amount_in_cents>
+  <setup_fee_in_cents>
+    <USD type="integer">6000</USD>
+  </setup_fee_in_cents>
+</plan>

--- a/spec/recurly/add_on_spec.rb
+++ b/spec/recurly/add_on_spec.rb
@@ -8,10 +8,16 @@ describe AddOn do
     stub_api_request(
       :get, 'plans/gold/add_ons', 'plans/add_ons/index-200'
     )
+    stub_api_request(
+      :get, 'plans/orchidreset', 'plans/show-200-item-backed'
+    )
+    stub_api_request(
+      :get, 'plans/orchidreset/add_ons', 'plans/item_backed_add_ons/index-200'
+    )
   end
 
   describe ".find" do
-    it "must return an addon when available" do
+    it "must return an add-on when available" do
       plan = Plan.find 'gold'
       add_ons = plan.add_ons
 
@@ -19,6 +25,18 @@ describe AddOn do
 
       add_on = add_ons.first
       add_on.must_be_instance_of AddOn
+      add_on.add_on_code.must_equal "marketing_email"
+    end
+
+    it "must return an item-backed add-on when available" do
+      plan = Plan.find 'orchidreset'
+      add_ons = plan.add_ons
+
+      add_ons.length.must_equal 1
+
+      add_on = add_ons.first
+      add_on.must_be_instance_of AddOn
+      add_on.add_on_code.must_equal "marfa_brunch"
     end
   end
 end


### PR DESCRIPTION
To create item-backed add-on:
```ruby
add-on = plan.add_ons.create!(
    item_code:               item.item_code,
    unit_amount_in_cents:    20
  )
```

To get an item-backed-add-on:
```ruby
plan.add_ons.find(item.item_code)
```

To update item-backed add-on:
```ruby
add_on.update_attributes(default_quantity: 4)
```

When add-on has an associated item, only the following attributes are updatable:
```ruby
unit_amount_in_cents
default_quantity
display_quantity_on_hosted_page
optional
```