### PR TITLE
Release 4.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.0
+current_version = 4.0.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
@@ -13,4 +13,3 @@ serialize =
 [bumpversion:file:GETTING_STARTED.md]
 parse = (?P<major>\d+)\.(?P<minor>\d+)
 serialize = {major}.{minor}
-

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -5,7 +5,7 @@ This repository houses the official ruby client for Recurly's V3 API.
 In your Gemfile, add `recurly` as a dependency.
 
 ```ruby
-gem 'recurly', '~> 3.9'
+gem 'recurly', '~> 4.0'
 ```
 
 > *Note*: We try to follow [semantic versioning](https://semver.org/) and will only apply breaking changes to major versions.

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,3 +1,3 @@
 module Recurly
-  VERSION = "3.9.0"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/recurly/recurly-client-ruby/tree/HEAD)

[Full Changelog](https://github.com/recurly/recurly-client-ruby/compare/3.18.1...HEAD)

**Implemented enhancements:**

- Remove site\_id and subdomain from client initializer [\#624](https://github.com/recurly/recurly-client-ruby/pull/624) ([joannasese](https://github.com/joannasese))

**Fixed bugs:**

- Every method is returning wrong number of arguments [\#664](https://github.com/recurly/recurly-client-ruby/issues/664)

**Merged pull requests:**

- Updating changelog script and changelog generator config for 4.x release [\#663](https://github.com/recurly/recurly-client-ruby/pull/663) ([douglasmiller](https://github.com/douglasmiller))
- Removing unused method 'set\_site\_id' [\#627](https://github.com/recurly/recurly-client-ruby/pull/627) ([douglasmiller](https://github.com/douglasmiller))
- Updating 4.x client to expect query string params as \['params'\] [\#619](https://github.com/recurly/recurly-client-ruby/pull/619) ([douglasmiller](https://github.com/douglasmiller))
- Updating error mapping based on status code [\#616](https://github.com/recurly/recurly-client-ruby/pull/616) ([douglasmiller](https://github.com/douglasmiller))