### PR TITLE
Fixes TypeError caused by attempts to Base64 encode nil @api_key values

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -331,7 +331,7 @@ module Recurly
     end
 
     def set_api_key(api_key)
-      @api_key = api_key
+      @api_key = api_key.to_s
     end
 
     def build_url(path, options)

--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -55,6 +55,8 @@ module Recurly
     # @param api_key [String] The private API key
     # @param logger [Logger] A logger to use. Defaults to creating a new STDOUT logger with level WARN.
     def initialize(api_key:, logger: nil)
+      raise ArgumentError, "'api_key' must be set to a non-nil value" if api_key.nil?
+
       set_api_key(api_key)
 
       if logger.nil?

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -388,6 +388,18 @@ RSpec.describe Recurly::Client do
     end
   end
 
+  context "with a missing api key" do
+    describe "initialize" do
+      let(:options) { { api_key: nil } }
+
+      it "should raise an ArgumentError when api_key is nil" do
+        expect {
+          Recurly::Client.new(**options)
+        }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe "unexpected HTML responses" do
     context "with 200 OK" do
       let(:response) do


### PR DESCRIPTION
When a Client is initialized with a nil `api_key` value (a Dotenv loading issue in my case), requests fail with an opaque TypeError when `#set_headers` tries to base64 encode it:

```shell
[2] Pry(main)> subscriptions.first
TypeError: no implicit conversion of nil into String
from /usr/local/var/rbenv/versions/2.5.7/lib/ruby/2.5.0/base64.rb:39:in `pack'
```
This explicitly casts `@api_key` to a string, which makes a blank value raise a `Recurly::Errors::UnauthorizedError` instead.