### PR TITLE
Removing --binstubs from local development build script

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,7 +1,7 @@
 user=recurly
 project=recurly-client-ruby
 unreleased=false
-exclude-labels=question,bug?,duplicate,V2
+exclude-labels=internal,question,bug?,duplicate,V2
 exclude-tags-regex=^[^3]+\..*
 issues-wo-labels=false
 verbose=false

--- a/scripts/build
+++ b/scripts/build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-bundle install --binstubs --quiet
-./bin/yard --quiet
+bundle install --quiet
+bundle exec yard --quiet

--- a/scripts/format
+++ b/scripts/format
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [ "$1" == "--check" ]; then
-  ./bin/rufo . --check
+  bundle exec rufo . --check
   RESULT=$?
   if [ $RESULT != 0 ]; then
     echo "Code is not properly formatted. Please execute ./scripts/format to autoformat the code."
     exit $RESULT
   fi
 else
-  ./bin/rufo . -x
+  bundle exec rufo . -x
 fi


### PR DESCRIPTION
Removing the `--binstubs` flag from the internal development `scripts/build` script.