### PR TITLE
Support the programmer passing their own logger

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -41,6 +41,27 @@ client = Recurly::Client.new(api_key: API_KEY2)
 sub = client.get_subscription(subscription_id: 'abcd7890')
 ```
 
+## Logging
+
+The client constructor optionally accepts a logger provided by the programmer. The logger you pass should be an instance of ruby stdlib's [Logger](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html)
+or follow the same interface. By default, the client creates a logger to `STDOUT` with level `INFO`.
+
+```ruby
+require 'logger'
+
+# Create a logger to STDOUT
+logger = Logger.new(STDOUT)
+logger.level = Logger::INFO
+
+# You could also use an existing logger
+# If you are using Rails you may want to use your application's logger
+logger = Rails.logger
+
+client = Recurly::Client.new(api_key: API_KEY, logger: logger)
+```
+
+> *SECURITY WARNING*: The log level should never be set to DEBUG in production. This could potentially result in sensitive data in your logging system.
+
 # Operations
 
 The {Recurly::Client} contains every `operation` you can perform on the site as a list of methods. Each method is documented explaining

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -44,7 +44,7 @@ sub = client.get_subscription(subscription_id: 'abcd7890')
 ## Logging
 
 The client constructor optionally accepts a logger provided by the programmer. The logger you pass should be an instance of ruby stdlib's [Logger](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html)
-or follow the same interface. By default, the client creates a logger to `STDOUT` with level `INFO`.
+or follow the same interface. By default, the client creates a logger to `STDOUT` with level `WARN`.
 
 ```ruby
 require 'logger'

--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -148,12 +148,12 @@ module Recurly
           http.start unless http.started?
           log_attrs = {
             method: request.method,
-            path: request.path
+            path: request.path,
           }
           if @logger.level < Logger::INFO
             log_attrs[:request_body] = request.body
             # No need to log the authorization header
-            headers = request.to_hash.reject { |k,_| k&.downcase == 'authorization' }
+            headers = request.to_hash.reject { |k, _| k&.downcase == "authorization" }
             log_attrs[:request_headers] = headers
           end
 
@@ -333,8 +333,8 @@ module Recurly
     %i(debug info warn error fatal).each do |level|
       define_method "log_#{level}" do |tag, **attrs|
         @logger.send(level, "Recurly") do
-           msg = attrs.each_pair.map { |k,v| "#{k}=#{v.inspect}" }.join(" ")
-           "[#{tag}] #{msg}"
+          msg = attrs.each_pair.map { |k, v| "#{k}=#{v.inspect}" }.join(" ")
+          "[#{tag}] #{msg}"
         end
       end
     end

--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -46,7 +46,7 @@ module Recurly
     #
     # @param api_key [String] The private API key
     # @param logger [Logger] A logger to use. Defaults to creating a new STDOUT logger with level WARN.
-    def initialize(api_key:, site_id: nil, subdomain: nil, logger: nil, **options)
+    def initialize(api_key:, site_id: nil, subdomain: nil, logger: nil)
       set_site_id(site_id, subdomain)
       set_api_key(api_key)
 

--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -45,14 +45,14 @@ module Recurly
     #   sub = client.get_subscription(subscription_id: 'uuid-abcd7890')
     #
     # @param api_key [String] The private API key
-    # @param logger [Logger] A logger to use. Defaults to creating a new STDOUT logger with level INFO.
+    # @param logger [Logger] A logger to use. Defaults to creating a new STDOUT logger with level WARN.
     def initialize(api_key:, site_id: nil, subdomain: nil, logger: nil, **options)
       set_site_id(site_id, subdomain)
       set_api_key(api_key)
 
       if logger.nil?
         @logger = Logger.new(STDOUT).tap do |l|
-          l.level = Logger::INFO
+          l.level = Logger::WARN
         end
       else
         @logger = logger
@@ -330,6 +330,7 @@ module Recurly
       end
     end
 
+    # Define a private `log_<level>` method for each log level
     %i(debug info warn error fatal).each do |level|
       define_method "log_#{level}" do |tag, **attrs|
         @logger.send(level, "Recurly") do

--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -15,11 +15,11 @@ module Recurly
     CA_FILE = File.join(File.dirname(__FILE__), "../data/ca-certificates.crt")
     BINARY_TYPES = [
       "application/pdf",
-    ]
+    ].freeze
     JSON_CONTENT_TYPE = "application/json"
     MAX_RETRIES = 3
-
-    BASE36_ALPHABET = ("0".."9").to_a + ("a".."z").to_a
+    LOG_LEVELS = %i(debug info warn error fatal).freeze
+    BASE36_ALPHABET = (("0".."9").to_a + ("a".."z").to_a).freeze
 
     # Initialize a client. It requires an API key.
     #
@@ -55,6 +55,9 @@ module Recurly
           l.level = Logger::WARN
         end
       else
+        unless LOG_LEVELS.all? { |lev| logger.respond_to?(lev) }
+          raise ArgumentError, "You must pass in a logger implementation that responds to the following messages: #{LOG_LEVELS}"
+        end
         @logger = logger
       end
 
@@ -331,7 +334,7 @@ module Recurly
     end
 
     # Define a private `log_<level>` method for each log level
-    %i(debug info warn error fatal).each do |level|
+    LOG_LEVELS.each do |level|
       define_method "log_#{level}" do |tag, **attrs|
         @logger.send(level, "Recurly") do
           msg = attrs.each_pair.map { |k, v| "#{k}=#{v.inspect}" }.join(" ")

--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -45,12 +45,28 @@ module Recurly
     #   sub = client.get_subscription(subscription_id: 'uuid-abcd7890')
     #
     # @param api_key [String] The private API key
-    # @param site_id [String] The site you wish to be scoped to.
-    # @param subdomain [String] Optional subdomain for the site you wish to be scoped to. Providing this makes all the `site_id` parameters optional.
-    def initialize(api_key:, site_id: nil, subdomain: nil, **options)
+    # @param logger [Logger] A logger to use. Defaults to creating a new STDOUT logger with level INFO.
+    def initialize(api_key:, site_id: nil, subdomain: nil, logger: nil, **options)
       set_site_id(site_id, subdomain)
       set_api_key(api_key)
-      set_options(options)
+
+      if logger.nil?
+        @logger = Logger.new(STDOUT).tap do |l|
+          l.level = Logger::INFO
+        end
+      else
+        @logger = logger
+      end
+
+      if @logger.level < Logger::INFO
+        msg = <<-MSG
+        The Recurly logger should not be initialized
+        beyond the level INFO. It is currently configured to emit
+        headers and request / response bodies. This has the potential to leak
+        PII and other sensitive information and should never be used in production.
+        MSG
+        log_warn("SECURITY_WARNING", message: msg)
+      end
 
       # execute block with this client if given
       yield(self) if block_given?
@@ -100,7 +116,6 @@ module Recurly
       if request_data
         request_class.new(request_data).validate!
         json_body = JSON.dump(request_data)
-        logger.info("PUT BODY #{json_body}")
         request.body = json_body
       end
       http_response = run_request(request, options)
@@ -115,9 +130,6 @@ module Recurly
     end
 
     private
-
-    # @return [Logger]
-    attr_reader :logger
 
     @connection_pool = Recurly::ConnectionPool.new
 
@@ -134,13 +146,36 @@ module Recurly
 
         begin
           http.start unless http.started?
+          log_attrs = {
+            method: request.method,
+            path: request.path
+          }
+          if @logger.level < Logger::INFO
+            log_attrs[:request_body] = request.body
+            # No need to log the authorization header
+            headers = request.to_hash.reject { |k,_| k&.downcase == 'authorization' }
+            log_attrs[:request_headers] = headers
+          end
+
+          log_info("Request", **log_attrs)
+          start = Time.now
           response = http.request(request)
+          elapsed = Time.now - start
 
           # GETs are safe to retry after a server error, requests with an Idempotency-Key will return the prior response
           if response.kind_of?(Net::HTTPServerError) && request.is_a?(Net::HTTP::Get)
             retries += 1
+            log_info("Retrying", retries: retries, **log_attrs)
+            start = Time.now
             response = http.request(request) if retries < MAX_RETRIES
+            elapsed = Time.now - start
           end
+
+          if @logger.level < Logger::INFO
+            log_attrs[:response_body] = response.body
+            log_attrs[:response_headers] = response.to_hash
+          end
+          log_info("Response", time_ms: (elapsed * 1_000).floor, status: response.code, **log_attrs)
 
           response
         rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, Errno::ECONNABORTED,
@@ -190,8 +225,6 @@ module Recurly
     def set_http_options(http, options)
       http.open_timeout = options[:open_timeout] || 20
       http.read_timeout = options[:read_timeout] || 60
-
-      http.set_debug_output(logger) if @log_level <= Logger::INFO && !http.started?
     end
 
     def handle_response!(request, http_response)
@@ -232,7 +265,7 @@ module Recurly
 
     def read_headers(response)
       if !@_ignore_deprecation_warning && response.headers["Recurly-Deprecated"]&.upcase == "TRUE"
-        puts "[recurly-client-ruby] WARNING: Your current API version \"#{api_version}\" is deprecated and will be sunset on #{response.headers["Recurly-Sunset-Date"]}"
+        log_warn("DEPRECTATION WARNING", message: "Your current API version \"#{api_version}\" is deprecated and will be sunset on #{response.headers["Recurly-Sunset-Date"]}")
       end
       response
     end
@@ -297,10 +330,13 @@ module Recurly
       end
     end
 
-    def set_options(options)
-      @log_level = options[:log_level] || Logger::WARN
-      @logger = Logger.new(STDOUT)
-      @logger.level = @log_level
+    %i(debug info warn error fatal).each do |level|
+      define_method "log_#{level}" do |tag, **attrs|
+        @logger.send(level, "Recurly") do
+           msg = attrs.each_pair.map { |k,v| "#{k}=#{v.inspect}" }.join(" ")
+           "[#{tag}] #{msg}"
+        end
+      end
     end
   end
 end

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -181,11 +181,59 @@ RSpec.describe Recurly::Client do
     end
 
     context "logging" do
-      describe "#log_level" do
-        let(:client_options) { { api_key: api_key } }
+      describe "initialize" do
+        context "with a valid logger" do
+          let(:options) do
+            {
+              api_key: api_key,
+              logger: Logger.new(STDOUT).tap { |l| l.level = Logger::WARN },
+            }
+          end
 
+          it "should allow a valid Logger to be passed in" do
+            expect {
+              Recurly::Client.new(**options)
+            }.not_to raise_error
+          end
+        end
+
+        context "with a debug logger" do
+          let(:logger) do
+            Logger.new(STDOUT).tap { |l| l.level = Logger::DEBUG }
+          end
+          let(:options) do
+            {
+              api_key: api_key,
+              logger: logger,
+            }
+          end
+
+          it "should allow but warn the programmer" do
+            expect(logger).to receive(:warn)
+            expect {
+              Recurly::Client.new(**options)
+            }.not_to raise_error
+          end
+        end
+
+        context "with a invalid logger" do
+          let(:options) do
+            {
+              api_key: api_key,
+              logger: {}, # some random object
+            }
+          end
+
+          it "should allow a valid Logger to be passed in" do
+            expect {
+              Recurly::Client.new(**options)
+            }.to raise_error(ArgumentError)
+          end
+        end
+      end
+
+      describe "log level" do
         it "defaults to WARN" do
-          expect(net_http).not_to receive(:set_debug_output)
           expect(client.instance_variable_get(:@logger).level).to eql(Logger::WARN)
 
           expect(net_http).to receive(:request).and_return(response)

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -180,24 +180,21 @@ RSpec.describe Recurly::Client do
       end
     end
 
-    describe "#log_level" do
-      context "set to Logger::DEBUG" do
-        let(:client_options) { { api_key: api_key, log_level: Logger::DEBUG } }
+    context "logging" do
+      describe "#log_level" do
+        let(:client_options) { { api_key: api_key } }
 
-        it "sets the Net::HTTP logger" do
-          expect(net_http).to receive(:set_debug_output).with(client.instance_variable_get(:@logger))
-          expect(client.instance_variable_get(:@logger).level).to eql(Logger::DEBUG)
+        it "defaults to WARN" do
+          expect(net_http).not_to receive(:set_debug_output)
+          expect(client.instance_variable_get(:@logger).level).to eql(Logger::WARN)
 
           expect(net_http).to receive(:request).and_return(response)
           subject.get_account(account_id: "code-benjamin-du-monde")
         end
-      end
 
-      context "defaults to Logger::WARN" do
-        it "does not set the Net::HTTP logger" do
-          expect(client.instance_variable_get(:@log_level)).to eql(Logger::WARN)
+        # It should never enable net http debug as that is dangerous
+        it "never enables the net_http debug output" do
           expect(net_http).not_to receive(:set_debug_output)
-
           expect(net_http).to receive(:request).and_return(response)
           subject.get_account(account_id: "code-benjamin-du-monde")
         end


### PR DESCRIPTION
This adds a `logger` option when creating the Client. It also slims down some of the logging messages. By default we will set the logging level to `INFO` which only logs high level HTTP details:

```
I, [2020-05-28T18:43:13.164922 #119]  INFO -- Recurly: [Request] method="POST" path="/accounts"
I, [2020-05-28T18:43:13.362743 #119]  INFO -- Recurly: [Response] time_ms=197 status="201" method="POST" path="/accounts"
I, [2020-05-28T18:43:13.364346 #119]  INFO -- Recurly: [Request] method="DELETE" path="/accounts/code-0d18c3c49f7"
I, [2020-05-28T18:43:13.525843 #119]  INFO -- Recurly: [Response] time_ms=161 status="200" method="DELETE" path="/accounts/code-0d18c3c49f7"
```

Setting level `DEBUG` will log things like headers and request / response bodies.
