### PR TITLE
Use github pages for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+on:
+  release:
+    types:
+      - published
+name: Documentation
+jobs:
+  build:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+
+    - name: Build Library and Docs
+      run: ./scripts/build
+
+    - name: Deploy
+      if: success()
+      uses: crazy-max/ghaction-github-pages@v1
+      with:
+        target_branch: gh-pages
+        build_dir: ./doc
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository houses the official ruby client for Recurly's V3 API.
 
 ## Reference Documentation
 
-Getting Started Guide and reference documentation can be found on [rubydoc.info](https://www.rubydoc.info/github/recurly/recurly-client-ruby/).
+Getting Started Guide and reference documentation can be found on [Github Pages](https://recurly.github.io/recurly-client-ruby/).
 
 ## Contributing
 


### PR DESCRIPTION
Rubydoc.info consistently loses our project. It's very disruptive and we have little control over the process. This is an attempt to host the rubydocs with github pages.