### PR TITLE
Generated Latest Changes for v2019-10-10(Decimal Usage and Quantities)

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -3841,12 +3841,13 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2019-10-10#operation/put_dunning_campaign_bulk_update put_dunning_campaign_bulk_update api documentation}
     #
+    # @param dunning_campaign_id [String] Dunning Campaign ID, e.g. +e28zov4fw0v2+.
     # @param body [Requests::DunningCampaignsBulkUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::DunningCampaignsBulkUpdate}
     #
     # @return [Resources::DunningCampaignsBulkUpdateResponse] A list of updated plans.
     #
-    def put_dunning_campaign_bulk_update(body:)
-      path = "/dunning_campaigns/{dunning_campaign_id}/bulk_update"
+    def put_dunning_campaign_bulk_update(dunning_campaign_id:, body:)
+      path = interpolate_path("/dunning_campaigns/{dunning_campaign_id}/bulk_update", dunning_campaign_id: dunning_campaign_id)
       put(path, body, Requests::DunningCampaignsBulkUpdate)
     end
   end

--- a/lib/recurly/requests/line_item_refund.rb
+++ b/lib/recurly/requests/line_item_refund.rb
@@ -17,6 +17,10 @@ module Recurly
       # @!attribute quantity
       #   @return [Integer] Line item quantity to be refunded.
       define_attribute :quantity, Integer
+
+      # @!attribute quantity_decimal
+      #   @return [String] A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+      define_attribute :quantity_decimal, String
     end
   end
 end

--- a/lib/recurly/requests/plan_ramp_interval.rb
+++ b/lib/recurly/requests/plan_ramp_interval.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :currencies, Array, { :item_type => :PlanRampPricing }
 
       # @!attribute starting_billing_cycle
-      #   @return [Integer] Represents the first billing cycle of a ramp.
+      #   @return [Integer] Represents the billing cycle where a ramp interval starts.
       define_attribute :starting_billing_cycle, Integer
     end
   end

--- a/lib/recurly/requests/subscription_ramp_interval.rb
+++ b/lib/recurly/requests/subscription_ramp_interval.rb
@@ -7,7 +7,7 @@ module Recurly
     class SubscriptionRampInterval < Request
 
       # @!attribute starting_billing_cycle
-      #   @return [Integer] Represents how many billing cycles are included in a ramp interval.
+      #   @return [Integer] Represents the billing cycle where a ramp interval starts.
       define_attribute :starting_billing_cycle, Integer
 
       # @!attribute unit_amount

--- a/lib/recurly/requests/usage_create.rb
+++ b/lib/recurly/requests/usage_create.rb
@@ -7,7 +7,7 @@ module Recurly
     class UsageCreate < Request
 
       # @!attribute amount
-      #   @return [Float] The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+      #   @return [Float] The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
       define_attribute :amount, Float
 
       # @!attribute merchant_tag

--- a/lib/recurly/resources/line_item.rb
+++ b/lib/recurly/resources/line_item.rb
@@ -130,6 +130,10 @@ module Recurly
       #   @return [Integer] This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
       define_attribute :quantity, Integer
 
+      # @!attribute quantity_decimal
+      #   @return [String] A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+      define_attribute :quantity_decimal, String
+
       # @!attribute refund
       #   @return [Boolean] Refund?
       define_attribute :refund, :Boolean
@@ -137,6 +141,10 @@ module Recurly
       # @!attribute refunded_quantity
       #   @return [Integer] For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
       define_attribute :refunded_quantity, Integer
+
+      # @!attribute refunded_quantity_decimal
+      #   @return [String] A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
+      define_attribute :refunded_quantity_decimal, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type

--- a/lib/recurly/resources/plan_ramp_interval.rb
+++ b/lib/recurly/resources/plan_ramp_interval.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :currencies, Array, { :item_type => :PlanRampPricing }
 
       # @!attribute starting_billing_cycle
-      #   @return [Integer] Represents the first billing cycle of a ramp.
+      #   @return [Integer] Represents the billing cycle where a ramp interval starts.
       define_attribute :starting_billing_cycle, Integer
     end
   end

--- a/lib/recurly/resources/subscription_ramp_interval_response.rb
+++ b/lib/recurly/resources/subscription_ramp_interval_response.rb
@@ -11,7 +11,7 @@ module Recurly
       define_attribute :remaining_billing_cycles, Integer
 
       # @!attribute starting_billing_cycle
-      #   @return [Integer] Represents how many billing cycles are included in a ramp interval.
+      #   @return [Integer] Represents the billing cycle where a ramp interval starts.
       define_attribute :starting_billing_cycle, Integer
 
       # @!attribute unit_amount

--- a/lib/recurly/resources/usage.rb
+++ b/lib/recurly/resources/usage.rb
@@ -7,7 +7,7 @@ module Recurly
     class Usage < Resource
 
       # @!attribute amount
-      #   @return [Float] The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+      #   @return [Float] The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
       define_attribute :amount, Float
 
       # @!attribute billed_at

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14463,6 +14463,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -18423,6 +18425,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18503,6 +18513,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18544,6 +18561,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -19335,7 +19360,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21093,7 +21118,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21104,7 +21129,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
@@ -21533,10 +21558,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           type: string
           enum:
@@ -21609,10 +21635,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `quantity_decimal` and `refunded_quantity_decimal` properties to `LineItem` class
- Add `quantity_decimal ` property to `LineItemRefund` class.
- Update `Usage` `amount` property description

Fix Bulk Dunning Campaign update
- Update `put_dunning_campaign_bulk_update ` method to receive the `dunning_campaign_id `