### PR TITLE
Expose last_two on BillingInfo class for IBAN accounts and repair tests

### DIFF
--- a/lib/recurly/billing_info.rb
+++ b/lib/recurly/billing_info.rb
@@ -8,7 +8,7 @@ module Recurly
     AMAZON_ATTRIBUTES = %w(amazon_billing_agreement_id amazon_region).freeze
     PAYPAL_ATTRIBUTES = %w(paypal_billing_agreement_id).freeze
     ROKU_ATTRIBUTES = %w(roku_billing_agreement_id last_four).freeze
-    SEPA_ATTRIBUTES = %w(iban).freeze
+    SEPA_ATTRIBUTES = %w(iban last_two).freeze
     BACS_ATTRIBUTES = %w(account_number sort_code type).freeze
     BECS_ATTRIBUTES = %w(account_number bsb_code type).freeze
 

--- a/spec/fixtures/billing_info/show-sepa-200.xml
+++ b/spec/fixtures/billing_info/show-sepa-200.xml
@@ -5,14 +5,15 @@ Content-Type: application/xml; charset=utf-8
 <billing_info href="https://api.recurly.com/v2/accounts/sepa1234567890/billing_info">
   <account href="https://api.recurly.com/v2/accounts/sepa1234567890"/>
   <company nil="nil"></company>
-  <address1>123 Pretty Pretty Good St.</address1>
+  <address1 nil="nil"></address1>
   <address2 nil="nil"></address2>
-  <city>Los Angeles</city>
-  <state>CA</state>
-  <zip>90210</zip>
-  <country>US</country>
+  <city nil="nil"></city>
+  <state nil="nil"></state>
+  <zip nil="nil"></zip>
+  <country>FR</country>
   <phone nil="nil"></phone>
   <vat_number nil="nil"></vat_number>
-  <iban>US1234567890</iban>
   <name_on_account>Account Name</name_on_account>
+  <last_two>06</last_two>
+  <updated_at type="datetime">2020-11-06T21:57:23Z</updated_at>
 </billing_info>

--- a/spec/recurly/billing_info_spec.rb
+++ b/spec/recurly/billing_info_spec.rb
@@ -62,7 +62,7 @@ XML
       )
       billing_info = BillingInfo.find 'sepa1234567890'
       billing_info.name_on_account.must_equal 'Account Name'
-      billing_info.iban.must_equal 'US1234567890'
+      billing_info.last_two.must_equal '06'
     end
 
     it "must return an account's billing info as bacs when available" do

--- a/spec/recurly/billing_info_spec.rb
+++ b/spec/recurly/billing_info_spec.rb
@@ -45,7 +45,7 @@ XML
       billing_info.state.must_equal 'CA'
     end
 
-    it "must return an accounts billing info as a bank account when available" do
+    it "must return an accounts billing info as a bank account (last_four) when available" do
       stub_api_request(
         :get, 'accounts/abcdef1234567890/billing_info', 'billing_info/show-200-bank-account'
       )
@@ -56,7 +56,7 @@ XML
       billing_info.routing_number.must_equal '12309812'
     end
 
-    it "must return an account's billing info as iban when available" do
+    it "must return an account's billing info as IBAN (last_two) when available" do
       stub_api_request(
         :get, 'accounts/sepa1234567890/billing_info', 'billing_info/show-sepa-200'
       )
@@ -65,7 +65,7 @@ XML
       billing_info.last_two.must_equal '06'
     end
 
-    it "must return an account's billing info as bacs when available" do
+    it "must return an account's billing info as BACS (sort_code) when available" do
       stub_api_request(
         :get, 'accounts/bacs1234567890/billing_info', 'billing_info/show-bacs-200'
       )
@@ -74,7 +74,7 @@ XML
       billing_info.sort_code.must_equal '200000'
     end
 
-    it "must return an account's billing info as becs when available" do
+    it "must return an account's billing info as BECS (bsb_code) when available" do
       stub_api_request(
         :get, 'accounts/becs1234567890/billing_info', 'billing_info/show-becs-200'
       )


### PR DESCRIPTION
Response for https://developers.recurly.com/api-v2/v2.29/#operation/createAccountsBillingInfoBankAccount endpoint using `iban` should include `last_two`, similar to `last_four` when `account_number` is used. This patch exposes the `last_two` field. 

Test has also been fixed to include `last_two` and remove `iban`, which was included erroneously.