### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly/resources/subscription.rb
+++ b/lib/recurly/resources/subscription.rb
@@ -14,6 +14,10 @@ module Recurly
       #   @return [DateTime] Activated at
       define_attribute :activated_at, DateTime
 
+      # @!attribute active_invoice_id
+      #   @return [String] The invoice ID of the latest invoice created for an active subscription.
+      define_attribute :active_invoice_id, String
+
       # @!attribute add_ons
       #   @return [Array[SubscriptionAddOn]] Add-ons
       define_attribute :add_ons, Array, { :item_type => :SubscriptionAddOn }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19999,6 +19999,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.