### PR TITLE
Fixing the omission of query params

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -53,14 +53,6 @@ module Recurly
       yield(self) if block_given?
     end
 
-    def get_resource_count(path, options)
-      request = Net::HTTP::Head.new build_path(path, options)
-      set_headers(request)
-      http_response = run_request(request)
-      resource = handle_response!(request, http_response)
-      resource.get_response.total_records
-    end
-
     protected
 
     def pager(path, **options)
@@ -69,6 +61,14 @@ module Recurly
         path: path,
         options: options,
       )
+    end
+
+    def head(path, **options)
+      path = scope_by_site(path, **options)
+      request = Net::HTTP::Head.new build_path(path, options)
+      set_headers(request, options[:headers])
+      http_response = run_request(request, options)
+      handle_response! request, http_response
     end
 
     def get(path, **options)

--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -53,8 +53,8 @@ module Recurly
       yield(self) if block_given?
     end
 
-    def get_resource_count(url)
-      request = Net::HTTP::Head.new url
+    def get_resource_count(path, options)
+      request = Net::HTTP::Head.new build_path(path, options)
       set_headers(request)
       http_response = run_request(request)
       resource = handle_response!(request, http_response)
@@ -259,8 +259,10 @@ module Recurly
     end
 
     def scope_by_site(path, **options)
-      if (site = site_id || options[:site_id]) && !path.start_with?("/sites/#{site}")
-        "/sites/#{site}#{path}"
+      if site = site_id || options[:site_id]
+        # Ensure that we are only including the site_id once because the Pager operations
+        # will use the cursor returned from the API which may already have these components
+        path.start_with?("/sites/#{site}") ? path : "/sites/#{site}#{path}"
       else
         path
       end

--- a/lib/recurly/pager.rb
+++ b/lib/recurly/pager.rb
@@ -24,7 +24,8 @@ module Recurly
 
     # Makes a HEAD request to the API to determine how many total records exist.
     def count
-      @client.get_resource_count(self.next, @options)
+      resource = @client.send(:head, self.next, @options)
+      return resource.get_response.total_records
     end
 
     # Enumerates each "page" from the server.

--- a/lib/recurly/pager.rb
+++ b/lib/recurly/pager.rb
@@ -24,7 +24,7 @@ module Recurly
 
     # Makes a HEAD request to the API to determine how many total records exist.
     def count
-      @client.get_resource_count(self.next)
+      @client.get_resource_count(self.next, @options)
     end
 
     # Enumerates each "page" from the server.

--- a/lib/recurly/pager.rb
+++ b/lib/recurly/pager.rb
@@ -25,7 +25,7 @@ module Recurly
     # Makes a HEAD request to the API to determine how many total records exist.
     def count
       resource = @client.send(:head, self.next, @options)
-      return resource.get_response.total_records
+      resource.get_response.total_records
     end
 
     # Enumerates each "page" from the server.

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -316,16 +316,4 @@ RSpec.describe Recurly::Client do
       end
     end
   end
-
-  describe "#extract_path returns the path and parameters" do
-    let(:path) { "/accounts?cursor=xyz&limit=20&sort=created_at" }
-
-    it "when given a path" do
-      expect(client.send(:extract_path, path)).to eql(path)
-    end
-
-    it "when given a full URI" do
-      expect(client.send(:extract_path, "https://v3.recurly.com#{path}")).to eql(path)
-    end
-  end
 end

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -56,17 +56,18 @@ RSpec.describe Recurly::Client do
       end
     end
 
-    describe "#get_resource_count" do
+    describe "#head" do
       let(:response) do
         resp = Net::HTTPOK.new(1.0, "200", "OK")
-        allow(resp).to receive(:body) { nil }
+        allow(resp).to receive(:body) { "" }
         resp_headers.each { |key, v| resp[key] = v }
         resp
       end
 
-      it "should return the 'recurly-total-records' header value" do
-        expect(net_http).to receive(:request).with(instance_of(Net::HTTP::Head)).and_return(response)
-        expect(subject.list_accounts.count).to eq(resp_headers["recurly-total-records"].to_i)
+      it "should return an Empty resource" do
+        expect(net_http).to receive(:request).and_return(response)
+        empty = subject.send(:head, "/accounts")
+        expect(empty).to be_instance_of Recurly::Resources::Empty
       end
     end
 

--- a/spec/recurly/pager_spec.rb
+++ b/spec/recurly/pager_spec.rb
@@ -6,15 +6,9 @@ RSpec.describe Recurly::Pager do
   let(:api_key) { "recurly-good" }
   let(:client) { Recurly::Client.new(api_key: api_key, subdomain: subdomain) }
   let(:path) { "/next_url" }
-  let(:options) { { a: 1, b: DateTime.new(2020, 1, 1) } }
+  let(:options) { { a: 1, b: "testing" } }
   subject do
     Recurly::Pager.new(client: client, path: path, options: options)
-  end
-
-  describe ".new" do
-    it "should build next from path and options" do
-      expect(subject.next).to eq("/next_url?a=1&b=2020-01-01T00%3A00%3A00%2B00%3A00")
-    end
   end
 
   describe "#requires_client?" do
@@ -35,8 +29,8 @@ RSpec.describe Recurly::Pager do
       page
     end
     it "should update the 'limit' param to 1" do
-      expect(client).to receive(:next_page)
-                          .with("/next_url?limit=1&a=1")
+      expect(client).to receive(:get)
+                          .with("/next_url", { limit: 1, a: 1 })
                           .and_return(first_response)
       subject.first
     end
@@ -44,7 +38,7 @@ RSpec.describe Recurly::Pager do
 
   it "#count" do
     expect(client).to receive(:get_resource_count)
-                        .with("/next_url?a=1&b=2020-01-01T00%3A00%3A00%2B00%3A00")
+                        .with("/next_url", { a: 1, b: "testing" })
     subject.count
   end
 
@@ -73,15 +67,9 @@ RSpec.describe Recurly::Pager do
 
     describe "#each_page" do
       it "should present an enumerator pages" do
-        expect(client).to receive(:next_page).exactly(3).times
-        allow(client).to receive(:next_page).and_return(more_response)
-        page_num = 0
+        expect(client).to receive(:get).exactly(3).times
+        allow(client).to receive(:get).and_return(more_response, more_response, done_response)
         subject.each_page do |page|
-          page_num += 1
-          if page_num == 2
-            # on the 3rd call let's return the done_response
-            allow(client).to receive(:next_page).and_return(done_response)
-          end
           expect(page).to be_an Array
           expect(page).to all(be_a Recurly::Resources::Account)
         end
@@ -92,20 +80,23 @@ RSpec.describe Recurly::Pager do
     end
     describe "#each" do
       it "should present an enumerator pages" do
-        expect(client).to receive(:next_page).exactly(3).times
-        allow(client).to receive(:next_page).and_return(more_response)
-        item_num = 0
+        expect(client).to receive(:get).exactly(3).times
+        allow(client).to receive(:get).and_return(more_response, more_response, done_response)
         subject.each do |item|
-          item_num += 1
-          if item_num >= 6
-            # on the 3rd call (2 items per page) let's return the done_response
-            allow(client).to receive(:next_page).and_return(done_response)
-          end
           expect(item).to be_a Recurly::Resources::Account
         end
       end
       it "should return an enumerator when not given a block" do
         expect(subject.each).to be_an Enumerator
+      end
+
+      it "#extract_path returns the path and parameters" do
+        allow(client).to receive(:get).and_return(more_response, done_response)
+        expect(client).to receive(:get).with("/next_url", anything)
+
+        subject.each do |item|
+          # NOOP
+        end
       end
     end
   end

--- a/spec/recurly/pager_spec.rb
+++ b/spec/recurly/pager_spec.rb
@@ -36,10 +36,21 @@ RSpec.describe Recurly::Pager do
     end
   end
 
-  it "#count" do
-    expect(client).to receive(:get_resource_count)
-                        .with("/next_url", { a: 1, b: "testing" })
-    subject.count
+  describe "#count" do
+    let(:head_response) do
+      response = double("Recurly::HTTP::Response", :total_records => 1337)
+
+      empty = Recurly::Resources::Empty.new
+      empty.instance_variable_set(:@response, response)
+      empty
+    end
+
+    it "#count" do
+      expect(client).to receive(:head)
+                          .with("/next_url", { a: 1, b: "testing" })
+                          .and_return(head_response)
+      expect(subject.count).to eq(1337)
+    end
   end
 
   context "enumerators" do


### PR DESCRIPTION
Only the `Pager` requests were including the optional query parameters when performing API requests.

This update moves the logic to handle query params from the `Pager` to the `Client` and consolidates some resulting portions of the `Pager` and `Client`