### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/resources/subscription_ramp_interval_response.rb
+++ b/lib/recurly/resources/subscription_ramp_interval_response.rb
@@ -15,8 +15,8 @@ module Recurly
       define_attribute :starting_billing_cycle, Integer
 
       # @!attribute unit_amount
-      #   @return [Integer] Represents the price for the ramp interval.
-      define_attribute :unit_amount, Integer
+      #   @return [Float] Represents the price for the ramp interval.
+      define_attribute :unit_amount, Float
     end
   end
 end

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21302,7 +21302,9 @@ components:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
         unit_amount:
-          type: integer
+          type: number
+          format: float
+          title: Unit price
           description: Represents the price for the ramp interval.
     TaxInfo:
       type: object


### PR DESCRIPTION
Fixed incorrect type in OpenAPI spec for SubscriptionRampIntervalResponse, `unit_amount` is now `float`