### PR TITLE
Release 4.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.0
+current_version = 4.0.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
@@ -13,4 +13,3 @@ serialize =
 [bumpversion:file:GETTING_STARTED.md]
 parse = (?P<major>\d+)\.(?P<minor>\d+)
 serialize = {major}.{minor}
-

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -5,7 +5,7 @@ This repository houses the official ruby client for Recurly's V3 API.
 In your Gemfile, add `recurly` as a dependency.
 
 ```ruby
-gem 'recurly', '~> 3.9'
+gem 'recurly', '~> 4.0'
 ```
 
 > *Note*: We try to follow [semantic versioning](https://semver.org/) and will only apply breaking changes to major versions.

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,3 +1,3 @@
 module Recurly
-  VERSION = "3.9.0"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/recurly/recurly-client-ruby/tree/HEAD)

[Full Changelog](https://github.com/recurly/recurly-client-ruby/compare/3.18.1...HEAD)

# Major Version Release

The 4.x major version of the client pairs with the `v2021-02-25` API version. This version of the client and the API contain breaking changes that should be considered before upgrading your integration.

## Breaking Changes in the API
All changes to the core API are documented in the [Developer Portal changelog](https://developers.recurly.com/api/changelog.html#v2021-02-25---current-ga-version)

## Breaking Changes in Client

- Remove `site_id` and `subdomain` from client initializer.  [#624]
- Remove `set_site_id` method from client.  [#627]
- Classify unexpected error responses from Recurly API via an HTTP status code mapping provided in `Recurly::Errors::ERROR_MAP`.  [#616]
- Remove `NetworkError` class. All error classes now extend the `APIError`. This means that the order of multiple rescue blocks will need to be re-considered.  [#616]

    ### 3.x

    ```ruby
    rescue Recurly::Errors::ValidationError => ex
      # catch a validation error
    rescue Recurly::Errors::APIError => ex
      # catch a generic api error
    rescue Recurly::Errors::TimeoutError => ex
      # catch a specific network error
    ```

    ### 4.x

    ```ruby
    rescue Recurly::Errors::ValidationError => ex
      # catch a validation error
    rescue Recurly::Errors::TimeoutError => ex
      # catch a specific network error
    rescue Recurly::Errors::APIError => ex
      # catch a generic api error
    ```

- Rename `InvalidResponseError` to `InvalidContentTypeError`.  [#616]
- Rename `UnavailableError` to `ServiceUnavailableError`.  [#616]
- Reorganize top-level keys of the optional parameters hash to improve clarity and create space for additional options.  [#619]

    ### 3.x

    ```ruby
    options = {
      limit: 200,
      headers: {
        'Accept-Language' => 'fr'
      }
    }
    accounts = @client.list_accounts(options)
    ```

    ### 4.x

    ```ruby
    options = {
      params: {
          limit: 200
      }
      headers: {
        'Accept-Language' => 'fr'
      }
    }
    accounts = @client.list_accounts(options)
    ```

**Implemented enhancements:**

- Remove site\_id and subdomain from client initializer [\#624](https://github.com/recurly/recurly-client-ruby/pull/624) ([joannasese](https://github.com/joannasese))

**Fixed bugs:**

- Every method is returning wrong number of arguments [\#664](https://github.com/recurly/recurly-client-ruby/issues/664)

**Merged pull requests:**

- Updating changelog script and changelog generator config for 4.x release [\#663](https://github.com/recurly/recurly-client-ruby/pull/663) ([douglasmiller](https://github.com/douglasmiller))
- Removing unused method 'set\_site\_id' [\#627](https://github.com/recurly/recurly-client-ruby/pull/627) ([douglasmiller](https://github.com/douglasmiller))
- Updating 4.x client to expect query string params as \['params'\] [\#619](https://github.com/recurly/recurly-client-ruby/pull/619) ([douglasmiller](https://github.com/douglasmiller))
- Updating error mapping based on status code [\#616](https://github.com/recurly/recurly-client-ruby/pull/616) ([douglasmiller](https://github.com/douglasmiller))


