### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/requests/billing_info_create.rb
+++ b/lib/recurly/requests/billing_info_create.rb
@@ -6,6 +6,14 @@ module Recurly
   module Requests
     class BillingInfoCreate < Request
 
+      # @!attribute account_number
+      #   @return [String] The bank account number. (ACH, Bacs only)
+      define_attribute :account_number, String
+
+      # @!attribute account_type
+      #   @return [String] The bank account type. (ACH only)
+      define_attribute :account_type, String
+
       # @!attribute address
       #   @return [Address]
       define_attribute :address, :Address
@@ -58,6 +66,10 @@ module Recurly
       #   @return [String] Expiration month
       define_attribute :month, String
 
+      # @!attribute name_on_account
+      #   @return [String] The name associated with the bank account (ACH, SEPA, Bacs only)
+      define_attribute :name_on_account, String
+
       # @!attribute number
       #   @return [String] Credit card number, spaces and dashes are accepted.
       define_attribute :number, String
@@ -69,6 +81,14 @@ module Recurly
       # @!attribute primary_payment_method
       #   @return [Boolean] The `primary_payment_method` field is used to designate the primary billing info on the account. The first billing info created on an account will always become primary. Adding additional billing infos provides the flexibility to mark another billing info as primary, or adding additional non-primary billing infos. This can be accomplished by passing the `primary_payment_method` with a value of `true`. When adding billing infos via the billing_info and /accounts endpoints, this value is not permitted, and will return an error if provided.
       define_attribute :primary_payment_method, :Boolean
+
+      # @!attribute routing_number
+      #   @return [String] The bank's rounting number. (ACH only)
+      define_attribute :routing_number, String
+
+      # @!attribute sort_code
+      #   @return [String] Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
+      define_attribute :sort_code, String
 
       # @!attribute tax_identifier
       #   @return [String] Tax identifier is required if adding a billing info that is a consumer card in Brazil or in Argentina. This would be the customer's CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax identifiers for all residents who pay taxes in Brazil and Argentina respectively.
@@ -89,6 +109,10 @@ module Recurly
       # @!attribute transaction_type
       #   @return [String] An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
       define_attribute :transaction_type, String
+
+      # @!attribute type
+      #   @return [String] The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+      define_attribute :type, String
 
       # @!attribute vat_number
       #   @return [String] VAT number

--- a/lib/recurly/resources/line_item.rb
+++ b/lib/recurly/resources/line_item.rb
@@ -34,6 +34,10 @@ module Recurly
       #   @return [Integer] Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
       define_attribute :avalara_transaction_type, Integer
 
+      # @!attribute bill_for_account_id
+      #   @return [String] The UUID of the account responsible for originating the line item.
+      define_attribute :bill_for_account_id, String
+
       # @!attribute created_at
       #   @return [DateTime] When the line item was created.
       define_attribute :created_at, DateTime

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16345,6 +16345,28 @@ components:
             characters comprising a country code; two check digits; and a number that
             includes the domestic bank account number, branch identifier, and potential
             routing information
+        name_on_account:
+          type: string
+          maxLength: 255
+          description: The name associated with the bank account (ACH, SEPA, Bacs
+            only)
+        account_number:
+          type: string
+          maxLength: 255
+          description: The bank account number. (ACH, Bacs only)
+        routing_number:
+          type: string
+          maxLength: 15
+          description: The bank's rounting number. (ACH only)
+        sort_code:
+          type: string
+          maxLength: 15
+          description: Bank identifier code for UK based banks. Required for Bacs
+            based billing infos. (Bacs only)
+        type:
+          "$ref": "#/components/schemas/AchTypeEnum"
+        account_type:
+          "$ref": "#/components/schemas/AchAccountTypeEnum"
         tax_identifier:
           type: string
           description: Tax identifier is required if adding a billing info that is
@@ -17898,6 +17920,12 @@ components:
           "$ref": "#/components/schemas/LegacyCategoryEnum"
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21885,6 +21913,7 @@ components:
       - billing_agreement_already_accepted
       - billing_agreement_not_accepted
       - billing_agreement_not_found
+      - billing_agreement_replaced
       - call_issuer
       - call_issuer_update_cardholder_data
       - cancelled
@@ -22058,3 +22087,15 @@ components:
       - automatic
       - manual
       - trial
+    AchTypeEnum:
+      type: string
+      description: The payment method type for a non-credit card based billing info.
+        The value of `bacs` is the only accepted value (Bacs only)
+      enum:
+      - bacs
+    AchAccountTypeEnum:
+      type: string
+      description: The bank account type. (ACH only)
+      enum:
+      - checking
+      - savings


### PR DESCRIPTION
Support for Account Hierarchy Invoice Rollup:
- Add `bill_for_account_id` attribute -- the UUID of the account responsible for originating the line item -- to the `LineItem` class.

BillingInfoCreate request format has changed:
- Added `name_on_account`
- Added `account_number`
- Added `routing_number`
- Added `sort_code`
- Added `type`
- Added `account_type`