### PR TITLE
Added support for ramp-pricing plans

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -27,6 +27,7 @@ module Recurly
   require 'recurly/measured_unit'
   require 'recurly/note'
   require 'recurly/plan'
+  require 'recurly/plan_ramp_interval'
   require 'recurly/redemption'
   require 'recurly/shipping_fee'
   require 'recurly/shipping_method'

--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -4,6 +4,9 @@ module Recurly
     # @return [Pager<AddOn>, []]
     has_many :add_ons
 
+    # @return [[PlanRampInterval], nil]
+    has_many :ramp_intervals, class_name: :PlanRampInterval
+
     define_attribute_methods %w(
       plan_code
       name
@@ -21,6 +24,8 @@ module Recurly
       unit_amount_in_cents
       plan_interval_length
       plan_interval_unit
+      pricing_model
+      ramp_intervals
       trial_interval_length
       trial_interval_unit
       total_billing_cycles

--- a/lib/recurly/plan_ramp_interval.rb
+++ b/lib/recurly/plan_ramp_interval.rb
@@ -1,0 +1,10 @@
+module Recurly
+  class PlanRampInterval < Resource
+    belongs_to :plan
+
+    define_attribute_methods %w(
+      starting_billing_cycle
+      unit_amount_in_cents
+    )
+  end
+end

--- a/spec/recurly/plan_spec.rb
+++ b/spec/recurly/plan_spec.rb
@@ -12,6 +12,7 @@ describe Plan do
       :setup_fee_in_cents        => 60_00,
       :plan_interval_length      => 1,
       :plan_interval_unit        => 'months',
+      :pricing_model             => 'fixed',
       :tax_exempt                => false,
       :revenue_schedule_type     => 'evenly',
       :avalara_transaction_type  => 600,
@@ -19,8 +20,9 @@ describe Plan do
     )
   }
 
-  it 'must serialize' do
-    plan.to_xml.must_equal <<XML.chomp
+  describe 'when pricing_model is fixed' do
+    it 'must serialize' do
+      plan.to_xml.must_equal <<XML.chomp
 <plan>\
 <accounting_code>gold_plan_acc_code</accounting_code>\
 <avalara_service_type>3</avalara_service_type>\
@@ -30,6 +32,7 @@ describe Plan do
 <plan_code>gold</plan_code>\
 <plan_interval_length>1</plan_interval_length>\
 <plan_interval_unit>months</plan_interval_unit>\
+<pricing_model>fixed</pricing_model>\
 <revenue_schedule_type>evenly</revenue_schedule_type>\
 <setup_fee_accounting_code>setup_fee_ac</setup_fee_accounting_code>\
 <setup_fee_in_cents>\
@@ -41,6 +44,54 @@ describe Plan do
 </unit_amount_in_cents>\
 </plan>
 XML
+    end
+  end
+
+  describe 'when pricing_model is ramp' do
+    before do
+      plan.pricing_model = 'ramp'
+      plan.unit_amount_in_cents = nil
+      plan.ramp_intervals = [
+        Recurly::PlanRampInterval.new(
+          starting_billing_cycle: 1,
+          unit_amount_in_cents: {
+            USD: 1000
+          }
+        ),
+        Recurly::PlanRampInterval.new(
+          starting_billing_cycle: 2,
+          unit_amount_in_cents: {
+            USD: 2000
+          }
+        )
+      ]
+    end
+
+    it 'must serialize' do
+      plan.to_xml.must_equal <<XML.chomp
+<plan>\
+<accounting_code>gold_plan_acc_code</accounting_code>\
+<avalara_service_type>3</avalara_service_type>\
+<avalara_transaction_type>600</avalara_transaction_type>\
+<description>The Gold Plan is for folks who love gold.</description>\
+<name>The Gold Plan</name>\
+<plan_code>gold</plan_code>\
+<plan_interval_length>1</plan_interval_length>\
+<plan_interval_unit>months</plan_interval_unit>\
+<pricing_model>ramp</pricing_model>\
+<ramp_intervals>\
+<ramp_interval><starting_billing_cycle>1</starting_billing_cycle><unit_amount_in_cents><USD>1000</USD></unit_amount_in_cents></ramp_interval>\
+<ramp_interval><starting_billing_cycle>2</starting_billing_cycle><unit_amount_in_cents><USD>2000</USD></unit_amount_in_cents></ramp_interval>\
+</ramp_intervals>\
+<revenue_schedule_type>evenly</revenue_schedule_type>\
+<setup_fee_accounting_code>setup_fee_ac</setup_fee_accounting_code>\
+<setup_fee_in_cents>\
+<USD>6000</USD>\
+</setup_fee_in_cents>\
+<tax_exempt>false</tax_exempt>\
+</plan>
+XML
+    end
   end
 
   describe ".find" do


### PR DESCRIPTION
- Adds `pricing_model` attribute to `Recurly::Plan`, which can be either 'fixed' (for fixed-pricing plans) or 'ramp' (for ramp-pricing plans)
- Adds `ramp_intervals` attribute to `Recurly::Plan` (see final bullet-point)
- Adds `Recurly::PlanRampInterval` class, which can be used to initialize ramp_intervals for plans via the `ramp_intervals` attribute