### PR TITLE
Removing unused method 'set_site_id'

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -325,14 +325,6 @@ module Recurly
       path % options
     end
 
-    def set_site_id(site_id, subdomain)
-      if site_id
-        @site_id = site_id
-      elsif subdomain
-        @site_id = "subdomain-#{subdomain}"
-      end
-    end
-
     def set_api_key(api_key)
       @api_key = api_key
     end


### PR DESCRIPTION
This is a follow-up PR to https://github.com/recurly/recurly-client-ruby/pull/624 which removes the now defunct method `set_site_id` method.