### PR TITLE
Making #post allow a nil body

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -103,12 +103,14 @@ module Recurly
       handle_response! request, http_response
     end
 
-    def post(path, request_data, request_class, **options)
-      request_class.new(request_data).validate!
+    def post(path, request_data = nil, request_class = nil, **options)
       request = Net::HTTP::Post.new build_url(path, options)
       request.set_content_type(JSON_CONTENT_TYPE)
       set_headers(request, options[:headers])
-      request.body = JSON.dump(request_data)
+      if request_data
+        request_class.new(request_data).validate!
+        request.body = JSON.dump(request_data)
+      end
       http_response = run_request(request, options)
       handle_response! request, http_response
     end

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -147,6 +147,14 @@ RSpec.describe Recurly::Client do
         account = subject.create_account(body: body)
         expect(account).to be_instance_of Recurly::Resources::Account
       end
+
+      it "should allow a nil request_data/class" do
+        req = Recurly::HTTP::Request.new(:post, "/verify")
+        expect(net_http).to receive(:request).and_return(response)
+        # Hacky way of ensuring that #post can be called without a body
+        account = subject.send(:post, "/verify")
+        expect(account).to be_instance_of Recurly::Resources::Account
+      end
     end
 
     describe "index calls" do


### PR DESCRIPTION
The protected `Client#post` previously required that `request_data` and `request_class` be provided. This update will make the `#post` method allow those parameters to be `nil` which matches the behavior of the `#put` method.