### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly/requests/subscription_update.rb
+++ b/lib/recurly/requests/subscription_update.rb
@@ -55,7 +55,7 @@ module Recurly
       define_attribute :shipping, :SubscriptionShippingUpdate
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Do not use it anymore to update a subscription's tax inclusivity. Use the POST subscription change route instead.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute terms_and_conditions

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -20855,9 +20855,10 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Do not use it anymore to update a
+            subscription's tax inclusivity. Use the POST subscription change route
+            instead.
+          deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:


### PR DESCRIPTION
deprecated `tax_inclusive` attribute to the following requests:

- subscription_update