### PR TITLE
Support item-specific coupons

### DIFF
--- a/lib/recurly/coupon.rb
+++ b/lib/recurly/coupon.rb
@@ -46,6 +46,8 @@ module Recurly
       unique_template_code
       free_trial_amount
       free_trial_unit
+      applies_to_all_items
+      item_codes
     )
     alias to_param coupon_code
 

--- a/spec/fixtures/coupons/show-200.xml
+++ b/spec/fixtures/coupons/show-200.xml
@@ -27,6 +27,10 @@ Content-Type: application/xml; charset=utf-8
   <plan_codes type="array">
     <plan_code>saul_good</plan_code>
   </plan_codes>
+  <item_codes type="array">
+    <item_code>huell_babineaux</item_code>
+    <item_code>patrick_kuby</item_code>
+  </item_codes>
   <a name="redeem" href="https://api.recurly.com/v2/coupons/bettercallsaul/redeem" method="put"/>
   <a name="restore" href="https://api.recurly.com/v2/coupons/bettercallsaul/restore" method="put"/>
 </coupon>

--- a/spec/recurly/coupon_spec.rb
+++ b/spec/recurly/coupon_spec.rb
@@ -11,6 +11,7 @@ describe Coupon do
     it "must return a coupon when available" do
       coupon.must_be_instance_of Coupon
       coupon.plan_codes.must_equal ['saul_good']
+      coupon.item_codes.must_equal ['huell_babineaux', 'patrick_kuby']
     end
   end
 


### PR DESCRIPTION
Add `item_codes` and `applies_to_all_items` to Coupon

Example
```ruby
# Create coupon with `item_codes`
coupon = Recurly::Coupon.create!(
  coupon_code:      'special',
  name:             'Special',
  discount_type:    'dollars',
  discount_in_cents: 2_00,
  
  # `applies_to_all_items` defaults to false, so next line is optional
  applies_to_all_items: false,
  item_codes: ['one_item', 'two_item'],
)
```