### PR TITLE
Generated Latest Changes for v2019-10-10 (Tax Inclusive Pricing)

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -524,7 +524,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2019-10-10#operation/get_a_billing_info get_a_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param billing_info_id [String] Billing Info ID.
+    # @param billing_info_id [String] Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
     # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
     #
     # @return [Resources::BillingInfo] A billing info.
@@ -539,7 +539,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2019-10-10#operation/update_a_billing_info update_a_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param billing_info_id [String] Billing Info ID.
+    # @param billing_info_id [String] Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
     # @param body [Requests::BillingInfoCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::BillingInfoCreate}
     # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
     #
@@ -555,7 +555,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2019-10-10#operation/remove_a_billing_info remove_a_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param billing_info_id [String] Billing Info ID.
+    # @param billing_info_id [String] Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
     # @param site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
     #
     # @return [Resources::Empty] Billing information deleted

--- a/lib/recurly/requests/add_on_pricing.rb
+++ b/lib/recurly/requests/add_on_pricing.rb
@@ -10,6 +10,10 @@ module Recurly
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/requests/invoice_collect.rb
+++ b/lib/recurly/requests/invoice_collect.rb
@@ -7,7 +7,7 @@ module Recurly
     class InvoiceCollect < Request
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute three_d_secure_action_result_token_id

--- a/lib/recurly/requests/line_item_create.rb
+++ b/lib/recurly/requests/line_item_create.rb
@@ -70,6 +70,10 @@ module Recurly
       #   @return [Boolean] `true` exempts tax on charges, `false` applies tax on charges. If not defined, then defaults to the Plan and Site settings. This attribute does not work for credits (negative line items). Credits are always applied post-tax. Pre-tax discounts should use the Coupons feature.
       define_attribute :tax_exempt, :Boolean
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute type
       #   @return [String] Line item type. If `item_code`/`item_id` is present then `type` should not be present. If `item_code`/`item_id` is not present then `type` is required.
       define_attribute :type, String

--- a/lib/recurly/requests/plan_pricing.rb
+++ b/lib/recurly/requests/plan_pricing.rb
@@ -14,6 +14,10 @@ module Recurly
       #   @return [Float] Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
       define_attribute :setup_fee, Float
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/requests/pricing.rb
+++ b/lib/recurly/requests/pricing.rb
@@ -10,6 +10,10 @@ module Recurly
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/requests/purchase_create.rb
+++ b/lib/recurly/requests/purchase_create.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :account, :AccountPurchase
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute collection_method

--- a/lib/recurly/requests/subscription_change_create.rb
+++ b/lib/recurly/requests/subscription_change_create.rb
@@ -54,6 +54,10 @@ module Recurly
       #   @return [SubscriptionChangeShippingCreate] The shipping address can currently only be changed immediately, using SubscriptionUpdate.
       define_attribute :shipping, :SubscriptionChangeShippingCreate
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute timeframe
       #   @return [String] The timeframe parameter controls when the upgrade or downgrade takes place. The subscription change can occur now, when the subscription is next billed, or when the subscription term ends. Generally, if you're performing an upgrade, you will want the change to occur immediately (now). If you're performing a downgrade, you should set the timeframe to `term_end` or `bill_date` so the change takes effect at a scheduled billing date. The `renewal` timeframe option is accepted as an alias for `term_end`.
       define_attribute :timeframe, String

--- a/lib/recurly/requests/subscription_create.rb
+++ b/lib/recurly/requests/subscription_create.rb
@@ -19,7 +19,7 @@ module Recurly
       define_attribute :auto_renew, :Boolean
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute collection_method
@@ -85,6 +85,10 @@ module Recurly
       # @!attribute starts_at
       #   @return [DateTime] If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
       define_attribute :starts_at, DateTime
+
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
 
       # @!attribute terms_and_conditions
       #   @return [String] This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.

--- a/lib/recurly/requests/subscription_purchase.rb
+++ b/lib/recurly/requests/subscription_purchase.rb
@@ -50,6 +50,10 @@ module Recurly
       #   @return [DateTime] If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
       define_attribute :starts_at, DateTime
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute total_billing_cycles
       #   @return [Integer] The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
       define_attribute :total_billing_cycles, Integer

--- a/lib/recurly/requests/subscription_update.rb
+++ b/lib/recurly/requests/subscription_update.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :auto_renew, :Boolean
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute collection_method
@@ -53,6 +53,10 @@ module Recurly
       # @!attribute shipping
       #   @return [SubscriptionShippingUpdate] Subscription shipping details
       define_attribute :shipping, :SubscriptionShippingUpdate
+
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
 
       # @!attribute terms_and_conditions
       #   @return [String] Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.

--- a/lib/recurly/resources/add_on_pricing.rb
+++ b/lib/recurly/resources/add_on_pricing.rb
@@ -10,6 +10,10 @@ module Recurly
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/resources/invoice.rb
+++ b/lib/recurly/resources/invoice.rb
@@ -19,7 +19,7 @@ module Recurly
       define_attribute :balance, Float
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute closed_at

--- a/lib/recurly/resources/plan_pricing.rb
+++ b/lib/recurly/resources/plan_pricing.rb
@@ -14,6 +14,10 @@ module Recurly
       #   @return [Float] Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
       define_attribute :setup_fee, Float
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/resources/pricing.rb
+++ b/lib/recurly/resources/pricing.rb
@@ -10,6 +10,10 @@ module Recurly
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/resources/subscription_change.rb
+++ b/lib/recurly/resources/subscription_change.rb
@@ -70,6 +70,10 @@ module Recurly
       #   @return [String] The ID of the subscription that is going to be changed.
       define_attribute :subscription_id, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit amount
       define_attribute :unit_amount, Float

--- a/lib/recurly/resources/subscription_change_preview.rb
+++ b/lib/recurly/resources/subscription_change_preview.rb
@@ -70,6 +70,10 @@ module Recurly
       #   @return [String] The ID of the subscription that is going to be changed.
       define_attribute :subscription_id, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit amount
       define_attribute :unit_amount, Float

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14525,7 +14525,8 @@ components:
     billing_info_id:
       name: billing_info_id
       in: path
-      description: Billing Info ID.
+      description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
+        feature.
       required: true
       schema:
         type: string
@@ -17683,7 +17684,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         subscription_ids:
           type: array
           title: Subscription IDs
@@ -17939,7 +17941,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     InvoiceCollection:
       type: object
       title: Invoice collection
@@ -18551,6 +18554,13 @@ components:
             A positive or negative amount with `type=credit` will result in a negative `unit_amount`.
             If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s
             `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -19113,6 +19123,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
     PlanUpdate:
       type: object
       properties:
@@ -19274,6 +19291,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -19291,6 +19315,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -20248,6 +20279,13 @@ components:
           type: number
           format: float
           title: Unit amount
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Subscription quantity
@@ -20353,6 +20391,13 @@ components:
             be used.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20485,7 +20530,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -20512,6 +20558,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20649,6 +20702,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20792,6 +20852,13 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:
@@ -20800,7 +20867,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     SubscriptionPause:
       type: object
       properties:
@@ -21469,7 +21537,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         collection_method:
           type: string
           title: Collection method


### PR DESCRIPTION
Adds to description of `billing_info_id`.
Adds support for **Tax Inclusive Pricing** feature of Recurly API.

Adds `tax_inclusive` attribute to the following requests:
- add_on_pricing
- line_item_create
- plan_pricing
- pricing
- subscription_change_create
- subscription_create
- subscription_purchase
- subscription_update

Adds `tax_inclusive` attribute to the following resources:
- add_on_pricing
- plan_pricing
- pricing
- subscription_change
- subscription_change_preview
