### PR TITLE
Implement Connection Pooling

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -1,5 +1,6 @@
 # Recurly is a Ruby client for Recurly's REST API.
 module Recurly
+  require 'recurly/connection_pool'
   require 'recurly/error'
   require 'recurly/helper'
   require 'recurly/api'

--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -96,6 +96,21 @@ module Recurly
       JS
     end
 
+    # Enabling the connection pool will use
+    # keep-alive and maintain a pool of connections to the server.
+    #
+    # @param enable [true, false] set to true to enable connection pool
+    def use_connection_pool(enable)
+      @use_connection_pool = enable
+    end
+
+    # Returns true if connection pooling is enabled
+    #
+    # @return [true, false]
+    def connection_pool_enabled?
+      defined?(@use_connection_pool) ? @use_connection_pool : false
+    end
+
     # Assigns a logger to log requests/responses and more.
     # The logger can only be set if the environment variable
     # `RECURLY_INSECURE_DEBUG` equals `true`.

--- a/lib/recurly/api/net_http_adapter.rb
+++ b/lib/recurly/api/net_http_adapter.rb
@@ -5,6 +5,11 @@ module Recurly
   class API
     module Net
       module HTTPAdapter
+
+        def connection_pool
+          @connection_pool ||= Recurly::ConnectionPool.new
+        end
+
         # A hash of Net::HTTP settings configured before the request.
         #
         # @return [Hash]
@@ -33,72 +38,76 @@ module Recurly
         }
 
         def request method, uri, options = {}
-          head = headers.dup
-          head.update options[:head] if options[:head]
-          head.delete_if { |_, value| value.nil? }
-          uri = base_uri + uri
-          if options[:params] && !options[:params].empty?
-            pairs = options[:params].map { |key, value|
-              "#{CGI.escape key.to_s}=#{CGI.escape value.to_s}"
-            }
-            uri += "?#{pairs.join '&'}"
-          end
-          self.validate_uri!(uri)
-          request = METHODS[method].new uri.request_uri, head
-          request.basic_auth(*[Recurly.api_key, nil].flatten[0, 2])
-          if options[:body]
-            request['Content-Type'] = content_type
-            request.body = options[:body]
-          end
-          if options[:etag]
-            request['If-None-Match'] = options[:etag]
-          end
-          if options[:format]
-            request['Accept'] = FORMATS[options[:format]]
-          end
-          if options[:locale]
-            request['Accept-Language'] = options[:locale]
-          end
-          http = ::Net::HTTP.new uri.host, uri.port
-          http.use_ssl = uri.scheme == 'https'
-          net_http.each_pair { |key, value| http.send "#{key}=", value }
-
-          if Recurly.logger
-            Recurly.log :info, "===> %s %s" % [request.method, uri]
-            headers = request.to_hash
-            headers['authorization'] &&= ['Basic [FILTERED]']
-            Recurly.log :debug, headers.inspect
-            if request.body && !request.body.empty?
-              Recurly.log :debug, XML.filter(request.body)
+          connection_pool.with_connection do |http|
+            head = headers.dup
+            head.update options[:head] if options[:head]
+            head.delete_if { |_, value| value.nil? }
+            uri = base_uri + uri
+            if options[:params] && !options[:params].empty?
+              pairs = options[:params].map { |key, value|
+                "#{CGI.escape key.to_s}=#{CGI.escape value.to_s}"
+              }
+              uri += "?#{pairs.join '&'}"
             end
-            start_time = Time.now
-          end
-
-          response = http.start { http.request request }
-          code = response.code.to_i
-
-          if Recurly.logger
-            latency = (Time.now - start_time) * 1_000
-            level = case code
-              when 200...300 then :info
-              when 300...400 then :warn
-              when 400...500 then :error
-              else                :fatal
+            self.validate_uri!(uri)
+            request = METHODS[method].new uri.request_uri, head
+            request.basic_auth(*[Recurly.api_key, nil].flatten[0, 2])
+            if options[:body]
+              request['Content-Type'] = content_type
+              request.body = options[:body]
             end
-            Recurly.log level, "<=== %d %s (%.1fms)" % [
-              code,
-              response.class.name[9, response.class.name.length].gsub(
-                /([a-z])([A-Z])/, '\1 \2'
-              ),
-              latency
-            ]
-            Recurly.log :debug, response.to_hash.inspect
-            Recurly.log :debug, response.body if response.body
-          end
+            if options[:etag]
+              request['If-None-Match'] = options[:etag]
+            end
+            if options[:format]
+              request['Accept'] = FORMATS[options[:format]]
+            end
+            if options[:locale]
+              request['Accept-Language'] = options[:locale]
+            end
 
-          case code
-            when 200...300 then response
-            else                raise ERRORS[code].new request, response
+            # only start the http connection if it was not previously started
+            http.start unless http.started?
+
+            net_http.each_pair { |key, value| http.send "#{key}=", value }
+
+            if Recurly.logger
+              Recurly.log :info, "===> %s %s" % [request.method, uri]
+              headers = request.to_hash
+              headers['authorization'] &&= ['Basic [FILTERED]']
+              Recurly.log :debug, headers.inspect
+              if request.body && !request.body.empty?
+                Recurly.log :debug, XML.filter(request.body)
+              end
+              start_time = Time.now
+            end
+
+            response = http.request request
+            code = response.code.to_i
+
+            if Recurly.logger
+              latency = (Time.now - start_time) * 1_000
+              level = case code
+                when 200...300 then :info
+                when 300...400 then :warn
+                when 400...500 then :error
+                else                :fatal
+              end
+              Recurly.log level, "<=== %d %s (%.1fms)" % [
+                code,
+                response.class.name[9, response.class.name.length].gsub(
+                  /([a-z])([A-Z])/, '\1 \2'
+                ),
+                latency
+              ]
+              Recurly.log :debug, response.to_hash.inspect
+              Recurly.log :debug, response.body if response.body
+            end
+
+            case code
+              when 200...300 then response
+              else                raise ERRORS[code].new request, response
+            end
           end
         rescue Errno::ECONNREFUSED => e
           raise Error, e.message

--- a/lib/recurly/connection_pool.rb
+++ b/lib/recurly/connection_pool.rb
@@ -8,6 +8,13 @@ module Recurly
     end
 
     def with_connection
+      # just create and tear down a new connection every time
+      # unless connection pooling is enabled
+      unless Recurly.connection_pool_enabled?
+        http = init_http_connection(keep_alive: false)
+        return http.start { yield http }
+      end
+
       http = nil
       @mutex.synchronize do
         http = @pool.pop
@@ -27,12 +34,14 @@ module Recurly
       response
     end
 
-    def init_http_connection
+    def init_http_connection(keep_alive: true)
       host = "#{Recurly.subdomain}.recurly.com"
       http = Net::HTTP.new(host, 443)
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-      http.keep_alive_timeout = 600
+      if keep_alive
+        http.keep_alive_timeout = 600
+      end
 
       http
     end

--- a/lib/recurly/connection_pool.rb
+++ b/lib/recurly/connection_pool.rb
@@ -1,0 +1,40 @@
+require "net/https"
+
+module Recurly
+  class ConnectionPool
+    def initialize
+      @mutex = Mutex.new
+      @pool = []
+    end
+
+    def with_connection
+      http = nil
+      @mutex.synchronize do
+        http = @pool.pop
+      end
+
+      # create connection if the pool was empty
+      http ||= init_http_connection
+
+      response = yield http
+
+      if http.started?
+        @mutex.synchronize do
+          @pool.push(http)
+        end
+      end
+
+      response
+    end
+
+    def init_http_connection
+      host = "#{Recurly.subdomain}.recurly.com"
+      http = Net::HTTP.new(host, 443)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      http.keep_alive_timeout = 600
+
+      http
+    end
+  end
+end

--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -198,7 +198,7 @@ module Recurly
         billing_info.add_element('three_d_secure_action_result_token_id', three_d_secure_action_result_token_id)
         builder.to_s
       end
-      
+
       reload API.put("#{uri}/convert_trial", body) 
       true
     end

--- a/spec/recurly/connection_pool_spec.rb
+++ b/spec/recurly/connection_pool_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe ConnectionPool do
+  subject { ConnectionPool.new }
+  
+  describe "when pool is empty" do
+    it "must create a connection" do
+      http = subject.with_connection { |h| h.start && h }
+      http.started?.must_equal true
+    end
+  end
+
+  describe "when pool has at least one started connection" do
+    # start one connection and get the http object
+    let(:http) { subject.with_connection { |h| h.start && h } }
+
+    it "must re-use the connection if it's available" do
+      # make sure it's started
+      http
+      http2 = subject.with_connection { |h| h }
+      # they should be the same connection
+      http.must_equal http2
+    end
+
+    it "must make a new connection if it's not available" do
+      # start it
+      subject.with_connection do |http1|
+        # http1 is checked out, so a new http2 should be created
+        subject.with_connection do |http2|
+          # they should not be the same connection
+          (http1 == http2).must_equal false
+        end
+      end
+    end
+  end
+
+  describe "when checked out connection fails to start" do
+    it "must not check it back into the pool" do
+      # we have intentially not started this http object in the block
+      http1 = subject.with_connection { |h| h }
+      # we are starting this second one
+      http2 = subject.with_connection { |h| h.start && h }
+      # these should be different objects
+      (http1 == http2).must_equal false
+
+      # if we ask for another one
+      http3 = subject.with_connection { |h| h }
+      # it should have reused http2
+      http2.must_equal http3
+    end
+
+    it "must make a new connection if it's not available" do
+      # start it
+      subject.with_connection do |http1|
+        # http1 is checked out, so a new http2 should be created
+        subject.with_connection do |http2|
+          # they should not be the same connection
+          (http1 == http2).must_equal false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Backporting the connection pooling code from V3 to ensure that connections are being properly reused. We should ensure that there have been no behavioral changes.

I've adjusted this so you must opt-in to it:

```
Recurly.use_connection_pool(true)
```