### PR TITLE
V2 add processing_prepayment_balance_in_cents to AccountBalance

### DIFF
--- a/lib/recurly/account_balance.rb
+++ b/lib/recurly/account_balance.rb
@@ -11,6 +11,7 @@ module Recurly
     define_attribute_methods %w(
       past_due
       balance_in_cents
+      processing_prepayment_balance_in_cents
     )
 
     # This object does not represent a model on the server side

--- a/spec/fixtures/account_balance/show-200.xml
+++ b/spec/fixtures/account_balance/show-200.xml
@@ -9,4 +9,8 @@ Content-Type: application/xml; charset=utf-8
     <USD type="integer">2910</USD>
     <EUR type="integer">-520</EUR>
   </balance_in_cents>
+  <processing_prepayment_balance_in_cents>
+    <USD type="integer">-3000</USD>
+    <EUR type="integer">0</EUR>
+  </processing_prepayment_balance_in_cents>
 </account_balance>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -299,6 +299,9 @@ XML
         balance = account_balance.balance_in_cents
         balance[:USD].must_equal(2910)
         balance[:EUR].must_equal(-520)
+        processing_prepayment_balance = account_balance.processing_prepayment_balance_in_cents
+        processing_prepayment_balance[:USD].must_equal(-3000)
+        processing_prepayment_balance[:EUR].must_equal(0)
       end
     end
 


### PR DESCRIPTION
Add new add `processing_prepayment_balance_in_cents` attribute to `AccountBalance`. The `processing_prepayment_balance_in_cents` attribute is a similar format to the `balance_in_cents` attribute and contains
the total for processing prepayment credit invoices in each currency. This value is useful when trying to determine if the customer's prepayment balance has run out or if it is currently processing while waiting on a payment for the corresponding purchase invoice.