### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -14,6 +14,14 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/recurly/recurly-client-ruby"
   spec.license = "MIT"
 
+  spec.metadata = {
+    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "changelog_uri" => "#{spec.homepage}/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://dev.recurly.com/docs",
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => "#{spec.homepage}/tree/#{spec.version}",
+  }
+
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/recurly), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.