### PR TITLE
Generated Latest Changes for v2021-02-25 (Tax Inclusive Pricing)

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -532,7 +532,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2021-02-25#operation/get_a_billing_info get_a_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param billing_info_id [String] Billing Info ID.
+    # @param billing_info_id [String] Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
     # @param params [Hash] Optional query string parameters:
     #
     # @return [Resources::BillingInfo] A billing info.
@@ -547,7 +547,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2021-02-25#operation/update_a_billing_info update_a_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param billing_info_id [String] Billing Info ID.
+    # @param billing_info_id [String] Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
     # @param body [Requests::BillingInfoCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::BillingInfoCreate}
     # @param params [Hash] Optional query string parameters:
     #
@@ -563,7 +563,7 @@ module Recurly
     # {https://developers.recurly.com/api/v2021-02-25#operation/remove_a_billing_info remove_a_billing_info api documenation}
     #
     # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
-    # @param billing_info_id [String] Billing Info ID.
+    # @param billing_info_id [String] Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
     # @param params [Hash] Optional query string parameters:
     #
     # @return [Resources::Empty] Billing information deleted

--- a/lib/recurly/requests/add_on_pricing.rb
+++ b/lib/recurly/requests/add_on_pricing.rb
@@ -10,6 +10,10 @@ module Recurly
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided.
       define_attribute :unit_amount, Float

--- a/lib/recurly/requests/invoice_collect.rb
+++ b/lib/recurly/requests/invoice_collect.rb
@@ -7,7 +7,7 @@ module Recurly
     class InvoiceCollect < Request
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute three_d_secure_action_result_token_id

--- a/lib/recurly/requests/line_item_create.rb
+++ b/lib/recurly/requests/line_item_create.rb
@@ -70,6 +70,10 @@ module Recurly
       #   @return [Boolean] `true` exempts tax on charges, `false` applies tax on charges. If not defined, then defaults to the Plan and Site settings. This attribute does not work for credits (negative line items). Credits are always applied post-tax. Pre-tax discounts should use the Coupons feature.
       define_attribute :tax_exempt, :Boolean
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute type
       #   @return [String] Line item type. If `item_code`/`item_id` is present then `type` should not be present. If `item_code`/`item_id` is not present then `type` is required.
       define_attribute :type, String

--- a/lib/recurly/requests/plan_pricing.rb
+++ b/lib/recurly/requests/plan_pricing.rb
@@ -14,6 +14,10 @@ module Recurly
       #   @return [Float] Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
       define_attribute :setup_fee, Float
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/requests/pricing.rb
+++ b/lib/recurly/requests/pricing.rb
@@ -10,6 +10,10 @@ module Recurly
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/requests/purchase_create.rb
+++ b/lib/recurly/requests/purchase_create.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :account, :AccountPurchase
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute collection_method

--- a/lib/recurly/requests/subscription_change_create.rb
+++ b/lib/recurly/requests/subscription_change_create.rb
@@ -54,6 +54,10 @@ module Recurly
       #   @return [SubscriptionChangeShippingCreate] Shipping addresses are tied to a customer's account. Each account can have up to 20 different shipping addresses, and if you have enabled multiple subscriptions per account, you can associate different shipping addresses to each subscription.
       define_attribute :shipping, :SubscriptionChangeShippingCreate
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute timeframe
       #   @return [String] The timeframe parameter controls when the upgrade or downgrade takes place. The subscription change can occur now, when the subscription is next billed, or when the subscription term ends. Generally, if you're performing an upgrade, you will want the change to occur immediately (now). If you're performing a downgrade, you should set the timeframe to `term_end` or `bill_date` so the change takes effect at a scheduled billing date. The `renewal` timeframe option is accepted as an alias for `term_end`.
       define_attribute :timeframe, String

--- a/lib/recurly/requests/subscription_create.rb
+++ b/lib/recurly/requests/subscription_create.rb
@@ -19,7 +19,7 @@ module Recurly
       define_attribute :auto_renew, :Boolean
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute collection_method
@@ -85,6 +85,10 @@ module Recurly
       # @!attribute starts_at
       #   @return [DateTime] If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
       define_attribute :starts_at, DateTime
+
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
 
       # @!attribute terms_and_conditions
       #   @return [String] This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.

--- a/lib/recurly/requests/subscription_purchase.rb
+++ b/lib/recurly/requests/subscription_purchase.rb
@@ -50,6 +50,10 @@ module Recurly
       #   @return [DateTime] If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
       define_attribute :starts_at, DateTime
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute total_billing_cycles
       #   @return [Integer] The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
       define_attribute :total_billing_cycles, Integer

--- a/lib/recurly/requests/subscription_update.rb
+++ b/lib/recurly/requests/subscription_update.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :auto_renew, :Boolean
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute collection_method
@@ -57,6 +57,10 @@ module Recurly
       # @!attribute shipping
       #   @return [SubscriptionShippingUpdate] Subscription shipping details
       define_attribute :shipping, :SubscriptionShippingUpdate
+
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
 
       # @!attribute terms_and_conditions
       #   @return [String] Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.

--- a/lib/recurly/resources/add_on_pricing.rb
+++ b/lib/recurly/resources/add_on_pricing.rb
@@ -10,6 +10,10 @@ module Recurly
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided.
       define_attribute :unit_amount, Float

--- a/lib/recurly/resources/invoice.rb
+++ b/lib/recurly/resources/invoice.rb
@@ -19,7 +19,7 @@ module Recurly
       define_attribute :balance, Float
 
       # @!attribute billing_info_id
-      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+      #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
       # @!attribute closed_at

--- a/lib/recurly/resources/plan_pricing.rb
+++ b/lib/recurly/resources/plan_pricing.rb
@@ -14,6 +14,10 @@ module Recurly
       #   @return [Float] Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
       define_attribute :setup_fee, Float
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/resources/pricing.rb
+++ b/lib/recurly/resources/pricing.rb
@@ -10,6 +10,10 @@ module Recurly
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit price
       define_attribute :unit_amount, Float

--- a/lib/recurly/resources/subscription_change.rb
+++ b/lib/recurly/resources/subscription_change.rb
@@ -66,6 +66,10 @@ module Recurly
       #   @return [String] The ID of the subscription that is going to be changed.
       define_attribute :subscription_id, String
 
+      # @!attribute tax_inclusive
+      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      define_attribute :tax_inclusive, :Boolean
+
       # @!attribute unit_amount
       #   @return [Float] Unit amount
       define_attribute :unit_amount, Float

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14579,7 +14579,8 @@ components:
     billing_info_id:
       name: billing_info_id
       in: path
-      description: Billing Info ID.
+      description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
+        feature.
       required: true
       schema:
         type: string
@@ -17377,7 +17378,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         subscription_ids:
           type: array
           title: Subscription IDs
@@ -17634,7 +17636,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     InvoiceCollection:
       type: object
       title: Invoice collection
@@ -18178,6 +18181,13 @@ components:
             A positive or negative amount with `type=credit` will result in a negative `unit_amount`.
             If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the
             `Item`'s `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -18691,6 +18701,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
     PlanUpdate:
       type: object
       properties:
@@ -18849,6 +18866,13 @@ components:
           description: |
             Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`.
             If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
     TierPricing:
@@ -18891,6 +18915,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -19828,6 +19859,13 @@ components:
           type: number
           format: float
           title: Unit amount
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Subscription quantity
@@ -19915,6 +19953,13 @@ components:
             be used.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20043,7 +20088,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -20067,6 +20113,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20198,6 +20251,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20334,6 +20394,13 @@ components:
           description: If present, this subscription's transactions will use the payment
             gateway with this code.
           maxLength: 13
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:
@@ -20342,7 +20409,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     SubscriptionPause:
       type: object
       properties:
@@ -20940,7 +21008,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         collection_method:
           title: Collection method
           description: Must be set to manual in order to preview a purchase for an
@@ -22017,6 +22086,7 @@ components:
       - three_d_secure_action_result_token_mismatch
       - three_d_secure_authentication
       - three_d_secure_connection_error
+      - three_d_secure_credential_error
       - three_d_secure_not_supported
       - too_many_attempts
       - total_credit_exceeds_capture


### PR DESCRIPTION
Adds to description of `billing_info_id`.
Adds support for **Tax Inclusive Pricing** feature of Recurly API.

Adds `tax_inclusive` attribute to the following requests:
- add_on_pricing
- line_item_create
- plan_pricing
- pricing
- subscription_change_create
- subscription_create
- subscription_purchase
- subscription_update

Adds `tax_inclusive` attribute to the following resources:
- add_on_pricing
- plan_pricing
- pricing
- subscription_change
