### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/requests/add_on_create.rb
+++ b/lib/recurly/requests/add_on_create.rb
@@ -39,11 +39,11 @@ module Recurly
       define_attribute :display_quantity, :Boolean
 
       # @!attribute item_code
-      #   @return [String] Unique code to identify an item. Available when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+      #   @return [String] Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
       define_attribute :item_code, String
 
       # @!attribute item_id
-      #   @return [String] System-generated unique identifier for an item. Available when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+      #   @return [String] System-generated unique identifier for an item. Available when the `Credit Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
       define_attribute :item_id, String
 
       # @!attribute measured_unit_id

--- a/lib/recurly/requests/billing_info_create.rb
+++ b/lib/recurly/requests/billing_info_create.rb
@@ -111,7 +111,7 @@ module Recurly
       define_attribute :transaction_type, String
 
       # @!attribute type
-      #   @return [String] The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+      #   @return [String] The payment method type for a non-credit card based billing info. `bacs` and `becs` are the only accepted values.
       define_attribute :type, String
 
       # @!attribute vat_number

--- a/lib/recurly/requests/line_item_create.rb
+++ b/lib/recurly/requests/line_item_create.rb
@@ -35,11 +35,11 @@ module Recurly
       define_attribute :end_date, DateTime
 
       # @!attribute item_code
-      #   @return [String] Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+      #   @return [String] Unique code to identify an item. Available when the Credit Invoices feature is enabled.
       define_attribute :item_code, String
 
       # @!attribute item_id
-      #   @return [String] System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+      #   @return [String] System-generated unique identifier for an item. Available when the Credit Invoices feature is enabled.
       define_attribute :item_id, String
 
       # @!attribute origin

--- a/lib/recurly/resources/account.rb
+++ b/lib/recurly/resources/account.rb
@@ -90,6 +90,10 @@ module Recurly
       #   @return [String]
       define_attribute :id, String
 
+      # @!attribute invoice_template
+      #   @return [AccountInvoiceTemplate] Invoice template associated to the account. Available when invoice customization flag is enabled.
+      define_attribute :invoice_template, :AccountInvoiceTemplate
+
       # @!attribute last_name
       #   @return [String]
       define_attribute :last_name, String

--- a/lib/recurly/resources/account_invoice_template.rb
+++ b/lib/recurly/resources/account_invoice_template.rb
@@ -1,0 +1,18 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class AccountInvoiceTemplate < Resource
+
+      # @!attribute id
+      #   @return [String] Unique ID to identify the invoice template.
+      define_attribute :id, String
+
+      # @!attribute name
+      #   @return [String] Template name
+      define_attribute :name, String
+    end
+  end
+end

--- a/lib/recurly/resources/line_item.rb
+++ b/lib/recurly/resources/line_item.rb
@@ -67,7 +67,7 @@ module Recurly
       define_attribute :end_date, DateTime
 
       # @!attribute external_sku
-      #   @return [String] Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+      #   @return [String] Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices feature is enabled.
       define_attribute :external_sku, String
 
       # @!attribute id
@@ -83,11 +83,11 @@ module Recurly
       define_attribute :invoice_number, String
 
       # @!attribute item_code
-      #   @return [String] Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+      #   @return [String] Unique code to identify an item. Available when the Credit Invoices feature is enabled.
       define_attribute :item_code, String
 
       # @!attribute item_id
-      #   @return [String] System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+      #   @return [String] System-generated unique identifier for an item. Available when the Credit Invoices feature is enabled.
       define_attribute :item_id, String
 
       # @!attribute legacy_category

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -232,7 +232,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices and Subscription Billing Terms features to be enabled.
+    Recurly's item catalog requires the Credit Invoices features to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -15540,6 +15540,8 @@ components:
           "$ref": "#/components/schemas/BillingInfo"
         custom_fields:
           "$ref": "#/components/schemas/CustomFields"
+        invoice_template:
+          "$ref": "#/components/schemas/AccountInvoiceTemplate"
     AccountNote:
       type: object
       required:
@@ -15636,6 +15638,20 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+    AccountInvoiceTemplate:
+      type: object
+      title: Invoice Template
+      description: Invoice template associated to the account. Available when invoice
+        customization flag is enabled.
+      properties:
+        id:
+          type: string
+          title: ID
+          description: Unique ID to identify the invoice template.
+        name:
+          type: string
+          title: Name
+          description: Template name
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -15900,16 +15916,16 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` and `Subscription Billing Terms` features are enabled. If `item_id`
-            and `item_code` are both present, `item_id` will be used.
+            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the `Credit Invoices` and `Subscription Billing Terms` features are enabled.
-            If `item_id` and `item_code` are both present, `item_id` will be used.
+            the `Credit Invoices` feature is enabled. If `item_id` and `item_code`
+            are both present, `item_id` will be used.
           maxLength: 13
         code:
           type: string
@@ -17888,20 +17904,20 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         external_sku:
           type: string
           title: External SKU
           description: Optional Stock Keeping Unit assigned to an item. Available
-            when the Credit Invoices and Subscription Billing Terms features are enabled.
+            when the Credit Invoices feature is enabled.
           maxLength: 50
         revenue_schedule_type:
           title: Revenue schedule type
@@ -18204,14 +18220,14 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
@@ -22160,9 +22176,10 @@ components:
     AchTypeEnum:
       type: string
       description: The payment method type for a non-credit card based billing info.
-        The value of `bacs` is the only accepted value (Bacs only)
+        `bacs` and `becs` are the only accepted values.
       enum:
       - bacs
+      - becs
     AchAccountTypeEnum:
       type: string
       description: The bank account type. (ACH only)


### PR DESCRIPTION
Support `becs` as a payment method type for non-credit card based billing info.
- Added `becs` as a valid non-credit card payment method type.

Support `invoice_template` in account when invoice customization feature is enabled.
- Added `invoice_template` to Account.

Updated documentation for the removal of the `Subscription Billing Terms` feature flag as the feature is now fully accessible on all sites.