### PR TITLE
Nokogiri: Fix XML formatting to make tests green & remove warning

### DIFF
--- a/lib/recurly/xml/nokogiri.rb
+++ b/lib/recurly/xml/nokogiri.rb
@@ -8,7 +8,7 @@ module Recurly
       end
 
       def add_element name, value = nil
-        root.add_child(node = ::Nokogiri::XML::Element.new(name, root))
+        root.add_child(node = ::Nokogiri::XML::Element.new(name, root.document))
         node << value if value
         node
       end

--- a/spec/fixtures/plans/add_ons/index-200-tiered-percentage.xml
+++ b/spec/fixtures/plans/add_ons/index-200-tiered-percentage.xml
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK
-        Content-Type: application/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 
-        <?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <add_ons type="array">
   <add_on href="https://your-subdomain.recurly.com/v2/plans/percentageplan/add_ons/planter">
     <plan href="https://your-subdomain.recurly.com/v2/plans/percentageplan"/>


### PR DESCRIPTION
### [Fix XML formatting to get Nokogiri tests passing](https://github.com/recurly/recurly-client-ruby/commit/9d68777d2a02c90a5b36fae894f390a01094615b)

The mis-formatting was causing this test that was recently added to fail:

    1) Error:
    Recurly::AddOn::.find#test_0005_must return an addon with percentage-tiered-pricing and usage_timeframe when available:
    Recurly::XML::ParseError: Recurly::XML::ParseError
      ./recurly-client-ruby/lib/recurly/xml/nokogiri.rb:7:in `rescue in initialize'
      ./recurly-client-ruby/lib/recurly/xml/nokogiri.rb:4:in `initialize'
      ./recurly-client-ruby/lib/recurly/xml.rb:61:in `initialize'
      ./recurly-client-ruby/lib/recurly/resource/pager.rb:290:in `new'
      ./recurly-client-ruby/lib/recurly/resource/pager.rb:290:in `load_from'
      ./recurly-client-ruby/lib/recurly/resource/pager.rb:171:in `load!'
      ./recurly-client-ruby/lib/recurly/resource/pager.rb:136:in `each'
      ./recurly-client-ruby/spec/recurly/add_on_spec.rb:78:in `first'
      ./recurly-client-ruby/spec/recurly/add_on_spec.rb:78:in `block (3 levels) in <top (required)>'

Fixing the format makes all tests green when running with `XML=nokogiri`.

Note: the XML file was added recently by https://github.com/recurly/recurly-client-ruby/pull/767.

### [Fix Nokogiri warning by passing the document as argument](https://github.com/recurly/recurly-client-ruby/commit/28ca8069fe1bc08387cf2656aac0af7c072780dc)

This warning is triggered in multiple specs when running with
`XML=nokogiri`:

    ./recurly-client-ruby/lib/recurly/xml/nokogiri.rb:11: warning:
    Passing a Node as the second parameter to Node.new is deprecated.
    Please pass a Document instead, or prefer an alternative constructor
    like Node#add_child. This will become an error in a future release
    of Nokogiri.

By changing to passing the document instead, as per the warning message,
all tests are green and no warning is issued anymore.

Closes https://github.com/recurly/recurly-client-ruby/issues/754.

---

#### Test run

_rexml_
```
% bundle exec rake
Run options: --seed 13435

# Running:

.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 1.462468s, 343.9391 runs/s, 607.1928 assertions/s.

503 runs, 888 assertions, 0 failures, 0 errors, 0 skips
```

_nokogiri_
```
% XML=nokogiri bundle exec rake
Run options: --seed 30196

# Running:

.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 0.450451s, 1116.6586 runs/s, 1971.3576 assertions/s.

503 runs, 888 assertions, 0 failures, 0 errors, 0 skips
```