### PR TITLE
Expose item_state and external_sku in AddOn class

### DIFF
--- a/lib/recurly/add_on.rb
+++ b/lib/recurly/add_on.rb
@@ -9,6 +9,7 @@ module Recurly
       add_on_code
       item_code
       name
+      item_state
       accounting_code
       default_quantity
       unit_amount_in_cents
@@ -23,6 +24,7 @@ module Recurly
       created_at
       updated_at
       tier_type
+      external_sku
       avalara_service_type
       avalara_transaction_type
     )

--- a/spec/fixtures/plans/item_backed_add_ons/index-200.xml
+++ b/spec/fixtures/plans/item_backed_add_ons/index-200.xml
@@ -6,6 +6,7 @@ Content-Type: application/xml; charset=utf-8
   <add_on href="https://api.recurly.com/v2/plans/orchidreset/add_ons/marfa_brunch">
     <plan href="https://api.recurly.com/v2/plans/orchidreset"/>
     <item href="https://api.recurly.com/v2/items/marfa_brunch"/>
+    <external_sku>sample-sku</external_sku>
     <item_state>active</item_state>
     <add_on_code>marfa_brunch</add_on_code>
     <name>Marfa Brunch</name>


### PR DESCRIPTION
Because `item_state` and `external_sku` are included in the xml response for item-based add-ons, it would be good practice to expose this fields to the programmer.