### PR TITLE
Let bump2version manage the getting started doc

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -10,3 +10,7 @@ serialize =
 
 [bumpversion:file:lib/recurly/version.rb]
 
+[bumpversion:file:GETTING_STARTED.md]
+parse = (?P<major>\d+)\.(?P<minor>\d+)
+serialize = {major}.{minor}
+

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -5,7 +5,7 @@ This repository houses the official ruby client for Recurly's V3 API.
 In your Gemfile, add `recurly` as a dependency.
 
 ```ruby
-gem 'recurly', '~> 3.2'
+gem 'recurly', '~> 3.5'
 ```
 
 > *Note*: We try to follow [semantic versioning](https://semver.org/) and will only apply breaking changes to major versions.


### PR DESCRIPTION
This ensures that the version number in the install instructions of the the GETTING_STARTED doc stays up to date.