### PR TITLE
Release 2.18.18

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.18.17
+current_version = 2.18.18
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## Unreleased
 
+<a name="v2.18.18"></a>
+## v.2.18.18 (2020-11-23)
+
+* Expose `item_state` and `external_sku` in AddOn class [PR](https://github.com/recurly/recurly-client-ruby/pull/650)
+* Handle UnprocessableEntity error for Invoice#refund [PR](https://github.com/recurly/recurly-client-ruby/pull/653)
+
 <a name="v2.18.17"></a>
 ## v2.18.17 (2020-11-12)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recurly is packaged as a Ruby gem. We recommend you install it with
 [Bundler](http://gembundler.com/) by adding the following line to your Gemfile:
 
 ``` ruby
-gem 'recurly', '~> 2.18.17'
+gem 'recurly', '~> 2.18.18'
 ```
 
 Recurly will automatically use [Nokogiri](http://nokogiri.org/) (for a nice

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,6 +1,6 @@
 module Recurly
   module Version
-    VERSION = "2.18.17"
+    VERSION = "2.18.18"
 
     class << self
       def inspect


### PR DESCRIPTION
- Bump Ruby client library version to 2.18.18
- Update changelog

-----

* Expose `item_state` and `external_sku` in AddOn class https://github.com/recurly/recurly-client-ruby/pull/650
* Handle UnprocessableEntity error for Invoice#refund https://github.com/recurly/recurly-client-ruby/pull/653

