### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/requests/plan_create.rb
+++ b/lib/recurly/requests/plan_create.rb
@@ -62,6 +62,14 @@ module Recurly
       #   @return [String] This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
       define_attribute :name, String
 
+      # @!attribute pricing_model
+      #   @return [String] A fixed pricing model has the same price for each billing period. A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on a specified cadence of billing periods. The price change could be an increase or decrease.
+      define_attribute :pricing_model, String
+
+      # @!attribute ramp_intervals
+      #   @return [Array[PlanRampInterval]] Ramp Intervals
+      define_attribute :ramp_intervals, Array, { :item_type => :PlanRampInterval }
+
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type
       define_attribute :revenue_schedule_type, String

--- a/lib/recurly/requests/plan_pricing.rb
+++ b/lib/recurly/requests/plan_pricing.rb
@@ -19,7 +19,7 @@ module Recurly
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount
-      #   @return [Float] Unit price
+      #   @return [Float] This field should not be sent when the pricing model is 'ramp'.
       define_attribute :unit_amount, Float
     end
   end

--- a/lib/recurly/requests/plan_ramp_interval.rb
+++ b/lib/recurly/requests/plan_ramp_interval.rb
@@ -1,0 +1,18 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class PlanRampInterval < Request
+
+      # @!attribute currencies
+      #   @return [Array[PlanRampPricing]] Represents the price for the ramp interval.
+      define_attribute :currencies, Array, { :item_type => :PlanRampPricing }
+
+      # @!attribute starting_billing_cycle
+      #   @return [Integer] Represents the first billing cycle of a ramp.
+      define_attribute :starting_billing_cycle, Integer
+    end
+  end
+end

--- a/lib/recurly/requests/plan_ramp_pricing.rb
+++ b/lib/recurly/requests/plan_ramp_pricing.rb
@@ -1,0 +1,18 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class PlanRampPricing < Request
+
+      # @!attribute currency
+      #   @return [String] 3-letter ISO 4217 currency code.
+      define_attribute :currency, String
+
+      # @!attribute unit_amount
+      #   @return [Float] Represents the price for the Ramp Interval.
+      define_attribute :unit_amount, Float
+    end
+  end
+end

--- a/lib/recurly/requests/plan_update.rb
+++ b/lib/recurly/requests/plan_update.rb
@@ -31,7 +31,7 @@ module Recurly
       define_attribute :code, String
 
       # @!attribute currencies
-      #   @return [Array[PlanPricing]] Pricing
+      #   @return [Array[PlanPricing]] Optional when the pricing model is 'ramp'.
       define_attribute :currencies, Array, { :item_type => :PlanPricing }
 
       # @!attribute description
@@ -53,6 +53,10 @@ module Recurly
       # @!attribute name
       #   @return [String] This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
       define_attribute :name, String
+
+      # @!attribute ramp_intervals
+      #   @return [Array[PlanRampInterval]] Ramp Intervals
+      define_attribute :ramp_intervals, Array, { :item_type => :PlanRampInterval }
 
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type

--- a/lib/recurly/requests/subscription_change_create.rb
+++ b/lib/recurly/requests/subscription_change_create.rb
@@ -46,6 +46,10 @@ module Recurly
       #   @return [Integer] Optionally override the default quantity of 1.
       define_attribute :quantity, Integer
 
+      # @!attribute ramp_intervals
+      #   @return [Array[SubscriptionRampInterval]] The new set of ramp intervals for the subscription.
+      define_attribute :ramp_intervals, Array, { :item_type => :SubscriptionRampInterval }
+
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type
       define_attribute :revenue_schedule_type, String

--- a/lib/recurly/requests/subscription_create.rb
+++ b/lib/recurly/requests/subscription_create.rb
@@ -70,6 +70,10 @@ module Recurly
       #   @return [Integer] Optionally override the default quantity of 1.
       define_attribute :quantity, Integer
 
+      # @!attribute ramp_intervals
+      #   @return [Array[SubscriptionRampInterval]] The new set of ramp intervals for the subscription.
+      define_attribute :ramp_intervals, Array, { :item_type => :SubscriptionRampInterval }
+
       # @!attribute renewal_billing_cycles
       #   @return [Integer] If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
       define_attribute :renewal_billing_cycles, Integer

--- a/lib/recurly/requests/subscription_purchase.rb
+++ b/lib/recurly/requests/subscription_purchase.rb
@@ -34,6 +34,10 @@ module Recurly
       #   @return [Integer] Optionally override the default quantity of 1.
       define_attribute :quantity, Integer
 
+      # @!attribute ramp_intervals
+      #   @return [Array[SubscriptionRampInterval]] The new set of ramp intervals for the subscription.
+      define_attribute :ramp_intervals, Array, { :item_type => :SubscriptionRampInterval }
+
       # @!attribute renewal_billing_cycles
       #   @return [Integer] If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
       define_attribute :renewal_billing_cycles, Integer

--- a/lib/recurly/requests/subscription_ramp_interval.rb
+++ b/lib/recurly/requests/subscription_ramp_interval.rb
@@ -1,0 +1,18 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class SubscriptionRampInterval < Request
+
+      # @!attribute starting_billing_cycle
+      #   @return [Integer] Represents how many billing cycles are included in a ramp interval.
+      define_attribute :starting_billing_cycle, Integer
+
+      # @!attribute unit_amount
+      #   @return [Integer] Represents the price for the ramp interval.
+      define_attribute :unit_amount, Integer
+    end
+  end
+end

--- a/lib/recurly/resources/payment_method.rb
+++ b/lib/recurly/resources/payment_method.rb
@@ -65,6 +65,10 @@ module Recurly
       # @!attribute routing_number_bank
       #   @return [String] The bank name of this routing number.
       define_attribute :routing_number_bank, String
+
+      # @!attribute username
+      #   @return [String] Username of the associated payment method. Currently only associated with Venmo.
+      define_attribute :username, String
     end
   end
 end

--- a/lib/recurly/resources/plan.rb
+++ b/lib/recurly/resources/plan.rb
@@ -74,6 +74,14 @@ module Recurly
       #   @return [String] Object type
       define_attribute :object, String
 
+      # @!attribute pricing_model
+      #   @return [String] A fixed pricing model has the same price for each billing period. A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on a specified cadence of billing periods. The price change could be an increase or decrease.
+      define_attribute :pricing_model, String
+
+      # @!attribute ramp_intervals
+      #   @return [Array[PlanRampInterval]] Ramp Intervals
+      define_attribute :ramp_intervals, Array, { :item_type => :PlanRampInterval }
+
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type
       define_attribute :revenue_schedule_type, String

--- a/lib/recurly/resources/plan_pricing.rb
+++ b/lib/recurly/resources/plan_pricing.rb
@@ -19,7 +19,7 @@ module Recurly
       define_attribute :tax_inclusive, :Boolean
 
       # @!attribute unit_amount
-      #   @return [Float] Unit price
+      #   @return [Float] This field should not be sent when the pricing model is 'ramp'.
       define_attribute :unit_amount, Float
     end
   end

--- a/lib/recurly/resources/plan_ramp_interval.rb
+++ b/lib/recurly/resources/plan_ramp_interval.rb
@@ -1,0 +1,18 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class PlanRampInterval < Resource
+
+      # @!attribute currencies
+      #   @return [Array[PlanRampPricing]] Represents the price for the ramp interval.
+      define_attribute :currencies, Array, { :item_type => :PlanRampPricing }
+
+      # @!attribute starting_billing_cycle
+      #   @return [Integer] Represents the first billing cycle of a ramp.
+      define_attribute :starting_billing_cycle, Integer
+    end
+  end
+end

--- a/lib/recurly/resources/plan_ramp_pricing.rb
+++ b/lib/recurly/resources/plan_ramp_pricing.rb
@@ -1,0 +1,18 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class PlanRampPricing < Resource
+
+      # @!attribute currency
+      #   @return [String] 3-letter ISO 4217 currency code.
+      define_attribute :currency, String
+
+      # @!attribute unit_amount
+      #   @return [Float] Represents the price for the Ramp Interval.
+      define_attribute :unit_amount, Float
+    end
+  end
+end

--- a/lib/recurly/resources/subscription.rb
+++ b/lib/recurly/resources/subscription.rb
@@ -126,6 +126,10 @@ module Recurly
       #   @return [Integer] Subscription quantity
       define_attribute :quantity, Integer
 
+      # @!attribute ramp_intervals
+      #   @return [Array[SubscriptionRampIntervalResponse]] The ramp intervals representing the pricing schedule for the subscription.
+      define_attribute :ramp_intervals, Array, { :item_type => :SubscriptionRampIntervalResponse }
+
       # @!attribute remaining_billing_cycles
       #   @return [Integer] The remaining billing cycles in the current term.
       define_attribute :remaining_billing_cycles, Integer

--- a/lib/recurly/resources/subscription_change.rb
+++ b/lib/recurly/resources/subscription_change.rb
@@ -54,6 +54,10 @@ module Recurly
       #   @return [Integer] Subscription quantity
       define_attribute :quantity, Integer
 
+      # @!attribute ramp_intervals
+      #   @return [Array[SubscriptionRampIntervalResponse]] The ramp intervals representing the pricing schedule for the subscription.
+      define_attribute :ramp_intervals, Array, { :item_type => :SubscriptionRampIntervalResponse }
+
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type
       define_attribute :revenue_schedule_type, String

--- a/lib/recurly/resources/subscription_ramp_interval_response.rb
+++ b/lib/recurly/resources/subscription_ramp_interval_response.rb
@@ -1,0 +1,22 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class SubscriptionRampIntervalResponse < Resource
+
+      # @!attribute remaining_billing_cycles
+      #   @return [Integer] Represents how many billing cycles are left in a ramp interval.
+      define_attribute :remaining_billing_cycles, Integer
+
+      # @!attribute starting_billing_cycle
+      #   @return [Integer] Represents how many billing cycles are included in a ramp interval.
+      define_attribute :starting_billing_cycle, Integer
+
+      # @!attribute unit_amount
+      #   @return [Integer] Represents the price for the ramp interval.
+      define_attribute :unit_amount, Integer
+    end
+  end
+end

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17535,7 +17535,7 @@ components:
           title: Field value
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
-          maxLength: 100
+          maxLength: 255
       required:
       - name
       - value
@@ -18959,6 +18959,14 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          "$ref": "#/components/schemas/PricingModelTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -19121,6 +19129,14 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          "$ref": "#/components/schemas/PricingModelTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -19242,6 +19258,7 @@ components:
           type: number
           format: float
           title: Unit price
+          description: This field should not be sent when the pricing model is 'ramp'.
           minimum: 0
           maximum: 1000000
         tax_inclusive:
@@ -19250,6 +19267,19 @@ components:
           default: false
           description: This field is deprecated. Please do not use it.
           deprecated: true
+    PlanRampInterval:
+      type: object
+      title: Plan Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents the first billing cycle of a ramp.
+          default: 1
+        currencies:
+          type: array
+          description: Represents the price for the ramp interval.
+          items:
+            "$ref": "#/components/schemas/PlanRampPricing"
     PlanUpdate:
       type: object
       properties:
@@ -19316,6 +19346,11 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -19362,6 +19397,7 @@ components:
         currencies:
           type: array
           title: Pricing
+          description: Optional when the pricing model is 'ramp'.
           items:
             "$ref": "#/components/schemas/PlanPricing"
           minItems: 1
@@ -19441,6 +19477,24 @@ components:
             If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
       required:
       - currency
+    PlanRampPricing:
+      type: object
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
+          description: Represents the price for the Ramp Interval.
+          minimum: 0
+          maximum: 1000000
+      required:
+      - currency
+      - unit_amount
     Pricing:
       type: object
       properties:
@@ -20044,6 +20098,13 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
         paused_at:
           type: string
           format: date-time
@@ -20546,6 +20607,13 @@ components:
           readOnly: true
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfo"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
     SubscriptionChangeBillingInfo:
       type: object
       description: Accept nested attributes for three_d_secure_action_result_token_id
@@ -20671,6 +20739,12 @@ components:
           "$ref": "#/components/schemas/GatewayTransactionTypeEnum"
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfoCreate"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription
@@ -20825,6 +20899,12 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -20964,6 +21044,12 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
       required:
       - plan_code
     SubscriptionUpdate:
@@ -21145,6 +21231,30 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+    SubscriptionRampInterval:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+          default: 1
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
+    SubscriptionRampIntervalResponse:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+        remaining_billing_cycles:
+          type: integer
+          description: Represents how many billing cycles are left in a ramp interval.
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
     TaxInfo:
       type: object
       title: Tax info
@@ -21998,6 +22108,10 @@ components:
         routing_number_bank:
           type: string
           description: The bank name of this routing number.
+        username:
+          type: string
+          description: Username of the associated payment method. Currently only associated
+            with Venmo.
     Error:
       type: object
       properties:
@@ -22327,6 +22441,16 @@ components:
       - api_only
       - read_only
       - write
+    PricingModelTypeEnum:
+      type: string
+      enum:
+      - fixed
+      - ramp
+      default: fixed
+      description: |
+        A fixed pricing model has the same price for each billing period.
+        A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+        a specified cadence of billing periods. The price change could be an increase or decrease.
     RevenueScheduleTypeEnum:
       type: string
       enum:
@@ -22594,6 +22718,7 @@ components:
       - paypal_billing_agreement
       - roku
       - sepadirectdebit
+      - venmo
       - wire_transfer
       - braintree_v_zero
     CardTypeEnum:


### PR DESCRIPTION
- Adds `pricing_model` property to plan requests and responses (`Plan`, `PlanCreate`), which indicates if the plan is 'fixed' or 'ramp' -priced
- Adds `ramp_intervals` property (`PlanRampInterval`) to plan requests and responses (`Plan`, `PlanCreate`), which defines the pricing schedule of a ramp plan
- Adds `ramp_intervals` property (`SubscriptionRampIntervalResponse`, `SubscriptionRampInterval`) to subscription requests and responses (`Subscription`, `SubscriptionCreate`, `SubscriptionChangeCreate`, `SubscriptionChangePreview`, `SubscriptionPurchase`), which defines the pricing schedule of a ramp subscription
- Adds `username` property to `PaymentMethod`