### PR TITLE
Update tiers for subscription add-ons

### DIFF
--- a/lib/recurly/add_on.rb
+++ b/lib/recurly/add_on.rb
@@ -2,6 +2,7 @@ module Recurly
   class AddOn < Resource
     # @return [Plan]
     belongs_to :plan
+    # @return [[Tier], []]
     has_many :tiers, class_name: :Tier, readonly: false
 
     define_attribute_methods %w(

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -1,5 +1,6 @@
 require 'date'
 require 'erb'
+require 'pry'
 
 module Recurly
   # The base class for all Recurly resources (e.g. {Account}, {Subscription},
@@ -824,9 +825,9 @@ module Recurly
 
         # Duck-typing here is problematic because of ActiveSupport's #to_xml.
         case value
-        when Resource, Subscription::AddOns
+        when Resource
           value.to_xml options.merge(:builder => node)
-        when Array
+        when Array, Subscription::AddOns
           value.each do |e|
             if e.is_a? Recurly::Resource
               # create a node to hold this resource

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -829,7 +829,19 @@ module Recurly
           value.to_xml options.merge(:builder => node)
         when Array, Subscription::AddOns
           value.each do |e|
-            if e.is_a? Recurly::Resource
+            if e.is_a? Recurly::Tier
+              if self.is_a? Recurly::AddOn
+                # create a node to hold this resource
+                e_node = node.add_element Helper.singularize(key)
+                # serialize the resource into this node
+                e.to_xml(options.merge(builder: e_node))
+              elsif self.is_a? Recurly::SubscriptionAddOn
+                # create a node to hold this resource
+                e_node = node.add_element Helper.singularize(key)
+                # serialize the resource into this node
+                e.to_xml_tier(options.merge(builder: e_node))
+              end
+            elsif e.is_a? Recurly::Resource
               # create a node to hold this resource
               e_node = node.add_element Helper.singularize(key)
               # serialize the resource into this node

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -1,6 +1,5 @@
 require 'date'
 require 'erb'
-require 'pry'
 
 module Recurly
   # The base class for all Recurly resources (e.g. {Account}, {Subscription},
@@ -829,23 +828,17 @@ module Recurly
           value.to_xml options.merge(:builder => node)
         when Array, Subscription::AddOns
           value.each do |e|
-            if e.is_a? Recurly::Tier
-              if self.is_a? Recurly::AddOn
+            if e.is_a? Recurly::Resource
+              if self.is_a? Recurly::SubscriptionAddOn
+                e_node = node.add_element Helper.singularize(key)
+                # formats xml for subscription add-on tiers
+                e.to_xml_tier(options.merge(builder: e_node))
+              else
                 # create a node to hold this resource
                 e_node = node.add_element Helper.singularize(key)
                 # serialize the resource into this node
                 e.to_xml(options.merge(builder: e_node))
-              elsif self.is_a? Recurly::SubscriptionAddOn
-                # create a node to hold this resource
-                e_node = node.add_element Helper.singularize(key)
-                # serialize the resource into this node
-                e.to_xml_tier(options.merge(builder: e_node))
               end
-            elsif e.is_a? Recurly::Resource
-              # create a node to hold this resource
-              e_node = node.add_element Helper.singularize(key)
-              # serialize the resource into this node
-              e.to_xml(options.merge(builder: e_node))
             else
               # it's just a primitive value
               node.add_element(Helper.singularize(key), e)

--- a/lib/recurly/subscription_add_on.rb
+++ b/lib/recurly/subscription_add_on.rb
@@ -32,9 +32,7 @@ module Recurly
           self.unit_amount_in_cents = add_on.unit_amount_in_cents.to_i
         end
         self.add_on_source = add_on.add_on_source
-        if add_on.tiers.length != 0
-          self.tiers = add_on.tiers 
-        end
+        self.tiers = add_on.tiers if add_on.tiers.any?
       when Hash
         self.attributes = add_on
       when String, Symbol

--- a/lib/recurly/subscription_add_on.rb
+++ b/lib/recurly/subscription_add_on.rb
@@ -19,7 +19,6 @@ module Recurly
     )
 
     attr_reader :subscription
-    attr_reader :tier
 
     def initialize add_on = nil, subscription = nil
       super()
@@ -34,9 +33,6 @@ module Recurly
         end
         self.add_on_source = add_on.add_on_source
         if add_on.tiers.length != 0
-          # includes tiers array in PUT request
-          puts "ADD-ON.TIERS: #{add_on.tiers}"
-          puts "SELF-ON.TIERS: #{self.tiers}"
           self.tiers = add_on.tiers 
         end
       when Hash

--- a/lib/recurly/subscription_add_on.rb
+++ b/lib/recurly/subscription_add_on.rb
@@ -5,6 +5,8 @@ module Recurly
 
     # @return [Pager<Usage>, []]
     has_many :usage
+    # @return [[Tier], []]
+    has_many :tiers, class_name: :Tier, readonly: false
 
     define_attribute_methods %w(
       add_on_code
@@ -17,6 +19,7 @@ module Recurly
     )
 
     attr_reader :subscription
+    attr_reader :tier
 
     def initialize add_on = nil, subscription = nil
       super()
@@ -30,6 +33,12 @@ module Recurly
           self.unit_amount_in_cents = add_on.unit_amount_in_cents.to_i
         end
         self.add_on_source = add_on.add_on_source
+        if add_on.tiers.length != 0
+          # includes tiers array in PUT request
+          puts "ADD-ON.TIERS: #{add_on.tiers}"
+          puts "SELF-ON.TIERS: #{self.tiers}"
+          self.tiers = add_on.tiers 
+        end
       when Hash
         self.attributes = add_on
       when String, Symbol

--- a/lib/recurly/tier.rb
+++ b/lib/recurly/tier.rb
@@ -12,6 +12,7 @@ module Recurly
       attributes.keys
     end
 
+    # Tiers are only writeable and readable through {AddOn} instances.
     embedded! true
   end
 end

--- a/lib/recurly/tier.rb
+++ b/lib/recurly/tier.rb
@@ -9,15 +9,16 @@ module Recurly
       unit_amount_in_cents
     )
 
+    # to_xml for subscription add-ons
     def to_xml_tier options = {}
       builder = options[:builder] || XML.new('<tiers/>')
       xml_keys.each { |key|
         node = builder.add_element key
-        if key == "unit_amount_in_cents"
-          value = respond_to?(key) ? send(key).to_i : self[key].to_i
-        else
-          value = respond_to?(key) ? send(key) : self[key]
-        end
+        value = key == "unit_amount_in_cents" ?
+          # converts Recurly::Money to Integer
+          respond_to?(key) ? send(key).to_i : self[key].to_i 
+          :
+          respond_to?(key) ? send(key) : self[key]
         node.text = value
       }
     builder.to_s

--- a/lib/recurly/tier.rb
+++ b/lib/recurly/tier.rb
@@ -2,17 +2,29 @@ module Recurly
   class Tier < Resource
 
     belongs_to :add_on
+    belongs_to :subscription_add_on
 
     define_attribute_methods %w(
       ending_quantity
       unit_amount_in_cents
     )
 
+    def to_xml_tier options = {}
+      builder = options[:builder] || XML.new('<tiers/>')
+      xml_keys.each { |key|
+        node = builder.add_element key
+        if key == "unit_amount_in_cents"
+          value = respond_to?(key) ? send(key).to_i : self[key].to_i
+        else
+          value = respond_to?(key) ? send(key) : self[key]
+        end
+        node.text = value
+      }
+    builder.to_s
+  end
+
     def xml_keys
       attributes.keys
     end
-
-    # Tiers are only writeable and readable through {AddOn} instances.
-    embedded! true
   end
 end

--- a/spec/fixtures/subscriptions/show-200-tiered.xml
+++ b/spec/fixtures/subscriptions/show-200-tiered.xml
@@ -1,0 +1,53 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription href="https://api.recurly.com/v2/subscriptions/abcdef1234567890">
+  <account href="https://api.recurly.com/v2/accounts/account_code"/>
+  <invoice href="https://api.recurly.com/v2/invoices/created-invoice"/>
+  <redemptions href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/redemptions" />
+  <shipping_address href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/shipping_address" />
+  <plan href="https://api.recurly.com/v2/plans/plan_code">
+    <plan_code>plan_code</plan_code>
+    <name>A Man, a Plan, a Canal: Panama</name>
+  </plan>
+  <uuid>abcdef1234567890</uuid>
+  <state>active</state>
+  <quantity type="integer">1</quantity>
+  <net_terms type="integer">10</net_terms>
+  <collection_method>manual</collection_method>
+  <po_number>1000</po_number>
+  <total_amount_in_cents type="integer">1000</total_amount_in_cents>
+  <activated_at type="datetime">2011-04-30T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2011-04-01T07:00:00Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2011-05-01T06:59:59Z</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+      <add_on_type>fixed</add_on_type>
+      <add_on_code>tiered_add_on</add_on_code>
+      <quantity type="integer">1</quantity>
+      <revenue_schedule_type>evenly</revenue_schedule_type>
+      <tier_type>tiered</tier_type>
+      <tiers type="array">
+        <tier>
+          <ending_quantity type="integer">2000</ending_quantity>
+          <unit_amount_in_cents type="integer">5000</unit_amount_in_cents>
+        </tier>
+        <tier>
+          <ending_quantity type="integer">999999999</ending_quantity>
+          <unit_amount_in_cents type="integer">3500</unit_amount_in_cents>
+        </tier>
+      </tiers>
+    </subscription_add_on>
+  </subscription_add_ons>
+  <a name="cancel" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/cancel" method="put"/>
+  <a name="terminate" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/terminate" method="put"/>
+  <a name="postpone" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/postpone" method="put"/>
+  <a name="notes" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/notes" method="put"/>
+</subscription>

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -128,6 +128,12 @@ describe Subscription do
       ])
     end
 
+    it "must include tiers when add-on is quantity-based" do
+      stub_api_request(:get, 'subscriptions/abcdef1234567890', 'subscriptions/show-200-tiered')
+      subscription = Subscription.find 'abcdef1234567890'
+      subscription.subscription_add_ons[0].tiers.length.must_equal(2)
+    end
+
     it "must allow add-on from item" do
       item = Item.new(
         item_code: 'mockitem',


### PR DESCRIPTION
This PR patches https://github.com/recurly/recurly-client-ruby/pull/565 and https://github.com/recurly/recurly-client-ruby/pull/576 so that the `PUT /sites/:site_id/subscriptions/:subscription_id endpoint` functions as intended.

Using the existing `to_xml()` when attempting to update tiers in subscription add-ons will send `unit_amount_in_cents` as `Recurly::Money` with currency, as shown below.
```
<subscription>
   ...
   <subscription_add_ons>
      <subscription_add_on>
         <add_on_code>tiered_add_on</add_on_code>
         <quantity>5</quantity>
         <tiers>
            <tier>
               <unit_amount_in_cents>
                  <USD>4999</USD>
               </unit_amount_in_cents>
               <ending_quantity>1999</ending_quantity>
            </tier>
            <tier>
               <ending_quantity>999999999</ending_quantity>
               <unit_amount_in_cents>
                  <USD>3500</USD>
               </unit_amount_in_cents>
            </tier>
         </tiers>
      </subscription_add_on>
   </subscription_add_ons>
   <timeframe>now</timeframe>
</subscription>
```

 This will throw an invalid xml error:
```
<error>
  <symbol>invalid_xml</symbol>
  <description>The provided XML was invalid.</description>
  <details>Tag &lt;unit_amount_in_cents&gt; must contain only text</details>
</error>
```

This submission formats the xml in the request body to send `unit_amount_in_cents` as `Integer`.
```
<subscription>
   ...
   <subscription_add_ons>
      <subscription_add_on>
         <add_on_code>tiered_add_on</add_on_code>
         <quantity>5</quantity>
         <tiers>
            <tier>
               <unit_amount_in_cents>4999</unit_amount_in_cents>
               <ending_quantity>1999</ending_quantity>
            </tier>
            <tier>
               <ending_quantity>999999999</ending_quantity>
               <unit_amount_in_cents>3500</unit_amount_in_cents>
            </tier>
         </tiers>
      </subscription_add_on>
   </subscription_add_ons>
   <timeframe>now</timeframe>
</subscription>
```

To update a subscription with quantity-based pricing add-ons:
```  
updated_add_on = Recurly::SubscriptionAddOn.new(sub_add_on.add_on_code)
updated_add_on.quantity = 5
updated_add_on.tiers = sub_add_on.tiers

updated_add_on.tiers[0] = Recurly::Tier.new({
    unit_amount_in_cents: 4999,
    ending_quantity:     1999
})

subscription.subscription_add_ons = subscription.subscription_add_ons.reject do |addon| 
    addon.add_on_code == sub_add_on.add_on_code
end

subscription.subscription_add_ons = subscription.subscription_add_ons + [updated_add_on]

subscription.update_attributes!(timeframe: "now")
```
