### PR TITLE
Release 2.18.16

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.18.15
+current_version = 2.18.16
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.16"></a>
+## v.2.18.16 (2020-11-05)
+
+* Support item-specific coupons [PR](https://github.com/recurly/recurly-client-ruby/pull/644)
+
 <a name="v2.18.15"></a>
 ## v.2.18.15 (2020-09-17)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.18.15'
+gem 'recurly', '~> 2.18.16'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,6 +1,6 @@
 module Recurly
   module Version
-    VERSION = "2.18.15"
+    VERSION = "2.18.16"
 
     class << self
       def inspect


### PR DESCRIPTION
- Bump to Ruby client library version 2.18.16
- Update changelog

-------
* Support item-specific coupons https://github.com/recurly/recurly-client-ruby/pull/644
