### PR TITLE
Better format error message

### DIFF
--- a/scripts/format
+++ b/scripts/format
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-set -e
 
 if [ "$1" == "--check" ]; then
   ./bin/rufo . --check
+  RESULT=$?
+  if [ $RESULT != 0 ]; then
+    echo "Code is not properly formatted. Please execute ./scripts/format to autoformat the code."
+    exit $RESULT
+  fi
 else
   ./bin/rufo . -x
 fi


### PR DESCRIPTION
When the tests fail due to a code format error, the message is not very clear:

```
[I] ⋊> ~/R/v/c/ruby on clearer-error-message-with-formatting ⨯ ./scripts/test                                                                                                                 
Checking style...
Formatting ./spec/recurly/client_spec.rb produced changes
```

This change adds a nicer error message:

```
[I] ⋊> ~/R/v/c/ruby on clearer-error-message-with-formatting ⨯ ./scripts/test                                                                                                                
Checking style...
Formatting ./spec/recurly/client_spec.rb produced changes
Code is not properly formatted. Please execute ./scripts/format to autoformat the code.
```