### PR TITLE
Streamline release process:

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -10,3 +10,4 @@ serialize =
 
 [bumpversion:file:README.md]
 
+[bumpversion:file:scripts/publish]

--- a/scripts/build-gem
+++ b/scripts/build-gem
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# switch to v2 branch
+git checkout v2
+
+# ensure local branch is up to date
+git pull
+
+# build gem
+gem build recurly.gemspec
+echo "Run './scripts/publish' to publish gem" 

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+gem release recurly-2.18.18.gem


### PR DESCRIPTION
- Create build-gem script that 1) checks out and pulls v2 branch and 2) builds ruby gem
- Create publish script, which will publish ruby gem - I wanted to keep building and publishing separate, but can combine them into one script if that's preferred.
- Add publish script file to bump2version configuration
