### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ rvm:
   - 3.0
 bundler_args: --binstubs
 before_install:
+  - sudo apt-get update && sudo apt-get install apt-transport-https ca-certificates -y && sudo update-ca-certificates
   - gem update --system
   - gem install bundler
+dist: focal
 script:
   - ./scripts/test

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21720,6 +21720,7 @@ components:
           - gateway_token
           - iban_bank_account
           - other
+          - braintree_v_zero
         card_type:
           type: string
           description: Visa, MasterCard, American Express, Discover, JCB, etc.


### PR DESCRIPTION
Adds `braintree_v_zero` to `PaymentMethodsEnum`. 