### PR TITLE
Adding hierarchical errors

### DIFF
--- a/lib/recurly/errors/api_errors.rb
+++ b/lib/recurly/errors/api_errors.rb
@@ -4,38 +4,80 @@
 # need and we will usher them to the appropriate places.
 module Recurly
   module Errors
-    class BadRequestError < Errors::APIError; end
+    ERROR_MAP = {
+      "500" => "InternalServerError",
+      "502" => "BadGatewayError",
+      "503" => "ServiceUnavailableError",
+      "304" => "NotModifiedError",
+      "400" => "BadRequestError",
+      "401" => "UnauthorizedError",
+      "402" => "PaymentRequiredError",
+      "403" => "ForbiddenError",
+      "404" => "NotFoundError",
+      "406" => "NotAcceptableError",
+      "412" => "PreconditionFailedError",
+      "422" => "UnprocessableEntityError",
+      "429" => "TooManyRequestsError",
+    }
 
-    class InternalServerError < Errors::APIError; end
+    class ResponseError < Errors::APIError; end
 
-    class ImmutableSubscriptionError < Errors::APIError; end
+    class ServerError < ResponseError; end
 
-    class InvalidApiKeyError < Errors::APIError; end
+    class InternalServerError < ServerError; end
 
-    class InvalidApiVersionError < Errors::APIError; end
+    class BadGatewayError < ServerError; end
 
-    class InvalidContentTypeError < Errors::APIError; end
+    class ServiceUnavailableError < ServerError; end
 
-    class InvalidPermissionsError < Errors::APIError; end
+    class RedirectionError < ResponseError; end
 
-    class InvalidTokenError < Errors::APIError; end
+    class NotModifiedError < ResponseError; end
 
-    class NotFoundError < Errors::APIError; end
+    class ClientError < Errors::APIError; end
 
-    class SimultaneousRequestError < Errors::APIError; end
+    class BadRequestError < ClientError; end
 
-    class TransactionError < Errors::APIError; end
+    class InvalidContentTypeError < BadRequestError; end
 
-    class UnauthorizedError < Errors::APIError; end
+    class UnauthorizedError < ClientError; end
 
-    class UnavailableInApiVersionError < Errors::APIError; end
+    class PaymentRequiredError < ClientError; end
 
-    class UnknownApiVersionError < Errors::APIError; end
+    class ForbiddenError < ClientError; end
 
-    class ValidationError < Errors::APIError; end
+    class InvalidApiKeyError < ForbiddenError; end
 
-    class MissingFeatureError < Errors::APIError; end
+    class InvalidPermissionsError < ForbiddenError; end
 
-    class RateLimitedError < Errors::APIError; end
+    class NotFoundError < ClientError; end
+
+    class NotAcceptableError < ClientError; end
+
+    class UnknownApiVersionError < NotAcceptableError; end
+
+    class UnavailableInApiVersionError < NotAcceptableError; end
+
+    class InvalidApiVersionError < NotAcceptableError; end
+
+    class PreconditionFailedError < ClientError; end
+
+    class UnprocessableEntityError < ClientError; end
+
+    class ValidationError < UnprocessableEntityError; end
+
+    class MissingFeatureError < UnprocessableEntityError; end
+
+    class TransactionError < UnprocessableEntityError; end
+
+    class SimultaneousRequestError < UnprocessableEntityError; end
+
+    class ImmutableSubscriptionError < UnprocessableEntityError; end
+
+    class InvalidTokenError < UnprocessableEntityError; end
+
+    class TooManyRequestsError < ClientError; end
+
+    class RateLimitedError < TooManyRequestsError; end
   end
 end

--- a/spec/recurly/errors_spec.rb
+++ b/spec/recurly/errors_spec.rb
@@ -3,7 +3,7 @@ require "date"
 
 RSpec.describe Recurly::Errors::APIError do
   describe ".error_class" do
-    error_keys = Recurly::Errors.constants - [:APIError]
+    error_keys = Recurly::Errors.constants - [:APIError, :ERROR_MAP]
     error_keys = error_keys.map do |key|
       key.to_s.split(/(?=[A-Z])/).map(&:downcase).join("_")
     end


### PR DESCRIPTION
Non-breaking update to error classes to give them a hierarchical structure. This will facilitate differentiating between a `ClientError` and a `ServerError` for example.

New error classes have also been added to be parent classes for some existing errors (e.g. `ForbiddenError` is a new class and both `InvalidApiKeyError` and `InvalidPermissionsError` extend it)

