### PR TITLE
Fix sub-add-on init bug

### DIFF
--- a/lib/recurly/subscription_add_on.rb
+++ b/lib/recurly/subscription_add_on.rb
@@ -29,7 +29,9 @@ module Recurly
         if add_on.unit_amount_in_cents
           self.unit_amount_in_cents = add_on.unit_amount_in_cents.to_i
         end
-        self.add_on_source = add_on.add_on_source
+        if add_on.respond_to? :add_on_source
+          self.add_on_source = add_on.add_on_source
+        end
       when Hash
         self.attributes = add_on
       when String, Symbol


### PR DESCRIPTION
If you are creating a SubscriptionAddOn from a Plan AddOn. Example:

```ruby
# plan_add_on is an existing plan's add-on and is of type: AddOn
a = Recurly::SubscriptionAddOn.new(plan_add_on)
```

you'll receive an exception because AddOn does not have the `add_on_source` method.