### PR TITLE
Release 2.18.10

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.18.9
+current_version = 2.18.10
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.10"></a>
+## v.2.18.10 (2020-06-30)
+
+This bumps us to API version 2.27. There are no breaking changes.
+
+* BACS support [PR](https://github.com/recurly/recurly-client-ruby/pull/595)
+* Support items on subscriptions [PR](https://github.com/recurly/recurly-client-ruby/pull/598)
+
 <a name="v2.18.9"></a>
 ## v.2.18.9 (2020-04-14)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.18.9'
+gem 'recurly', '~> 2.18.10'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,6 +1,6 @@
 module Recurly
   module Version
-    VERSION = "2.18.9"
+    VERSION = "2.18.10"
 
     class << self
       def inspect


### PR DESCRIPTION
This bumps us to API version 2.27. There are no breaking changes.

* BACS support https://github.com/recurly/recurly-client-ruby/pull/595
* Support items on subscriptions https://github.com/recurly/recurly-client-ruby/pull/598