### PR TITLE
Release 3.14.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.13.0
+current_version = 3.14.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -5,7 +5,7 @@ This repository houses the official ruby client for Recurly's V3 API.
 In your Gemfile, add `recurly` as a dependency.
 
 ```ruby
-gem 'recurly', '~> 3.13'
+gem 'recurly', '~> 3.14'
 ```
 
 > *Note*: We try to follow [semantic versioning](https://semver.org/) and will only apply breaking changes to major versions.

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,3 +1,3 @@
 module Recurly
-  VERSION = "3.13.0"
+  VERSION = "3.14.0"
 end


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/recurly/recurly-client-ruby/tree/HEAD)

[Full Changelog](https://github.com/recurly/recurly-client-ruby/compare/3.13.0...HEAD)

**Implemented enhancements:**

- Mon Oct 19 20:38:03 UTC 2020 Upgrade API version v2019-10-10 [\#642](https://github.com/recurly/recurly-client-ruby/pull/642) ([douglasmiller](https://github.com/douglasmiller))

**Merged pull requests:**

- Fixes uninitialized constant `Recurly::Errors::ServiceNotAvailableError` [\#641](https://github.com/recurly/recurly-client-ruby/pull/641) ([ruyrocha](https://github.com/ruyrocha))