### PR TITLE
Update rake to 12.3.3

### DIFF
--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "net-http-persistent", "~> 2.9.4"
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "yard", "~> 0.9"
   spec.add_development_dependency "pry", "~> 0.10"


### PR DESCRIPTION
Updates the rake gem to 12.3.3 to resolve security issues.

https://github.com/advisories/GHSA-jppv-gw3r-w3q8
