### PR TITLE
Latest Changes for 2019-10-10

### DIFF
--- a/lib/recurly/requests/purchase_create.rb
+++ b/lib/recurly/requests/purchase_create.rb
@@ -10,6 +10,10 @@ module Recurly
       #   @return [AccountPurchase]
       define_attribute :account, :AccountPurchase
 
+      # @!attribute billing_info_id
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      define_attribute :billing_info_id, String
+
       # @!attribute collection_method
       #   @return [String] Must be set to manual in order to preview a purchase for an Account that does not have payment information associated with the Billing Info.
       define_attribute :collection_method, String

--- a/lib/recurly/requests/subscription_create.rb
+++ b/lib/recurly/requests/subscription_create.rb
@@ -18,6 +18,10 @@ module Recurly
       #   @return [Boolean] Whether the subscription renews at the end of its term.
       define_attribute :auto_renew, :Boolean
 
+      # @!attribute billing_info_id
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      define_attribute :billing_info_id, String
+
       # @!attribute collection_method
       #   @return [String] Collection method
       define_attribute :collection_method, String

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15154,7 +15154,7 @@ components:
           maxLength: 255
         company:
           type: string
-          maxLength: 50
+          maxLength: 100
         vat_number:
           type: string
           description: The VAT number of the account (to avoid having the VAT applied).
@@ -20079,6 +20079,13 @@ components:
             are provided the `plan_id` will be used.
         account:
           "$ref": "#/components/schemas/AccountCreate"
+        billing_info_id:
+          type: string
+          title: Billing Info ID
+          description: The `billing_info_id` is the value that represents a specific
+            billing info for an end customer. When `billing_info_id` is used to assign
+            billing info to the subscription, all future billing events for the subscription
+            will bill to the specified billing info.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -21012,6 +21019,13 @@ components:
           maxLength: 3
         account:
           "$ref": "#/components/schemas/AccountPurchase"
+        billing_info_id:
+          type: string
+          title: Billing info ID
+          description: The `billing_info_id` is the value that represents a specific
+            billing info for an end customer. When `billing_info_id` is used to assign
+            billing info to the subscription, all future billing events for the subscription
+            will bill to the specified billing info.
         collection_method:
           type: string
           title: Collection method


### PR DESCRIPTION
- Adds `billing_info_id` to `PurchaseCreate` and `SubscriptionCreate` requests.