### PR TITLE
Fixes bug with put_dunning_campaign_bulk_update

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -4035,13 +4035,14 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2021-02-25#operation/put_dunning_campaign_bulk_update put_dunning_campaign_bulk_update api documentation}
     #
+    # @param dunning_campaign_id [String] Dunning Campaign ID, e.g. +e28zov4fw0v2+.
     # @param body [Requests::DunningCampaignsBulkUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::DunningCampaignsBulkUpdate}
     # @param params [Hash] Optional query string parameters:
     #
     # @return [Resources::DunningCampaignsBulkUpdateResponse] A list of updated plans.
     #
-    def put_dunning_campaign_bulk_update(body:, **options)
-      path = "/dunning_campaigns/{dunning_campaign_id}/bulk_update"
+    def put_dunning_campaign_bulk_update(dunning_campaign_id:, body:, **options)
+      path = interpolate_path("/dunning_campaigns/{dunning_campaign_id}/bulk_update", dunning_campaign_id: dunning_campaign_id)
       put(path, body, Requests::DunningCampaignsBulkUpdate, **options)
     end
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14922,6 +14922,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -20774,7 +20776,7 @@ components:
             zero then a `method_id` or `method_code` is required.
         address_id:
           type: string
-          titpe: Shipping address ID
+          title: Shipping address ID
           description: Assign a shipping address from the account's existing shipping
             addresses. If this and address are both present, address will take precedence.
         address:


### PR DESCRIPTION
The `put_dunning_campaign_bulk_update ` method was missing the `dunning_campaign_id` parameter, which is used to construct the request URL.