### PR TITLE
Add Webhooks::verify_signature

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -9,6 +9,7 @@ require "recurly/http"
 require "recurly/errors"
 require "recurly/connection_pool"
 require "recurly/client"
+require "recurly/webhooks"
 
 module Recurly
   STRICT_MODE = ENV["RECURLY_STRICT_MODE"] && ENV["RECURLY_STRICT_MODE"].downcase == "true"

--- a/lib/recurly/errors.rb
+++ b/lib/recurly/errors.rb
@@ -48,4 +48,5 @@ module Recurly
 
   require_relative "./errors/api_errors"
   require_relative "./errors/network_errors"
+  require_relative "./errors/webhooks_errors"
 end

--- a/lib/recurly/errors/webhooks_errors.rb
+++ b/lib/recurly/errors/webhooks_errors.rb
@@ -1,0 +1,5 @@
+module Recurly
+  module Errors
+    class SignatureVerificationError < StandardError; end
+  end
+end

--- a/lib/recurly/webhooks.rb
+++ b/lib/recurly/webhooks.rb
@@ -1,0 +1,52 @@
+module Recurly
+  module Webhooks
+    DEFAULT_TOLERANCE = 5 * 60 * 1000
+
+    # Verify webhook signature
+    #
+    # @param header [String] recurly-signature header from request
+    # @param secret [String] Shared secret for notification endpoint
+    # @param body [String] Request POST body
+    # @param tolerance [Integer] Allowed notification time drift in milliseconds
+    # @example
+    #   begin
+    #     Recurly::Webhooks.verify_signature(header,
+    #                                        ENV['WEBHOOKS_KEY'],
+    #                                        request.body)
+    #   rescue Recurly::Errors::SignatureVerificationError => e
+    #     puts e.message
+    #   end
+    #
+    def self.verify_signature(header, secret, body, tolerance: DEFAULT_TOLERANCE)
+      s_timestamp, *signatures = header.split(",")
+      timestamp = Integer(s_timestamp)
+      now = (Time.now.to_f * 1000).to_i
+
+      if (now - timestamp).abs > tolerance
+        raise Recurly::Errors::SignatureVerificationError.new(
+          "Notification (#{Time.at(timestamp / 1000.0)}) is more than #{tolerance / 1000.0}s out of date"
+        )
+      end
+
+      expected = OpenSSL::HMAC.hexdigest("sha256", secret, "#{timestamp}.#{body}")
+
+      unless signatures.any? { |s| secure_compare(expected, s) }
+        raise Recurly::Errors::SignatureVerificationError.new(
+          "No matching signatures found for payload"
+        )
+      end
+    end
+
+    # https://github.com/rack/rack/blob/2-2-stable/lib/rack/utils.rb#L374
+    # https://github.com/heartcombo/devise/blob/4-1-stable/lib/devise.rb#L477
+    def self.secure_compare(a, b)
+      return false if a.bytesize != b.bytesize
+      l = a.unpack("C#{a.bytesize}")
+
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
+    end
+    private_class_method :secure_compare
+  end
+end

--- a/spec/recurly/webhooks_spec.rb
+++ b/spec/recurly/webhooks_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+RSpec.describe Recurly::Webhooks do
+  describe "verify_signature" do
+    let(:secret) { "354fab5bd35f5a0d50845ee7e30165244468b13c2c343f104e4e730a59326d9d" }
+    let(:body) { '{"id":"rjxwmwedwqug","object_type":"account","site_id":"qc326l1hl8k9","event_type":"created","event_time":"2022-09-13T21:18:40Z","account_code":"adfas23zzz14123"}' }
+    let(:timestamp) { (Time.now.to_f * 1000).to_i }
+    let(:signature) { OpenSSL::HMAC.hexdigest("sha256", secret, "#{timestamp}.#{body}") }
+    let(:header) { "#{timestamp},#{signature}" }
+
+    context "with current notification" do
+      it "raises no error" do
+        expect { Recurly::Webhooks.verify_signature(header, secret, body) }.
+          not_to raise_error
+      end
+
+      it "raises error if secrets mismatched" do
+        expect { Recurly::Webhooks.verify_signature(header, "key", body) }.
+          to raise_error(Recurly::Errors::SignatureVerificationError, /matching signature/)
+      end
+
+      it "raises error if payload body is altered" do
+        expect { Recurly::Webhooks.verify_signature(header, secret, "{}") }.
+          to raise_error(Recurly::Errors::SignatureVerificationError, /matching signature/)
+      end
+
+      it "raises error if header timestamp is altered" do
+        altered_ts = ((Time.now + 1).to_f * 1000).to_i
+
+        expect { Recurly::Webhooks.verify_signature("#{altered_ts},#{signature}", secret, body) }.
+          to raise_error(Recurly::Errors::SignatureVerificationError, /matching signature/)
+      end
+    end
+
+    context "with notification older than five minutes" do
+      let(:header) { "1663103925004,ad24699f3beaa24c9af2cc7ada3ce4c835da0090194241b9d3add83d27f14bc3" }
+
+      it "raises by default" do
+        expect { Recurly::Webhooks.verify_signature(header, secret, body) }.
+          to raise_error(Recurly::Errors::SignatureVerificationError, /out of date/)
+      end
+
+      it "raises no error when tolerance is large enough" do
+        expect { Recurly::Webhooks.verify_signature(header, secret, body, tolerance: Float::INFINITY) }.
+          not_to raise_error
+      end
+    end
+
+    context "with multiple signatures in header" do
+      let(:header) { "#{timestamp},de1ec7ab1e,#{signature}" }
+
+      it "raises no error" do
+        expect { Recurly::Webhooks.verify_signature(header, secret, body) }.
+          not_to raise_error
+      end
+    end
+
+    context "malformed timestamp header" do
+      let(:header) { "abc,#{signature}" }
+
+      it "raises" do
+        expect { Recurly::Webhooks.verify_signature(header, secret, body) }.
+          to raise_error(ArgumentError)
+      end
+    end
+
+    context "no signatures in header" do
+      let(:header) { "#{timestamp}," }
+
+      it "raises" do
+        expect { Recurly::Webhooks.verify_signature(header, secret, body) }.
+          to raise_error(Recurly::Errors::SignatureVerificationError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new `Webhooks` helper module to ease verifying signed webhook requests.

### Example
```ruby
# Extracted from recurly-signature header
header = '1659641851,a8c8524a0cdd99e36b55d9fdf6c8aed2c2315dfa1a36c4961f65986ee6cf6ae9'

begin
  Recurly::Webhooks.verify_signature(header, ENV['WEBHOOKS_KEY'], request.body)
rescue Recurly::Errors::SignatureVerificationError => e
  puts e.message
end
```