### PR TITLE
Ensure that path parameters are not empty strings

### DIFF
--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -267,10 +267,18 @@ RSpec.describe Recurly::Client do
 
   context "with bad url parameter arguments" do
     describe "#get" do
-      it "should throw an ArgumentError" do
+      it "should throw an ArgumentError with non-primitive arguments" do
         expect {
           subject.get_account(account_id: Recurly::Resources::Account.new)
         }.to raise_error(ArgumentError)
+      end
+
+      it "should throw an ArgumentError with nil arguments" do
+        expect { subject.get_account(account_id: nil) }.to raise_error(ArgumentError)
+      end
+
+      it "should throw an ArgumentError with empty arguments" do
+        expect { subject.get_account(account_id: "") }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
Adding a validation method that will ensure that path parameters are not empty strings to address issues where a `get_*` operation (`/resources/{resource_id}`) does not get handled by the API as a `list_*` operations (`/resources/`). The validation will also ensure that only approved types are used.