### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly/requests/add_on_pricing.rb
+++ b/lib/recurly/requests/add_on_pricing.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :currency, String
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount

--- a/lib/recurly/requests/plan_pricing.rb
+++ b/lib/recurly/requests/plan_pricing.rb
@@ -15,7 +15,7 @@ module Recurly
       define_attribute :setup_fee, Float
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount

--- a/lib/recurly/requests/pricing.rb
+++ b/lib/recurly/requests/pricing.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :currency, String
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount

--- a/lib/recurly/requests/subscription_change_create.rb
+++ b/lib/recurly/requests/subscription_change_create.rb
@@ -55,7 +55,7 @@ module Recurly
       define_attribute :shipping, :SubscriptionChangeShippingCreate
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute timeframe

--- a/lib/recurly/requests/subscription_update.rb
+++ b/lib/recurly/requests/subscription_update.rb
@@ -55,7 +55,7 @@ module Recurly
       define_attribute :shipping, :SubscriptionShippingUpdate
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] This field is deprecated. Do not use it anymore to update a subscription's tax inclusivity. Use the POST subscription change route instead.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute terms_and_conditions

--- a/lib/recurly/resources/account_balance_amount.rb
+++ b/lib/recurly/resources/account_balance_amount.rb
@@ -13,6 +13,10 @@ module Recurly
       # @!attribute currency
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
+
+      # @!attribute processing_prepayment_amount
+      #   @return [Float] Total amount for the prepayment credit invoices in a `processing` state on the account.
+      define_attribute :processing_prepayment_amount, Float
     end
   end
 end

--- a/lib/recurly/resources/add_on_pricing.rb
+++ b/lib/recurly/resources/add_on_pricing.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :currency, String
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount

--- a/lib/recurly/resources/plan_pricing.rb
+++ b/lib/recurly/resources/plan_pricing.rb
@@ -15,7 +15,7 @@ module Recurly
       define_attribute :setup_fee, Float
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount

--- a/lib/recurly/resources/pricing.rb
+++ b/lib/recurly/resources/pricing.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :currency, String
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount

--- a/lib/recurly/resources/subscription_change.rb
+++ b/lib/recurly/resources/subscription_change.rb
@@ -71,7 +71,7 @@ module Recurly
       define_attribute :subscription_id, String
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount

--- a/lib/recurly/resources/subscription_change_preview.rb
+++ b/lib/recurly/resources/subscription_change_preview.rb
@@ -71,7 +71,7 @@ module Recurly
       define_attribute :subscription_id, String
 
       # @!attribute tax_inclusive
-      #   @return [Boolean] Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+      #   @return [Boolean] This field is deprecated. Please do not use it.
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15426,11 +15426,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15556,11 +15558,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15714,6 +15718,12 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+        processing_prepayment_amount:
+          type: number
+          format: float
+          title: Amount
+          description: Total amount for the prepayment credit invoices in a `processing`
+            state on the account.
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19127,9 +19137,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
     PlanUpdate:
       type: object
       properties:
@@ -19294,9 +19303,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -19318,9 +19326,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -20289,9 +20296,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Subscription quantity
@@ -20401,9 +20407,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Quantity
@@ -20862,9 +20867,7 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: This field is deprecated. Do not use it anymore to update a
-            subscription's tax inclusivity. Use the POST subscription change route
-            instead.
+          description: This field is deprecated. Please do not use it.
           deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"


### PR DESCRIPTION
- Added `pl-PL` and `sv-SE` to the acceptable values for `preferred_locale` to allow specifying Polish or Swedish for the preferred email language on an account.
- Added `processing_prepayment_amount` to the `GET accounts/{account_id}/balance` response in the `AccountBalanceAmount` element. This is the total amount for the prepayment credit invoices in a `processing` state on the account.
- The `tax_inclusive ` field has been deprecated on the `plans`, `add_ons`, `subscriptions` and `subscription_change` endpoints.