### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/requests/add_on_create.rb
+++ b/lib/recurly/requests/add_on_create.rb
@@ -90,6 +90,10 @@ module Recurly
       #   @return [Float] The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage, `tier_type` is `flat` and `usage_type` is percentage. Must be omitted otherwise.
       define_attribute :usage_percentage, Float
 
+      # @!attribute usage_timeframe
+      #   @return [String] The time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to accumulate usage over the course of multiple billing periods.
+      define_attribute :usage_timeframe, String
+
       # @!attribute usage_type
       #   @return [String] Type of usage, required if `add_on_type` is `usage`. See our [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an overview of how to configure usage add-ons.
       define_attribute :usage_type, String

--- a/lib/recurly/resources/add_on.rb
+++ b/lib/recurly/resources/add_on.rb
@@ -110,6 +110,10 @@ module Recurly
       #   @return [Float] The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0.
       define_attribute :usage_percentage, Float
 
+      # @!attribute usage_timeframe
+      #   @return [String] The time at which usage totals are reset for billing purposes.
+      define_attribute :usage_timeframe, String
+
       # @!attribute usage_type
       #   @return [String] Type of usage, returns usage type if `add_on_type` is `usage`.
       define_attribute :usage_type, String

--- a/lib/recurly/resources/subscription.rb
+++ b/lib/recurly/resources/subscription.rb
@@ -14,6 +14,10 @@ module Recurly
       #   @return [DateTime] Activated at
       define_attribute :activated_at, DateTime
 
+      # @!attribute active_invoice_id
+      #   @return [String] The invoice ID of the latest invoice created for an active subscription.
+      define_attribute :active_invoice_id, String
+
       # @!attribute add_ons
       #   @return [Array[SubscriptionAddOn]] Add-ons
       define_attribute :add_ons, Array, { :item_type => :SubscriptionAddOn }

--- a/lib/recurly/resources/subscription_add_on.rb
+++ b/lib/recurly/resources/subscription_add_on.rb
@@ -69,6 +69,10 @@ module Recurly
       # @!attribute usage_percentage
       #   @return [Float] The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is percentage.
       define_attribute :usage_percentage, Float
+
+      # @!attribute usage_timeframe
+      #   @return [String] The time at which usage totals are reset for billing purposes.
+      define_attribute :usage_timeframe, String
     end
   end
 end

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16265,6 +16265,8 @@ components:
           readOnly: true
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -16443,6 +16445,8 @@ components:
             * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeCreateEnum"
         tiers:
           type: array
           title: Tiers
@@ -20059,6 +20063,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on
@@ -20098,6 +20109,8 @@ components:
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -22176,6 +22189,25 @@ components:
       - tiered
       - stairstep
       - volume
+    UsageTimeframeEnum:
+      type: string
+      title: Usage Timeframe
+      description: The time at which usage totals are reset for billing purposes.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
+    UsageTimeframeCreateEnum:
+      type: string
+      title: Usage Timeframe
+      description: |
+        The time at which usage totals are reset for billing purposes.
+        Allows for `tiered` add-ons to accumulate usage over the course of multiple
+        billing periods.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
     CreditPaymentActionEnum:
       type: string
       enum:


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.

Adds `usage_timeframe` to the add-on create request and responses. It represents the time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to accumulate usage over the course of multiple billing periods.  The valid values are `billing_period` or `subscription_term` with `billing_period` being the default value.