### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -476,6 +476,21 @@ module Recurly
       post(path, options[:body], Requests::BillingInfoVerify, **options)
     end
 
+    # Verify an account's credit card billing cvv
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/verify_billing_info_cvv verify_billing_info_cvv api documentation}
+    #
+    # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
+    # @param body [Requests::BillingInfoVerifyCVV] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::BillingInfoVerifyCVV}
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Resources::Transaction] Transaction information from verify.
+    #
+    def verify_billing_info_cvv(account_id:, body:, **options)
+      path = interpolate_path("/accounts/{account_id}/billing_info/verify_cvv", account_id: account_id)
+      post(path, body, Requests::BillingInfoVerifyCVV, **options)
+    end
+
     # Get the list of billing information associated with an account
     #
     # {https://developers.recurly.com/api/v2021-02-25#operation/list_billing_infos list_billing_infos api documentation}

--- a/lib/recurly/requests/billing_info_verify_cvv.rb
+++ b/lib/recurly/requests/billing_info_verify_cvv.rb
@@ -1,0 +1,14 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class BillingInfoVerifyCVV < Request
+
+      # @!attribute verification_value
+      #   @return [String] Unique security code for a credit card.
+      define_attribute :verification_value, String
+    end
+  end
+end

--- a/lib/recurly/requests/plan_ramp_interval.rb
+++ b/lib/recurly/requests/plan_ramp_interval.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :currencies, Array, { :item_type => :PlanRampPricing }
 
       # @!attribute starting_billing_cycle
-      #   @return [Integer] Represents the first billing cycle of a ramp.
+      #   @return [Integer] Represents the billing cycle where a ramp interval starts.
       define_attribute :starting_billing_cycle, Integer
     end
   end

--- a/lib/recurly/requests/subscription_ramp_interval.rb
+++ b/lib/recurly/requests/subscription_ramp_interval.rb
@@ -7,7 +7,7 @@ module Recurly
     class SubscriptionRampInterval < Request
 
       # @!attribute starting_billing_cycle
-      #   @return [Integer] Represents how many billing cycles are included in a ramp interval.
+      #   @return [Integer] Represents the billing cycle where a ramp interval starts.
       define_attribute :starting_billing_cycle, Integer
 
       # @!attribute unit_amount

--- a/lib/recurly/resources/plan_ramp_interval.rb
+++ b/lib/recurly/resources/plan_ramp_interval.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :currencies, Array, { :item_type => :PlanRampPricing }
 
       # @!attribute starting_billing_cycle
-      #   @return [Integer] Represents the first billing cycle of a ramp.
+      #   @return [Integer] Represents the billing cycle where a ramp interval starts.
       define_attribute :starting_billing_cycle, Integer
     end
   end

--- a/lib/recurly/resources/subscription_ramp_interval_response.rb
+++ b/lib/recurly/resources/subscription_ramp_interval_response.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :remaining_billing_cycles, Integer
 
       # @!attribute starting_billing_cycle
-      #   @return [Integer] Represents how many billing cycles are included in a ramp interval.
+      #   @return [Integer] Represents the billing cycle where a ramp interval starts.
       define_attribute :starting_billing_cycle, Integer
 
       # @!attribute unit_amount

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -2441,6 +2441,47 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Transaction:
           %v\", transaction)"
+  "/accounts/{account_id}/billing_info/verify_cvv":
+    post:
+      tags:
+      - billing_info
+      operationId: verify_billing_info_cvv
+      summary: Verify an account's credit card billing cvv
+      parameters:
+      - "$ref": "#/components/parameters/account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BillingInfoVerifyCVV"
+      responses:
+        '200':
+          description: Transaction information from verify.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Transaction"
+        '429':
+          description: Over limit error. A credit card can only be checked 3 times
+            in 24 hours.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: Invalid billing information, or error running the verification
+            transaction.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorMayHaveTransaction"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/accounts/{account_id}/billing_infos":
     get:
       tags:
@@ -16942,6 +16983,12 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+    BillingInfoVerifyCVV:
+      type: object
+      properties:
+        verification_value:
+          type: string
+          description: Unique security code for a credit card.
     Coupon:
       type: object
       properties:
@@ -19275,7 +19322,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21239,7 +21286,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21250,7 +21297,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.


### PR DESCRIPTION
- Added `/accounts/{account_id}/billing_info/verify_cvv` route which takes a `verification_value` and returns a `transaction` if the `verification_value` matches the cvv of the credit card on file. A `422` is returned if the `verification_value` does not match the credit card on file and the a `429` is returned if the same credit card is checked more than 3 times in 24 hours.