### PR TITLE
Postpone subscriptions using the field next_bill_date

### DIFF
--- a/lib/recurly/subscription.rb
+++ b/lib/recurly/subscription.rb
@@ -261,12 +261,12 @@ module Recurly
     #
     # @return [true, false] +true+ when successful, +false+ when unable to
     #   (e.g., the subscription is not active).
-    # @param next_renewal_date [Time] when the subscription should renew.
+    # @param next_bill_date [Time] when the subscription should renew.
     # @param bulk [boolean] set to true for bulk updates (bypassing 60 second wait).
-    def postpone next_renewal_date, bulk=false
+    def postpone next_bill_date, bulk=false
       return false unless link? :postpone
       reload follow_link(:postpone,
-        :params => { :next_renewal_date => next_renewal_date, :bulk => bulk }
+        :params => { :next_bill_date => next_bill_date, :bulk => bulk }
       )
       true
     end

--- a/spec/fixtures/subscriptions/postpone-200.xml
+++ b/spec/fixtures/subscriptions/postpone-200.xml
@@ -1,0 +1,32 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription href="">
+  <account href="https://api.recurly.com/v2/accounts/account_code"/>
+  <plan href="https://api.recurly.com/v2/plans/plan_code">
+    <plan_code>plan_code</plan_code>
+    <name>A Man, a Plan, a Canal: Panama</name>
+  </plan>
+  <uuid>abcdef1234567890</uuid>
+  <state>pending</state>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <currency>USD</currency>
+  <customer_notes>Some New Customer Notes</customer_notes>
+  <terms_and_conditions>Some New Terms and Conditions</terms_and_conditions>
+  <vat_reverse_charge_notes>Some New Vat Reverse Charge Notes</vat_reverse_charge_notes>
+  <quantity type="integer">1</quantity>
+  <activated_at nil="nil"></activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <total_billing_cycles nil="nil"></total_billing_cycles>
+  <remaining_billing_cycles nil="nil"></remaining_billing_cycles>
+  <gateway_code>Some Gateway Code</gateway_code>
+  <current_period_started_at type="datetime">2014-05-20T18:20:01Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2021-05-20</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <cost_in_cents type="integer">1000</cost_in_cents>
+  <subscription_add_ons type="array">
+  </subscription_add_ons>
+</subscription>

--- a/spec/fixtures/subscriptions/show-200.xml
+++ b/spec/fixtures/subscriptions/show-200.xml
@@ -51,4 +51,5 @@ Content-Type: application/xml; charset=utf-8
   <a name="cancel" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/cancel" method="put"/>
   <a name="terminate" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/terminate" method="put"/>
   <a name="notes" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/notes" method="put"/>
+  <a name="postpone" href="https://api.recurly.com/v2/subscriptions/abcdef1234567890/postpone" method="put"/>
 </subscription>

--- a/spec/recurly/subscription_spec.rb
+++ b/spec/recurly/subscription_spec.rb
@@ -464,4 +464,17 @@ describe Subscription do
       shad.must_be_instance_of Recurly::ShippingAddress
     end
   end
+
+  describe '#postpone' do
+    it 'postpones subscriptions' do
+      stub_api_request :get, 'subscriptions/abcdef1234567890', 'subscriptions/show-200'
+      stub_api_request :put, 'subscriptions/abcdef1234567890/postpone?bulk=false&next_bill_date=2021-05-20', 'subscriptions/postpone-200'
+
+      next_bill_date = Date.parse('2021-05-20')
+      subscription = Subscription.find 'abcdef1234567890'
+      
+      subscription.postpone(next_bill_date).must_equal true
+      subscription.current_period_ends_at.must_equal next_bill_date
+    end
+  end
 end


### PR DESCRIPTION
Pospone subscriptions using the `next_bill_date ` field instead of the deprecated `next_renewal_date`.
[DOC](https://developers.recurly.com/api-v2/v2.29/index.html#operation/postponeSubscriptionOrExtendTrial)