### PR TITLE
Release 3.11.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.10.0
+current_version = 3.11.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
@@ -13,4 +13,3 @@ serialize =
 [bumpversion:file:GETTING_STARTED.md]
 parse = (?P<major>\d+)\.(?P<minor>\d+)
 serialize = {major}.{minor}
-

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -5,7 +5,7 @@ This repository houses the official ruby client for Recurly's V3 API.
 In your Gemfile, add `recurly` as a dependency.
 
 ```ruby
-gem 'recurly', '~> 3.10'
+gem 'recurly', '~> 3.11'
 ```
 
 > *Note*: We try to follow [semantic versioning](https://semver.org/) and will only apply breaking changes to major versions.

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,3 +1,3 @@
 module Recurly
-  VERSION = "3.10.0"
+  VERSION = "3.11.0"
 end


### PR DESCRIPTION
[Full Changelog](https://github.com/recurly/recurly-client-ruby/compare/3.10.0...HEAD)

**Implemented enhancements:**

- Fri Aug 21 16:17:28 UTC 2020 Upgrade API version v2019-10-10 [\#629](https://github.com/recurly/recurly-client-ruby/pull/629) ([douglasmiller](https://github.com/douglasmiller))