### PR TITLE
Restoring NetworkError and it's derivatives

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -205,7 +205,7 @@ module Recurly
           end
 
           raise Recurly::Errors::ConnectionFailedError, "Failed to connect to Recurly: #{ex.message}"
-        rescue Net::ReadTimeout, Timeout::Error
+        rescue Timeout::Error
           raise Recurly::Errors::TimeoutError, "Request timed out"
         rescue OpenSSL::SSL::SSLError => ex
           raise Recurly::Errors::SSLError, ex.message

--- a/lib/recurly/errors.rb
+++ b/lib/recurly/errors.rb
@@ -47,4 +47,5 @@ module Recurly
   end
 
   require_relative "./errors/api_errors"
+  require_relative "./errors/network_errors"
 end

--- a/lib/recurly/errors/network_errors.rb
+++ b/lib/recurly/errors/network_errors.rb
@@ -1,0 +1,7 @@
+module Recurly
+  module Errors
+    class NetworkError < APIError; end
+    class ConnectionFailedError < NetworkError; end
+    class SSLError < NetworkError; end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/recurly/recurly-client-ruby/issues/684 and adds tests to ensure that the functionality is preserved.