### PR TITLE
Establish association between Tier and SubscriptionAddOn

### DIFF
--- a/lib/recurly/add_on.rb
+++ b/lib/recurly/add_on.rb
@@ -2,6 +2,7 @@ module Recurly
   class AddOn < Resource
     # @return [Plan]
     belongs_to :plan
+    # @return [[Tier], []]
     has_many :tiers, class_name: :Tier, readonly: false
 
     define_attribute_methods %w(

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -824,9 +824,9 @@ module Recurly
 
         # Duck-typing here is problematic because of ActiveSupport's #to_xml.
         case value
-        when Resource, Subscription::AddOns
+        when Resource
           value.to_xml options.merge(:builder => node)
-        when Array
+        when Array, Subscription::AddOns
           value.each do |e|
             if e.is_a? Recurly::Resource
               # create a node to hold this resource

--- a/lib/recurly/subscription_add_on.rb
+++ b/lib/recurly/subscription_add_on.rb
@@ -6,6 +6,9 @@ module Recurly
     # @return [Pager<Usage>, []]
     has_many :usage
 
+    # @return [[Tier], []]
+    has_many :tiers, class_name: :Tier, readonly: false
+
     define_attribute_methods %w(
       add_on_code
       quantity
@@ -32,6 +35,7 @@ module Recurly
         if add_on.respond_to? :add_on_source
           self.add_on_source = add_on.add_on_source
         end
+        self.tiers = add_on.tiers if add_on.tiers.any?
       when Hash
         self.attributes = add_on
       when String, Symbol

--- a/lib/recurly/tier.rb
+++ b/lib/recurly/tier.rb
@@ -2,6 +2,7 @@ module Recurly
   class Tier < Resource
 
     belongs_to :add_on
+    belongs_to :subscription_add_on
 
     define_attribute_methods %w(
       ending_quantity


### PR DESCRIPTION
This PR patches https://github.com/recurly/recurly-client-ruby/pull/565 and https://github.com/recurly/recurly-client-ruby/pull/576 by including an association between SubscriptionAddOn and Tier to enable updating quantity-based sub add-ons. Note that this change will trigger the following error because `unit_amount_in_cents` is sent as `Recurly::Money` instead of as an `Integer`. This error will be addressed in a separate ticket.
```
<error>
  <symbol>invalid_xml</symbol>
  <description>The provided XML was invalid.</description>
  <details>Tag &lt;unit_amount_in_cents&gt; must contain only text</details>
</error>
```

Code example:
```ruby
subscription = Recurly::Subscription.find('insert-uuid')
sub_add_on = subscription.subscription_add_ons[0]
updated_add_on = Recurly::SubscriptionAddOn.new(sub_add_on.add_on_code)
updated_add_on.quantity = 5

updated_add_on.tiers = sub_add_on.tiers

updated_add_on.tiers[0] = Recurly::Tier.new({
    unit_amount_in_cents: 4999,
    ending_quantity:     1999
})

subscription.subscription_add_ons = subscription.subscription_add_ons.reject do |addon| 
    addon.add_on_code == sub_add_on.add_on_code
end

subscription.subscription_add_ons = subscription.subscription_add_ons + [updated_add_on]

subscription.update_attributes!(timeframe: "now")
```