### PR TITLE
Support items on subscriptions

### DIFF
--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -18,7 +18,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.26'
+    RECURLY_API_VERSION = '2.27'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -32,6 +32,7 @@ module Recurly
       tax_code
       trial_requires_billing_info
       auto_renew
+      allow_any_item_on_subscriptions
       created_at
       updated_at
     )

--- a/lib/recurly/subscription/add_ons.rb
+++ b/lib/recurly/subscription/add_ons.rb
@@ -25,7 +25,12 @@ module Recurly
       def << add_on
         add_on = SubscriptionAddOn.new(add_on, @subscription)
 
-        exist = @add_ons.find { |a| a.add_on_code == add_on.add_on_code }
+        exist = @add_ons.find do |a|
+          source1 = a.add_on_source || "plan_add_on"
+          source2 = add_on.add_on_source || "plan_add_on"
+          a.add_on_code == add_on.add_on_code && source1 == source2
+        end
+
         if exist
           exist.quantity ||= 1
           exist.quantity += add_on.quantity || 1

--- a/lib/recurly/subscription_add_on.rb
+++ b/lib/recurly/subscription_add_on.rb
@@ -13,6 +13,7 @@ module Recurly
       add_on_type
       usage_type
       usage_percentage
+      add_on_source
     )
 
     attr_reader :subscription
@@ -28,6 +29,7 @@ module Recurly
         if add_on.unit_amount_in_cents
           self.unit_amount_in_cents = add_on.unit_amount_in_cents.to_i
         end
+        self.add_on_source = add_on.add_on_source
       when Hash
         self.attributes = add_on
       when String, Symbol

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -128,6 +128,23 @@ describe Subscription do
       ])
     end
 
+    it "must allow add-on from item" do
+      item = Item.new(
+        item_code: 'mockitem',
+        name: 'Mock Item'
+      )
+      subscription = Subscription.new add_ons: [
+        add_on_code: item.item_code,
+        add_on_source: "item", 
+        unit_amount_in_cents: 199, 
+        quantity: 2
+      ]
+
+      subscription.add_ons.to_a.must_equal([
+        SubscriptionAddOn.new("add_on_code": item.item_code, "add_on_source": "item", "unit_amount_in_cents": 199, "quantity": 2)
+      ])
+    end
+
     it "must serialize" do
       subscription = Subscription.new
       subscription.add_ons << :trial


### PR DESCRIPTION
This PR adds support for items on subscriptions, where merchants may now associate a subscription add-on with an item in their catalog.

`allow_any_item_on_subscriptions` has been added to the `Plan` class. It is used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used.

`add_on_source`, added to the `SubscriptionAddOn` class, is used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add-on data will be pulled from the plan's add-ons. If the associated  `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog.

Code example:
```ruby
# create sub add-on with item
addon1 = Recurly::SubscriptionAddOn.new(item.item_code)
addon1.quantity = 1
addon1.add_on_source = "item"
addon1.unit_amount_in_cents = 299

# create sub add-on with existing add-on
addon2 = Recurly::SubscriptionAddOn.new(add_on.add_on_code)

# create subscription
subscription = Recurly::Subscription.create!(
    plan_code:             plan.plan_code,
    currency:              'USD',
    unit_amount_in_cents:  1200,
    account:               {
      account_code: (account.account_code),
      billing_info: valid_billing_info
    },
    subscription_add_ons:  [addon1, addon2],
)
```