### PR TITLE
Generated Latest Changes for v2019-10-10 (Account Hierarchy Invoice Rollup)

### DIFF
--- a/lib/recurly/resources/line_item.rb
+++ b/lib/recurly/resources/line_item.rb
@@ -34,6 +34,10 @@ module Recurly
       #   @return [Integer] Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
       define_attribute :avalara_transaction_type, Integer
 
+      # @!attribute bill_for_account_id
+      #   @return [String] The UUID of the account responsible for originating the line item.
+      define_attribute :bill_for_account_id, String
+
       # @!attribute created_at
       #   @return [DateTime] When the line item was created.
       define_attribute :created_at, DateTime

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18279,6 +18279,12 @@ components:
           - carryforward
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21916,6 +21922,8 @@ components:
                 - batch_processing_error
                 - billing_agreement_already_accepted
                 - billing_agreement_not_accepted
+                - billing_agreement_not_found
+                - billing_agreement_replaced
                 - call_issuer
                 - call_issuer_update_cardholder_data
                 - cannot_refund_unsettled_transactions


### PR DESCRIPTION
Add `bill_for_account_id` attribute -- the UUID of the account responsible for originating the line item -- to the `LineItem` class.