### PR TITLE
Add tax identifier fields to billing info

### DIFF
--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -18,7 +18,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.28'
+    RECURLY_API_VERSION = '2.29'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -40,6 +40,8 @@ module Recurly
       three_d_secure_action_result_token_id
       transaction_type
       mandate_reference
+      tax_identifier
+      tax_identifier_type
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES | SEPA_ATTRIBUTES | BACS_ATTRIBUTES | BECS_ATTRIBUTES
 
     # @return [String]


### PR DESCRIPTION
Allows merchants to specify individual tax identifiers for customers (CPF + Brazil support) when creating and updating billing information.

Two fields introduced:
`tax_identifier`
`tax_identifier_type`

Example code:
```ruby
account.billing_info = {
  first_name: 'Chickpea',
  last_name: 'Batard',
  address1: '11060 US-31',
  city: 'Elk Rapids',
  state: 'MI',
  zip: '49629',
  country: 'US',
  number: '4111-1111-1111-1111',
  month: 12,
  year: 2045,
  tax_identifier: '758.356.352-65',
  tax_identifier_type: 'cpf'
}
account.billing_info.save!
```