### PR TITLE
Release 2.18.8

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.18.7
+current_version = 2.18.8
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.8"></a>
+## v.2.18.8 (2020-3-26)
+
+This bumps us to API version 2.26.
+
+* Add item_code to AddOn (included in API version 2.25) [PR](https://github.com/recurly/recurly-client-ruby/pull/559)
+* Add SEPA IBAN attributes to billing_info [PR](https://github.com/recurly/recurly-client-ruby/pull/562)
+* Tiered pricing [PR](https://github.com/recurly/recurly-client-ruby/pull/565)
+* Add mandate_reference attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-ruby/pull/572)
+
 <a name="v2.18.7"></a>
 ## v2.18.7 (2020-2-20)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.18.7'
+gem 'recurly', '~> 2.18.8'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,6 +1,6 @@
 module Recurly
   module Version
-    VERSION = "2.18.7"
+    VERSION = "2.18.8"
 
     class << self
       def inspect


### PR DESCRIPTION
This bumps us to API version 2.26.

* Add item_code to AddOn (included in API version 2.25) [PR](https://github.com/recurly/recurly-client-ruby/pull/559)
* Add SEPA IBAN attributes to billing_info [PR](https://github.com/recurly/recurly-client-ruby/pull/562)
* Tiered pricing [PR](https://github.com/recurly/recurly-client-ruby/pull/565)
* Add mandate_reference attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-ruby/pull/572)