### PR TITLE
Release 2.18.14

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.18.13
+current_version = 2.18.14
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.14"></a>
+## v.2.18.14 (2020-08-20)
+
+This bumps us up to API version 2.29. There are no breaking changes.
+
+* Add tax identifier fields to billing info [PR](https://github.com/recurly/recurly-client-ruby/pull/625)
+
 <a name="v2.18.13"></a>
 ## v.2.18.13 (2020-08-14)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.18.13'
+gem 'recurly', '~> 2.18.14'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/api.rb
+++ b/lib/recurly/api.rb
@@ -18,7 +18,7 @@ module Recurly
     @@base_uri = "https://api.recurly.com/v2/"
     @@valid_domains = [".recurly.com"]
 
-    RECURLY_API_VERSION = '2.28'
+    RECURLY_API_VERSION = '2.29'
 
     FORMATS = Helper.hash_with_indifferent_read_access(
       'pdf' => 'application/pdf',

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -40,6 +40,8 @@ module Recurly
       three_d_secure_action_result_token_id
       transaction_type
       mandate_reference
+      tax_identifier
+      tax_identifier_type
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES | SEPA_ATTRIBUTES | BACS_ATTRIBUTES | BECS_ATTRIBUTES
 
     # @return [String]

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,6 +1,6 @@
 module Recurly
   module Version
-    VERSION = "2.18.13"
+    VERSION = "2.18.14"
 
     class << self
       def inspect


### PR DESCRIPTION
This PR merges v2.29 features into v2 branch for release and bumps the client library version to 2.18.14.

---

This bumps us up to API version 2.29. There are no breaking changes.

* Add tax identifier fields to billing info https://github.com/recurly/recurly-client-ruby/pull/625
