### PR TITLE
New endpoint to verify an account's billing information

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -40,6 +40,7 @@ module Recurly
   require 'recurly/gift_card'
   require 'recurly/purchase'
   require 'recurly/webhook'
+  require 'recurly/verify'
   require 'recurly/tier'
 
   @subdomain = nil

--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -44,6 +44,15 @@ module Recurly
       tax_identifier_type
     ) | CREDIT_CARD_ATTRIBUTES | BANK_ACCOUNT_ATTRIBUTES | AMAZON_ATTRIBUTES | PAYPAL_ATTRIBUTES | ROKU_ATTRIBUTES | SEPA_ATTRIBUTES | BACS_ATTRIBUTES | BECS_ATTRIBUTES
 
+    # Verify an account's stored billing info
+    #
+    # @param [Hash] gateway_code (optional) is the code for the gateway to use for verification. If unspecified, a gateway will be selected using the normal rules.
+    # @return [Transaction]
+    # @raise [Invalid] Raise if the account's billing info cannot be verified
+    def verify(attrs = {})
+      Transaction.from_response API.post("#{path}/verify", attrs.empty? ? nil : Verify.to_xml(attrs))
+    end
+
     # @return [String]
     def inspect
       attributes = self.class.attribute_names

--- a/lib/recurly/verify.rb
+++ b/lib/recurly/verify.rb
@@ -1,0 +1,12 @@
+module Recurly
+  class Verify < Resource
+    define_attribute_methods %w(
+      gateway_code
+    )
+
+    def self.to_xml(attrs)
+      verify = new attrs
+      verify.to_xml
+    end
+  end
+end

--- a/spec/fixtures/billing_info/verify-200.xml
+++ b/spec/fixtures/billing_info/verify-200.xml
@@ -1,0 +1,61 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction href="https://api.recurly.com/v2/transactions/abcdef1234567890" type="credit_card">
+  <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <uuid>55e508df05ca7ea5bb9da34d98be5d61</uuid>
+  <action>verify</action>
+  <amount_in_cents type="integer">0</amount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <currency>USD</currency>
+  <status>success</status>
+  <payment_method>credit_card</payment_method>
+  <reference>1903896</reference>
+  <source>billing_info</source>
+  <recurring type="boolean">false</recurring>
+  <test type="boolean">true</test>
+  <voidable type="boolean">false</voidable>
+  <refundable type="boolean">false</refundable>
+  <ip_address nil="nil"></ip_address>
+  <gateway_type>test</gateway_type>
+  <origin>api_verify_card</origin>
+  <description nil="nil"></description>
+  <message>Successful test transaction</message>
+  <approval_code nil="nil"></approval_code>
+  <failure_type nil="nil"></failure_type>
+  <gateway_error_codes nil="nil"></gateway_error_codes>
+  <cvv_result code="" nil="nil"></cvv_result>
+  <avs_result code="D">Street address and postal code match.</avs_result>
+  <avs_result_street nil="nil"></avs_result_street>
+  <avs_result_postal nil="nil"></avs_result_postal>
+  <created_at type="datetime">2020-09-10T04:19:44Z</created_at>
+  <collected_at type="datetime">2020-09-10T04:19:44Z</collected_at>
+  <updated_at type="datetime">2020-09-10T04:19:44Z</updated_at>
+  <details>
+    <account>
+      <account_code>abcdef1234567890</account_code>
+      <first_name>Vera</first_name>
+      <last_name>Verification</last_name>
+      <company nil="nil"></company>
+      <email nil="nil"></email>
+      <billing_info type="credit_card">
+        <first_name>Vera</first_name>
+        <last_name>Verification</last_name>
+        <address1>11060 US-31</address1>
+        <address2 nil="nil"></address2>
+        <city>Elk Rapids</city>
+        <state>MI</state>
+        <zip>49629</zip>
+        <country>US</country>
+        <phone nil="nil"></phone>
+        <vat_number nil="nil"></vat_number>
+        <card_type>Visa</card_type>
+        <year type="integer">2045</year>
+        <month type="integer">12</month>
+        <first_six>411111</first_six>
+        <last_four>1111</last_four>
+      </billing_info>
+    </account>
+  </details>
+</transaction>

--- a/spec/fixtures/billing_info/verify-422.xml
+++ b/spec/fixtures/billing_info/verify-422.xml
@@ -1,0 +1,8 @@
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+  <symbol>billing_info_type_invalid</symbol>
+  <description>Only stored credit card billing information can be verified at this time</description>
+</error>


### PR DESCRIPTION
If the account has billing information for anything other than a credit card, this will return 422, with an appropriate error message. If successful, this will return 200, with the transaction's data.
gateway_code (optional) is the code for the gateway to use for the verification. If unspecified, a gateway will be selected using the normal rules.

Example:
```ruby
# verify without specifying gateway code to use 
billing_info.verify()
# verify with a specific gateway code
billing_info.verify({gateway-code: "gateway-code"})
```