### PR TITLE
Adding #first and #count methods to Pager

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -53,12 +53,20 @@ module Recurly
       yield(self) if block_given?
     end
 
-    def next_page(pager)
-      path = extract_path(pager.next)
+    def next_page(url)
+      path = extract_path(url)
       request = Net::HTTP::Get.new path
       set_headers(request)
       http_response = run_request(request)
       handle_response! request, http_response
+    end
+
+    def get_resource_count(url)
+      request = Net::HTTP::Head.new url
+      set_headers(request)
+      http_response = run_request(request)
+      resource = handle_response!(request, http_response)
+      resource.get_response.total_records
     end
 
     protected

--- a/lib/recurly/http.rb
+++ b/lib/recurly/http.rb
@@ -4,7 +4,7 @@ module Recurly
       attr_accessor :status, :body, :request,
         :request_id, :rate_limit, :rate_limit_remaining,
         :rate_limit_reset, :date, :proxy_metadata,
-        :content_type
+        :content_type, :total_records
 
       def initialize(resp, request)
         @request = Request.new(request.method, request.path, request.body)
@@ -13,6 +13,7 @@ module Recurly
         @rate_limit = resp["x-ratelimit-limit"].to_i
         @rate_limit_remaining = resp["x-ratelimit-remaining"].to_i
         @rate_limit_reset = Time.at(resp["x-ratelimit-reset"].to_i).to_datetime
+        @total_records = resp["recurly-total-records"]&.to_i
         if resp["content-type"]
           @content_type = resp["content-type"].split(";").first
         else

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Recurly::Client do
       "date" => "Thu, 01 Aug 2019 01:26:44 GMT",
       "server" => "cloudflare",
       "cf-ray" => "4ff4b71268424738-EWR",
+      "recurly-total-records" => "3804",
     }
   end
   let(:net_http) { Recurly::ConnectionPool.new.init_http_connection }
@@ -52,6 +53,20 @@ RSpec.describe Recurly::Client do
 
         expect(net_http).to receive(:request).and_return(response)
         _account = subject.get_account(account_id: "code-benjamin-du-monde")
+      end
+    end
+
+    describe "#get_resource_count" do
+      let(:response) do
+        resp = Net::HTTPOK.new(1.0, "200", "OK")
+        allow(resp).to receive(:body) { nil }
+        resp_headers.each { |key, v| resp[key] = v }
+        resp
+      end
+
+      it "should return the 'recurly-total-records' header value" do
+        expect(net_http).to receive(:request).with(instance_of(Net::HTTP::Head)).and_return(response)
+        expect(subject.list_accounts.count).to eq(resp_headers["recurly-total-records"].to_i)
       end
     end
 

--- a/spec/recurly/pager_spec.rb
+++ b/spec/recurly/pager_spec.rb
@@ -23,6 +23,31 @@ RSpec.describe Recurly::Pager do
     end
   end
 
+  describe "#first" do
+    let(:options) { { limit: 200, a: 1 } }
+    let(:first_response) do
+      page = Recurly::Resources::Page.new
+      page.data = [
+        { "object" => "account", "id" => "1" },
+      ]
+      page.has_more = true
+      page.next = "https://partner-api.recurly.com/next_url"
+      page
+    end
+    it "should update the 'limit' param to 1" do
+      expect(client).to receive(:next_page)
+                          .with("/next_url?limit=1&a=1")
+                          .and_return(first_response)
+      subject.first
+    end
+  end
+
+  it "#count" do
+    expect(client).to receive(:get_resource_count)
+                        .with("/next_url?a=1&b=2020-01-01T00%3A00%3A00%2B00%3A00")
+    subject.count
+  end
+
   context "enumerators" do
     let(:more_response) do
       page = Recurly::Resources::Page.new


### PR DESCRIPTION
Adds the `first` and `count` methods to the `Pager` class.

The `first` method will perform a request to the API with the `limit` set to 1 and will only return the first result from the server.

The `count` method will perform a `HEAD` request to the API for the appropriate endpoint. The value of the response header, `recurly-total-records`, will be returned. This is the total number of records that will be returned by the pager.