### PR TITLE
Add mandate_reference attribute to BillingInfo

### DIFF
--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -36,6 +36,7 @@ module Recurly
       fraud_session_id
       three_d_secure_action_result_token_id
       transaction_type
+      mandate_reference
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES
 
     # @return ["credit_card", "paypal", "amazon", "bank_account", "roku", nil] The type of billing info.


### PR DESCRIPTION
A mandate reference is a specific ID used in a payment system to show that an agreement was made between the customer and the merchant. It is often required for compliance reasons to display when a billing info is created or a payment is created.