### PR TITLE
Follow up bug fixes for #568

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -182,7 +182,7 @@ module Recurly
       response = HTTP::Response.new(http_response, request)
       raise_api_error!(http_response, response) unless http_response.kind_of?(Net::HTTPSuccess)
       resource = if response.body
-          if http_response.content_type.include?(JSON_CONTENT_TYPE)
+          if http_response.content_type&.include?(JSON_CONTENT_TYPE)
             JSONParser.parse(self, response.body)
           elsif BINARY_TYPES.include?(http_response.content_type)
             FileParser.parse(response.body)

--- a/lib/recurly/http.rb
+++ b/lib/recurly/http.rb
@@ -7,7 +7,7 @@ module Recurly
         :content_type
 
       def initialize(resp, request)
-        @request = request
+        @request = Request.new(request.method, request.path, request.body)
         @status = resp.code.to_i
         @request_id = resp["x-request-id"]
         @rate_limit = resp["x-ratelimit-limit"].to_i

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Recurly::Client do
         expect(net_http).to receive(:request).and_return(response)
         account = subject.get_account(account_id: "code-benjamin-du-monde")
         expect(account.get_response).to be_instance_of Recurly::HTTP::Response
+        expect(account.get_response.request).to be_instance_of Recurly::HTTP::Request
       end
     end
 


### PR DESCRIPTION
Following up on 2 fixes for #568

* The request in the exposed metadata should be of type
  Recurly::HTTP::Request not net/http's Request. This was not caught
  because they have the same interface
* Account for null content-types