### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 3.0
 bundler_args: --binstubs
 before_install:
+  - sudo apt-get update && sudo apt-get install apt-transport-https ca-certificates -y && sudo update-ca-certificates
   - gem update --system
   - gem install bundler
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ before_install:
   - sudo apt-get update && sudo apt-get install apt-transport-https ca-certificates -y && sudo update-ca-certificates
   - gem update --system
   - gem install bundler
+dist: focal
 script:
   - ./scripts/test

--- a/lib/recurly/requests/subscription_change_create.rb
+++ b/lib/recurly/requests/subscription_change_create.rb
@@ -51,7 +51,7 @@ module Recurly
       define_attribute :revenue_schedule_type, String
 
       # @!attribute shipping
-      #   @return [SubscriptionChangeShippingCreate] The shipping address can currently only be changed immediately, using SubscriptionUpdate.
+      #   @return [SubscriptionChangeShippingCreate] Shipping addresses are tied to a customer's account. Each account can have up to 20 different shipping addresses, and if you have enabled multiple subscriptions per account, you can associate different shipping addresses to each subscription.
       define_attribute :shipping, :SubscriptionChangeShippingCreate
 
       # @!attribute timeframe

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19961,8 +19961,10 @@ components:
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription
-      description: The shipping address can currently only be changed immediately,
-        using SubscriptionUpdate.
+      description: Shipping addresses are tied to a customer's account. Each account
+        can have up to 20 different shipping addresses, and if you have enabled multiple
+        subscriptions per account, you can associate different shipping addresses
+        to each subscription.
       properties:
         method_id:
           type: string
@@ -21777,6 +21779,7 @@ components:
       - roku
       - sepadirectdebit
       - wire_transfer
+      - braintree_v_zero
     CardTypeEnum:
       type: string
       enum:


### PR DESCRIPTION
- Adds `braintree_v_zero` to the `PaymentMethodEnum`. 
- Updates the `SubscriptionChangeShippingCreate` description to include the number of shipping addresses allowed per account as well as specifying specific shipping addresses to individual subscriptions.