### PR TITLE
Allow API base url configuration

### DIFF
--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe Recurly::Client do
       "recurly-total-records" => "3804",
     }
   end
-  let(:net_http) { Recurly::ConnectionPool.new.init_http_connection }
+  let(:net_http) {
+    Recurly::ConnectionPool.new.init_http_connection(URI.parse(Recurly::Client::BASE_URL), Recurly::Client::CA_FILE)
+  }
   let(:connection_pool) {
     pool = double("ConnectionPool")
     allow(pool).to receive(:with_connection).and_yield net_http


### PR DESCRIPTION
Adds the `base_url` and `ca_file` client configuration options
which will be used as the base url when connecting to the API.
Defaults to `https://v3.recurly.com` and the bundled ca file in the
repo.