### PR TITLE
Updating 4.x client to expect query string params as ['params']

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -106,17 +106,19 @@ plans.each_page.each_with_index do |data, page_num|
 end
 ```
 
-Pagination endpoints take a number of options to sort and filter the results. They can be passed in as keyword arguments.
+Pagination endpoints take a number of options to sort and filter the results. They can be passed in as a hash provided by the `:params` keyword argument.
 The names, types, and descriptions of these arguments are listed in the rubydocs for each method:
 
 ```ruby
 options = {
-  limit: 200, # number of items per page
-  state: :active, # only active plans
-  sort: :updated_at,
-  order: :asc,
-  begin_time: DateTime.new(2017,1,1), # January 1st 2017,
-  end_time: DateTime.now
+  params: {
+    limit: 200, # number of items per page
+    state: :active, # only active plans
+    sort: :updated_at,
+    order: :asc,
+    begin_time: DateTime.new(2017,1,1), # January 1st 2017,
+    end_time: DateTime.now
+  }
 }
 
 plans = client.list_plans(**options)

--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -12,7 +12,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_sites list_sites api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -24,13 +25,14 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param state [String] Filter by state.
+    #        :state [String] Filter by state.
+    #
     # @return [Pager<Resources::Site>] A list of sites.
     # @example
     #   sites = @client.list_sites(limit: 200)
@@ -48,6 +50,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_site get_site api documenation}
     #
     # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #
     # @return [Resources::Site] A site.
     # @example
     #   begin
@@ -59,16 +63,17 @@ module Recurly
     #     puts "Resource Not Found"
     #   end
     #
-    def get_site(site_id:)
+    def get_site(site_id:, **options)
       path = interpolate_path("/sites/{site_id}", site_id: site_id)
-      get(path)
+      get(path, **options)
     end
 
     # List a site's accounts
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_accounts list_accounts api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -80,24 +85,25 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param email [String] Filter for accounts with this exact email address. A blank value will return accounts with both +null+ and +""+ email addresses. Note that multiple accounts can share one email address.
-    # @param subscriber [Boolean] Filter for accounts with or without a subscription in the +active+,
+    #        :email [String] Filter for accounts with this exact email address. A blank value will return accounts with both +null+ and +""+ email addresses. Note that multiple accounts can share one email address.
+    #        :subscriber [Boolean] Filter for accounts with or without a subscription in the +active+,
     #   +canceled+, or +future+ state.
     #
-    # @param past_due [String] Filter for accounts with an invoice in the +past_due+ state.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :past_due [String] Filter for accounts with an invoice in the +past_due+ state.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Account>] A list of the site's accounts.
     # @example
     #   accounts = @client.list_accounts(limit: 200)
@@ -115,7 +121,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/create_account create_account api documenation}
     #
     # @param body [Requests::AccountCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AccountCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -163,7 +171,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_account get_account api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -186,7 +196,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param body [Requests::AccountUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AccountUpdate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -215,7 +227,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/deactivate_account deactivate_account api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -237,7 +251,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_account_acquisition get_account_acquisition api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::AccountAcquisition] An account's acquisition data.
     # @example
     #   begin
@@ -260,7 +276,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param body [Requests::AccountAcquisitionUpdatable] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AccountAcquisitionUpdatable}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::AccountAcquisition] An account's updated acquisition data.
     # @example
     #   begin
@@ -294,7 +312,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/remove_account_acquisition remove_account_acquisition api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Empty] Acquisition data was succesfully deleted.
     # @example
     #   begin
@@ -316,7 +336,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/reactivate_account reactivate_account api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Account] An account.
     # @example
     #   begin
@@ -338,7 +360,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_account_balance get_account_balance api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::AccountBalance] An account's balance.
     # @example
     #   begin
@@ -360,7 +384,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_billing_info get_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::BillingInfo] An account's billing information.
     # @example
     #   begin
@@ -383,7 +409,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param body [Requests::BillingInfoCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::BillingInfoCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::BillingInfo] Updated billing information.
     # @example
     #   begin
@@ -412,7 +440,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/remove_billing_info remove_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Empty] Billing information deleted
     # @example
     #   begin
@@ -434,7 +464,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_account_coupon_redemptions list_account_coupon_redemptions api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -446,17 +477,18 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::CouponRedemption>] A list of the the coupon redemptions on an account.
     # @example
     #   redemptions = @client.list_account_coupon_redemptions(
@@ -477,7 +509,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_active_coupon_redemption get_active_coupon_redemption api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::CouponRedemption] An active coupon redemption on an account.
     # @example
     #   begin
@@ -500,7 +534,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param body [Requests::CouponRedemptionCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::CouponRedemptionCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::CouponRedemption] Returns the new coupon redemption.
     # @example
     #   begin
@@ -529,7 +565,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/remove_coupon_redemption remove_coupon_redemption api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::CouponRedemption] Coupon redemption deleted.
     # @example
     #   begin
@@ -551,19 +589,21 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_account_credit_payments list_account_credit_payments api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    # @param params [Hash] Optional query string parameters:
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::CreditPayment>] A list of the account's credit payments.
     # @example
     #   payments = @client.list_account_credit_payments(
@@ -584,7 +624,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_account_invoices list_account_invoices api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -596,25 +637,26 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param type [String] Filter by type when:
+    #        :type [String] Filter by type when:
     #   - +type=charge+, only charge invoices will be returned.
     #   - +type=credit+, only credit invoices will be returned.
     #   - +type=non-legacy+, only charge and credit invoices will be returned.
     #   - +type=legacy+, only legacy invoices will be returned.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Invoice>] A list of the account's invoices.
     # @example
     #   invoices = @client.list_account_invoices(
@@ -636,7 +678,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param body [Requests::InvoiceCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::InvoiceCollection] Returns the new invoices.
     # @example
     #   begin
@@ -666,7 +710,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param body [Requests::InvoiceCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::InvoiceCollection] Returns the invoice previews.
     # @example
     #   begin
@@ -695,7 +741,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_account_line_items list_account_line_items api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -707,22 +754,23 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param original [String] Filter by original field.
-    # @param state [String] Filter by state field.
-    # @param type [String] Filter by type field.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :original [String] Filter by original field.
+    #        :state [String] Filter by state field.
+    #        :type [String] Filter by type field.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::LineItem>] A list of the account's line items.
     # @example
     #   line_items = @client.list_account_line_items(
@@ -744,7 +792,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param body [Requests::LineItemCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::LineItemCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::LineItem] Returns the new line item.
     # @example
     #   begin
@@ -774,7 +824,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_account_notes list_account_notes api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -786,7 +837,8 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::AccountNote>] A list of an account's notes.
     # @example
     #   account_notes = @client.list_account_notes(account_id: account_id, limit: 200)
@@ -805,7 +857,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param account_note_id [String] Account Note ID.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::AccountNote] An account note.
     # @example
     #   begin
@@ -830,7 +884,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_shipping_addresses list_shipping_addresses api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -842,19 +897,20 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::ShippingAddress>] A list of an account's shipping addresses.
     # @example
     #   shipping_addresses = @client.list_shipping_addresses(
@@ -876,7 +932,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param body [Requests::ShippingAddressCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::ShippingAddressCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::ShippingAddress] Returns the new shipping address.
     # @example
     #   begin
@@ -909,7 +967,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param shipping_address_id [String] Shipping Address ID.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::ShippingAddress] A shipping address.
     # @example
     #   begin
@@ -936,7 +996,9 @@ module Recurly
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param shipping_address_id [String] Shipping Address ID.
     # @param body [Requests::ShippingAddressUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::ShippingAddressUpdate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::ShippingAddress] The updated shipping address.
     # @example
     #   begin
@@ -968,7 +1030,9 @@ module Recurly
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
     # @param shipping_address_id [String] Shipping Address ID.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Empty] Shipping address deleted.
     # @example
     #   begin
@@ -993,7 +1057,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_account_subscriptions list_account_subscriptions api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1005,25 +1070,26 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param state [String] Filter by state.
+    #        :state [String] Filter by state.
     #
     #   - When +state=active+, +state=canceled+, +state=expired+, or +state=future+, subscriptions with states that match the query and only those subscriptions will be returned.
     #   - When +state=in_trial+, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
     #   - When +state=live+, only subscriptions that are in an active, canceled, or future state or are in trial will be returned.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Subscription>] A list of the account's subscriptions.
     # @example
     #   subscriptions = @client.list_account_subscriptions(
@@ -1044,7 +1110,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_account_transactions list_account_transactions api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1056,21 +1123,22 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param type [String] Filter by type field. The value +payment+ will return both +purchase+ and +capture+ transactions.
-    # @param success [String] Filter by success field.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :type [String] Filter by type field. The value +payment+ will return both +purchase+ and +capture+ transactions.
+    #        :success [String] Filter by success field.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Transaction>] A list of the account's transactions.
     # @example
     #   transactions = @client.list_account_transactions(
@@ -1091,7 +1159,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_child_accounts list_child_accounts api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1103,24 +1172,25 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param email [String] Filter for accounts with this exact email address. A blank value will return accounts with both +null+ and +""+ email addresses. Note that multiple accounts can share one email address.
-    # @param subscriber [Boolean] Filter for accounts with or without a subscription in the +active+,
+    #        :email [String] Filter for accounts with this exact email address. A blank value will return accounts with both +null+ and +""+ email addresses. Note that multiple accounts can share one email address.
+    #        :subscriber [Boolean] Filter for accounts with or without a subscription in the +active+,
     #   +canceled+, or +future+ state.
     #
-    # @param past_due [String] Filter for accounts with an invoice in the +past_due+ state.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :past_due [String] Filter for accounts with an invoice in the +past_due+ state.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Account>] A list of an account's child accounts.
     # @example
     #   child_accounts = @client.list_child_accounts(
@@ -1140,7 +1210,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_account_acquisition list_account_acquisition api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1152,19 +1223,20 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::AccountAcquisition>] A list of the site's account acquisition data.
     # @example
     #   acquisitions = @client.list_account_acquisition(limit: 200)
@@ -1181,7 +1253,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_coupons list_coupons api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1193,19 +1266,20 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Coupon>] A list of the site's coupons.
     # @example
     #   coupons = @client.list_coupons(limit: 200)
@@ -1223,7 +1297,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/create_coupon create_coupon api documenation}
     #
     # @param body [Requests::CouponCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::CouponCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Coupon] A new coupon.
     # @example
     #   begin
@@ -1258,7 +1334,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_coupon get_coupon api documenation}
     #
     # @param coupon_id [String] Coupon ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-10off+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Coupon] A coupon.
     # @example
     #   begin
@@ -1281,7 +1359,9 @@ module Recurly
     #
     # @param coupon_id [String] Coupon ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-10off+.
     # @param body [Requests::CouponUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::CouponUpdate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Coupon] The updated coupon.
     # @example
     #   begin
@@ -1306,7 +1386,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/deactivate_coupon deactivate_coupon api documenation}
     #
     # @param coupon_id [String] Coupon ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-10off+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Coupon] The expired Coupon
     # @example
     #   begin
@@ -1328,7 +1410,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_unique_coupon_codes list_unique_coupon_codes api documenation}
     #
     # @param coupon_id [String] Coupon ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-10off+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1340,20 +1423,22 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::UniqueCouponCode>] A list of unique coupon codes that were generated
+    #
     def list_unique_coupon_codes(coupon_id:, **options)
       path = interpolate_path("/coupons/{coupon_id}/unique_coupon_codes", coupon_id: coupon_id)
       pager(path, **options)
@@ -1363,19 +1448,21 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_credit_payments list_credit_payments api documenation}
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    # @param params [Hash] Optional query string parameters:
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::CreditPayment>] A list of the site's credit payments.
     # @example
     #   payments = @client.list_credit_payments(limit: 200)
@@ -1393,8 +1480,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_credit_payment get_credit_payment api documenation}
     #
     # @param credit_payment_id [String] Credit Payment ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::CreditPayment] A credit payment.
+    #
     def get_credit_payment(credit_payment_id:, **options)
       path = interpolate_path("/credit_payments/{credit_payment_id}", credit_payment_id: credit_payment_id)
       get(path, **options)
@@ -1404,7 +1494,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_custom_field_definitions list_custom_field_definitions api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1416,20 +1507,21 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param related_type [String] Filter by related type.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :related_type [String] Filter by related type.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::CustomFieldDefinition>] A list of the site's custom field definitions.
     # @example
     #   custom_fields = @client.list_custom_field_definitions(limit: 200)
@@ -1447,7 +1539,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_custom_field_definition get_custom_field_definition api documenation}
     #
     # @param custom_field_definition_id [String] Custom Field Definition ID
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::CustomFieldDefinition] An custom field definition.
     # @example
     #   begin
@@ -1470,7 +1564,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_items list_items api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1482,20 +1577,21 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param state [String] Filter by state.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :state [String] Filter by state.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Item>] A list of the site's items.
     # @example
     #   items = @client.list_items(limit: 200)
@@ -1513,7 +1609,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/create_item create_item api documenation}
     #
     # @param body [Requests::ItemCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::ItemCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Item] A new item.
     # @example
     #   begin
@@ -1547,7 +1645,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_item get_item api documenation}
     #
     # @param item_id [String] Item ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-red+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Item] An item.
     # @example
     #   begin
@@ -1570,7 +1670,9 @@ module Recurly
     #
     # @param item_id [String] Item ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-red+.
     # @param body [Requests::ItemUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::ItemUpdate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Item] The updated item.
     # @example
     #   begin
@@ -1599,7 +1701,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/deactivate_item deactivate_item api documenation}
     #
     # @param item_id [String] Item ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-red+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Item] An item.
     # @example
     #   begin
@@ -1621,7 +1725,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/reactivate_item reactivate_item api documenation}
     #
     # @param item_id [String] Item ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-red+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Item] An item.
     # @example
     #   begin
@@ -1642,7 +1748,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_invoices list_invoices api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1654,25 +1761,26 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param type [String] Filter by type when:
+    #        :type [String] Filter by type when:
     #   - +type=charge+, only charge invoices will be returned.
     #   - +type=credit+, only credit invoices will be returned.
     #   - +type=non-legacy+, only charge and credit invoices will be returned.
     #   - +type=legacy+, only legacy invoices will be returned.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Invoice>] A list of the site's invoices.
     # @example
     #   invoices = @client.list_invoices(limit: 200)
@@ -1690,7 +1798,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_invoice get_invoice api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Invoice] An invoice.
     # @example
     #   begin
@@ -1713,7 +1823,9 @@ module Recurly
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
     # @param body [Requests::InvoiceUpdatable] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceUpdatable}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Invoice] An invoice.
     # @example
     #   begin
@@ -1739,7 +1851,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_invoice_pdf get_invoice_pdf api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::BinaryFile] An invoice as a PDF.
     # @example
     #   begin
@@ -1764,8 +1878,10 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/collect_invoice collect_invoice api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param body [Requests::InvoiceCollect] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceCollect}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :body [Requests::InvoiceCollect] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceCollect}
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Invoice] The updated invoice.
     # @example
     #   begin
@@ -1787,7 +1903,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/fail_invoice fail_invoice api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Invoice] The updated invoice.
     # @example
     #   begin
@@ -1809,7 +1927,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/mark_invoice_successful mark_invoice_successful api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Invoice] The updated invoice.
     # @example
     #   begin
@@ -1831,7 +1951,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/reopen_invoice reopen_invoice api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Invoice] The updated invoice.
     # @example
     #   begin
@@ -1853,7 +1975,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/void_invoice void_invoice api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Invoice] The updated invoice.
     # @example
     #   begin
@@ -1876,8 +2000,11 @@ module Recurly
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
     # @param body [Requests::ExternalTransaction] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::ExternalTransaction}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Transaction] The recorded transaction.
+    #
     def record_external_transaction(invoice_id:, body:, **options)
       path = interpolate_path("/invoices/{invoice_id}/transactions", invoice_id: invoice_id)
       post(path, body, Requests::ExternalTransaction, **options)
@@ -1888,7 +2015,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_invoice_line_items list_invoice_line_items api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1900,22 +2028,23 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param original [String] Filter by original field.
-    # @param state [String] Filter by state field.
-    # @param type [String] Filter by type field.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :original [String] Filter by original field.
+    #        :state [String] Filter by state field.
+    #        :type [String] Filter by type field.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::LineItem>] A list of the invoice's line items.
     # @example
     #   line_items = @client.list_invoice_line_items(
@@ -1936,7 +2065,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_invoice_coupon_redemptions list_invoice_coupon_redemptions api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -1948,17 +2078,18 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::CouponRedemption>] A list of the the coupon redemptions associated with the invoice.
     # @example
     #   coupon_redemptions = @client.list_invoice_coupon_redemptions(
@@ -1979,7 +2110,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_related_invoices list_related_invoices api documenation}
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Invoice>] A list of the credit or charge invoices associated with the invoice.
     # @example
     #   invoices = @client.list_related_invoices(
@@ -2001,7 +2134,9 @@ module Recurly
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+.
     # @param body [Requests::InvoiceRefund] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::InvoiceRefund}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Invoice] Returns the new credit invoice.
     # @example
     #   begin
@@ -2029,7 +2164,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_line_items list_line_items api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -2041,22 +2177,23 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param original [String] Filter by original field.
-    # @param state [String] Filter by state field.
-    # @param type [String] Filter by type field.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :original [String] Filter by original field.
+    #        :state [String] Filter by state field.
+    #        :type [String] Filter by type field.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::LineItem>] A list of the site's line items.
     # @example
     #   line_items = @client.list_line_items(
@@ -2076,7 +2213,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_line_item get_line_item api documenation}
     #
     # @param line_item_id [String] Line Item ID.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::LineItem] A line item.
     # @example
     #   begin
@@ -2098,7 +2237,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/remove_line_item remove_line_item api documenation}
     #
     # @param line_item_id [String] Line Item ID.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Empty] Line item deleted.
     # @example
     #   begin
@@ -2121,7 +2262,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_plans list_plans api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -2133,20 +2275,21 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param state [String] Filter by state.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :state [String] Filter by state.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Plan>] A list of plans.
     # @example
     #   plans = @client.list_plans(limit: 200)
@@ -2164,7 +2307,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/create_plan create_plan api documenation}
     #
     # @param body [Requests::PlanCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::PlanCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Plan] A plan.
     # @example
     #   begin
@@ -2203,7 +2348,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_plan get_plan api documenation}
     #
     # @param plan_id [String] Plan ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Plan] A plan.
     # @example
     #   begin
@@ -2226,7 +2373,9 @@ module Recurly
     #
     # @param plan_id [String] Plan ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
     # @param body [Requests::PlanUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::PlanUpdate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Plan] A plan.
     # @example
     #   begin
@@ -2251,7 +2400,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/remove_plan remove_plan api documenation}
     #
     # @param plan_id [String] Plan ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Plan] Plan deleted
     # @example
     #   begin
@@ -2273,7 +2424,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_plan_add_ons list_plan_add_ons api documenation}
     #
     # @param plan_id [String] Plan ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -2285,20 +2437,21 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param state [String] Filter by state.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :state [String] Filter by state.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::AddOn>] A list of add-ons.
     # @example
     #   add_ons = @client.list_plan_add_ons(
@@ -2320,7 +2473,9 @@ module Recurly
     #
     # @param plan_id [String] Plan ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
     # @param body [Requests::AddOnCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AddOnCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::AddOn] An add-on.
     # @example
     #   begin
@@ -2354,7 +2509,9 @@ module Recurly
     #
     # @param plan_id [String] Plan ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
     # @param add_on_id [String] Add-on ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::AddOn] An add-on.
     # @example
     #   begin
@@ -2380,7 +2537,9 @@ module Recurly
     # @param plan_id [String] Plan ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
     # @param add_on_id [String] Add-on ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
     # @param body [Requests::AddOnUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::AddOnUpdate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::AddOn] An add-on.
     # @example
     #   begin
@@ -2410,7 +2569,9 @@ module Recurly
     #
     # @param plan_id [String] Plan ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
     # @param add_on_id [String] Add-on ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::AddOn] Add-on deleted
     # @example
     #   begin
@@ -2434,7 +2595,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_add_ons list_add_ons api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -2446,20 +2608,21 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param state [String] Filter by state.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :state [String] Filter by state.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::AddOn>] A list of add-ons.
     # @example
     #   add_ons = @client.list_add_ons(
@@ -2479,7 +2642,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_add_on get_add_on api documenation}
     #
     # @param add_on_id [String] Add-on ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-gold+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::AddOn] An add-on.
     # @example
     #   begin
@@ -2500,7 +2665,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_shipping_methods list_shipping_methods api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -2512,19 +2678,20 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::ShippingMethod>] A list of the site's shipping methods.
     # @example
     #   shipping_methods = @client.list_shipping_methods(
@@ -2544,8 +2711,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/create_shipping_method create_shipping_method api documenation}
     #
     # @param body [Requests::ShippingMethodCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::ShippingMethodCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::ShippingMethod] A new shipping method.
+    #
     def create_shipping_method(body:, **options)
       path = interpolate_path("/shipping_methods")
       post(path, body, Requests::ShippingMethodCreate, **options)
@@ -2556,8 +2726,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_shipping_method get_shipping_method api documenation}
     #
     # @param shipping_method_id [String] Shipping Method ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-usps_2-day+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::ShippingMethod] A shipping method.
+    #
     def get_shipping_method(shipping_method_id:, **options)
       path = interpolate_path("/shipping_methods/{shipping_method_id}", shipping_method_id: shipping_method_id)
       get(path, **options)
@@ -2569,8 +2742,11 @@ module Recurly
     #
     # @param shipping_method_id [String] Shipping Method ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-usps_2-day+.
     # @param body [Requests::ShippingMethodUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::ShippingMethodUpdate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::ShippingMethod] The updated shipping method.
+    #
     def update_shipping_method(shipping_method_id:, body:, **options)
       path = interpolate_path("/shipping_methods/{shipping_method_id}", shipping_method_id: shipping_method_id)
       put(path, body, Requests::ShippingMethodUpdate, **options)
@@ -2581,8 +2757,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/deactivate_shipping_method deactivate_shipping_method api documenation}
     #
     # @param shipping_method_id [String] Shipping Method ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-usps_2-day+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::ShippingMethod] A shipping method.
+    #
     def deactivate_shipping_method(shipping_method_id:, **options)
       path = interpolate_path("/shipping_methods/{shipping_method_id}", shipping_method_id: shipping_method_id)
       delete(path, **options)
@@ -2592,7 +2771,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_subscriptions list_subscriptions api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -2604,25 +2784,26 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param state [String] Filter by state.
+    #        :state [String] Filter by state.
     #
     #   - When +state=active+, +state=canceled+, +state=expired+, or +state=future+, subscriptions with states that match the query and only those subscriptions will be returned.
     #   - When +state=in_trial+, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
     #   - When +state=live+, only subscriptions that are in an active, canceled, or future state or are in trial will be returned.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Subscription>] A list of the site's subscriptions.
     # @example
     #   subscriptions = @client.list_subscriptions(limit: 200)
@@ -2640,7 +2821,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/create_subscription create_subscription api documenation}
     #
     # @param body [Requests::SubscriptionCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2673,7 +2856,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_subscription get_subscription api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2698,7 +2883,9 @@ module Recurly
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
     # @param body [Requests::SubscriptionUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionUpdate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2727,7 +2914,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/terminate_subscription terminate_subscription api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param refund [String] The type of refund to perform:
+    # @param params [Hash] Optional query string parameters:
+    #        :refund [String] The type of refund to perform:
     #
     #   * +full+ - Performs a full refund of the last invoice for the current subscription term.
     #   * +partial+ - Prorates a refund based on the amount of time remaining in the current bill cycle.
@@ -2737,7 +2925,8 @@ module Recurly
     #
     #   You may also terminate a subscription with no refund and then manually refund specific invoices.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Subscription] An expired subscription.
     # @example
     #   begin
@@ -2761,8 +2950,10 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/cancel_subscription cancel_subscription api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param body [Requests::SubscriptionCancel] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionCancel}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :body [Requests::SubscriptionCancel] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionCancel}
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Subscription] A canceled or failed subscription.
     # @example
     #   begin
@@ -2786,7 +2977,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/reactivate_subscription reactivate_subscription api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Subscription] An active subscription.
     # @example
     #   begin
@@ -2811,7 +3004,9 @@ module Recurly
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
     # @param body [Requests::SubscriptionPause] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionPause}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2839,7 +3034,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/resume_subscription resume_subscription api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Subscription] A subscription.
     # @example
     #   begin
@@ -2863,8 +3060,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/convert_trial convert_trial api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Subscription] A subscription.
+    #
     def convert_trial(subscription_id:, **options)
       path = interpolate_path("/subscriptions/{subscription_id}/convert_trial", subscription_id: subscription_id)
       put(path, **options)
@@ -2875,7 +3075,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_subscription_change get_subscription_change api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::SubscriptionChange] A subscription's pending change.
     # @example
     #   begin
@@ -2900,7 +3102,9 @@ module Recurly
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
     # @param body [Requests::SubscriptionChangeCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionChangeCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::SubscriptionChange] A subscription change.
     # @example
     #   begin
@@ -2929,7 +3133,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/remove_subscription_change remove_subscription_change api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Empty] Subscription change was deleted.
     # @example
     #   begin
@@ -2954,8 +3160,11 @@ module Recurly
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
     # @param body [Requests::SubscriptionChangeCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::SubscriptionChangeCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::SubscriptionChangePreview] A subscription change.
+    #
     def preview_subscription_change(subscription_id:, body:, **options)
       path = interpolate_path("/subscriptions/{subscription_id}/change/preview", subscription_id: subscription_id)
       post(path, body, Requests::SubscriptionChangeCreate, **options)
@@ -2966,7 +3175,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_subscription_invoices list_subscription_invoices api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -2978,25 +3188,26 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param type [String] Filter by type when:
+    #        :type [String] Filter by type when:
     #   - +type=charge+, only charge invoices will be returned.
     #   - +type=credit+, only credit invoices will be returned.
     #   - +type=non-legacy+, only charge and credit invoices will be returned.
     #   - +type=legacy+, only legacy invoices will be returned.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Invoice>] A list of the subscription's invoices.
     # @example
     #   invoices = @client.list_subscription_invoices(
@@ -3017,7 +3228,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_subscription_line_items list_subscription_line_items api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -3029,22 +3241,23 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param original [String] Filter by original field.
-    # @param state [String] Filter by state field.
-    # @param type [String] Filter by type field.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :original [String] Filter by original field.
+    #        :state [String] Filter by state field.
+    #        :type [String] Filter by type field.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::LineItem>] A list of the subscription's line items.
     # @example
     #   line_items = @client.list_subscription_line_items(
@@ -3065,7 +3278,8 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_subscription_coupon_redemptions list_subscription_coupon_redemptions api documenation}
     #
     # @param subscription_id [String] Subscription ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -3077,17 +3291,18 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::CouponRedemption>] A list of the the coupon redemptions on a subscription.
     # @example
     #   coupon_redemptions = @client.list_subscription_coupon_redemptions(
@@ -3107,7 +3322,8 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2020-01-01#operation/list_transactions list_transactions api documenation}
     #
-    # @param ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
     #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
     #
     #   *Important notes:*
@@ -3119,21 +3335,22 @@ module Recurly
     #   * Records are returned in an arbitrary order. Since results are all
     #     returned at once you can sort the records yourself.
     #
-    # @param limit [Integer] Limit number of records 1-200.
-    # @param order [String] Sort order.
-    # @param sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
     #   order. In descending order updated records will move behind the cursor and could
     #   prevent some records from being returned.
     #
-    # @param begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
     #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
     #
-    # @param type [String] Filter by type field. The value +payment+ will return both +purchase+ and +capture+ transactions.
-    # @param success [String] Filter by success field.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #        :type [String] Filter by type field. The value +payment+ will return both +purchase+ and +capture+ transactions.
+    #        :success [String] Filter by success field.
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Pager<Resources::Transaction>] A list of the site's transactions.
     # @example
     #   transactions = @client.list_transactions(limit: 200)
@@ -3151,7 +3368,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_transaction get_transaction api documenation}
     #
     # @param transaction_id [String] Transaction ID or UUID. For ID no prefix is used e.g. +e28zov4fw0v2+. For UUID use prefix +uuid-+, e.g. +uuid-123457890+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::Transaction] A transaction.
     # @example
     #   begin
@@ -3173,8 +3392,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/get_unique_coupon_code get_unique_coupon_code api documenation}
     #
     # @param unique_coupon_code_id [String] Unique Coupon Code ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-abc-8dh2-def+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::UniqueCouponCode] A unique coupon code.
+    #
     def get_unique_coupon_code(unique_coupon_code_id:, **options)
       path = interpolate_path("/unique_coupon_codes/{unique_coupon_code_id}", unique_coupon_code_id: unique_coupon_code_id)
       get(path, **options)
@@ -3185,8 +3407,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/deactivate_unique_coupon_code deactivate_unique_coupon_code api documenation}
     #
     # @param unique_coupon_code_id [String] Unique Coupon Code ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-abc-8dh2-def+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::UniqueCouponCode] A unique coupon code.
+    #
     def deactivate_unique_coupon_code(unique_coupon_code_id:, **options)
       path = interpolate_path("/unique_coupon_codes/{unique_coupon_code_id}", unique_coupon_code_id: unique_coupon_code_id)
       delete(path, **options)
@@ -3197,8 +3422,11 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/reactivate_unique_coupon_code reactivate_unique_coupon_code api documenation}
     #
     # @param unique_coupon_code_id [String] Unique Coupon Code ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-abc-8dh2-def+.
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::UniqueCouponCode] A unique coupon code.
+    #
     def reactivate_unique_coupon_code(unique_coupon_code_id:, **options)
       path = interpolate_path("/unique_coupon_codes/{unique_coupon_code_id}/restore", unique_coupon_code_id: unique_coupon_code_id)
       put(path, **options)
@@ -3209,7 +3437,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/create_purchase create_purchase api documenation}
     #
     # @param body [Requests::PurchaseCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::PurchaseCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::InvoiceCollection] Returns the new invoices
     # @example
     #   begin
@@ -3248,7 +3478,9 @@ module Recurly
     # {https://developers.recurly.com/api/v2020-01-01#operation/preview_purchase preview_purchase api documenation}
     #
     # @param body [Requests::PurchaseCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::PurchaseCreate}
-    # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    # @param params [Hash] Optional query string parameters:
+    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
+    #
     # @return [Resources::InvoiceCollection] Returns preview of the new invoices
     # @example
     #   begin

--- a/spec/recurly/pager_spec.rb
+++ b/spec/recurly/pager_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Recurly::Pager do
   let(:api_key) { "recurly-good" }
   let(:client) { Recurly::Client.new(api_key: api_key, subdomain: subdomain) }
   let(:path) { "/next_url" }
-  let(:options) { { a: 1, b: "testing" } }
+  let(:options) { { params: { a: 1, b: "testing" } } }
   subject do
     Recurly::Pager.new(client: client, path: path, options: options)
   end
@@ -18,7 +18,7 @@ RSpec.describe Recurly::Pager do
   end
 
   describe "#first" do
-    let(:options) { { limit: 200, a: 1 } }
+    let(:options) { { params: { limit: 200, a: 1 } } }
     let(:first_response) do
       page = Recurly::Resources::Page.new
       page.data = [
@@ -30,7 +30,7 @@ RSpec.describe Recurly::Pager do
     end
     it "should update the 'limit' param to 1" do
       expect(client).to receive(:get)
-                          .with("/next_url", { limit: 1, a: 1 })
+                          .with("/next_url", { params: { limit: 1, a: 1 } })
                           .and_return(first_response)
       subject.first
     end
@@ -47,7 +47,7 @@ RSpec.describe Recurly::Pager do
 
     it "#count" do
       expect(client).to receive(:head)
-                          .with("/next_url", { a: 1, b: "testing" })
+                          .with("/next_url", { params: { a: 1, b: "testing" } })
                           .and_return(head_response)
       expect(subject.count).to eq(1337)
     end


### PR DESCRIPTION
This is an update for the `4.x` version of the client.

This updates how optional parameters are specified in operations. In the `3.x` version of the client, optional parameters were specified an optional keyword arguments directly on each operation. This `4.x` update moves these parameters into a hash whose key, `:params` is an optional keyword argument on the operation. 

This is to facilitate additional options that may be passed into each operation (e.g. `:headers` for custom headers). 

The ability to specify custom headers was added to the `3.x` clients in https://github.com/recurly/recurly-client-ruby/pull/597, though this solution is not very future flexible.

Existing `3.x` code sample:
```ruby
options = {
  limit: 200,
  headers: {
    'Accept-Language' => 'fr'
  }
}
accounts = @client.list_accounts(options)
```

Updated `4.x` code sample:
```ruby
options = {
  params: {
      limit: 200
  }
  headers: {
    'Accept-Language' => 'fr'
  }
}
accounts = @client.list_accounts(options)
```