### PR TITLE
Generated Latest Changes for v2021-02-25(Decimal Usage and Quantities and DunningEvent new fields)

### DIFF
--- a/lib/recurly/requests/billing_info_create.rb
+++ b/lib/recurly/requests/billing_info_create.rb
@@ -39,7 +39,7 @@ module Recurly
       define_attribute :cvv, String
 
       # @!attribute external_hpp_type
-      #   @return [String] Use for Adyen HPP billing info.
+      #   @return [String] Use for Adyen HPP billing info. This should only be used as part of a pending purchase request, when the billing info is nested inside an account object.
       define_attribute :external_hpp_type, String
 
       # @!attribute first_name
@@ -83,7 +83,7 @@ module Recurly
       define_attribute :number, String
 
       # @!attribute online_banking_payment_type
-      #   @return [String] Use for Online Banking billing info.
+      #   @return [String] Use for Online Banking billing info. This should only be used as part of a pending purchase request, when the billing info is nested inside an account object.
       define_attribute :online_banking_payment_type, String
 
       # @!attribute paypal_billing_agreement_id

--- a/lib/recurly/requests/line_item_refund.rb
+++ b/lib/recurly/requests/line_item_refund.rb
@@ -17,6 +17,10 @@ module Recurly
       # @!attribute quantity
       #   @return [Integer] Line item quantity to be refunded.
       define_attribute :quantity, Integer
+
+      # @!attribute quantity_decimal
+      #   @return [String] A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+      define_attribute :quantity_decimal, String
     end
   end
 end

--- a/lib/recurly/requests/usage_create.rb
+++ b/lib/recurly/requests/usage_create.rb
@@ -7,7 +7,7 @@ module Recurly
     class UsageCreate < Request
 
       # @!attribute amount
-      #   @return [Float] The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+      #   @return [Float] The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
       define_attribute :amount, Float
 
       # @!attribute merchant_tag

--- a/lib/recurly/resources/invoice.rb
+++ b/lib/recurly/resources/invoice.rb
@@ -58,6 +58,14 @@ module Recurly
       #   @return [String] Unique ID to identify the dunning campaign used when dunning the invoice. For sites without multiple dunning campaigns enabled, this will always be the default dunning campaign.
       define_attribute :dunning_campaign_id, String
 
+      # @!attribute dunning_events_sent
+      #   @return [Integer] Number of times the event was sent.
+      define_attribute :dunning_events_sent, Integer
+
+      # @!attribute final_dunning_event
+      #   @return [Boolean] Last communication attempt.
+      define_attribute :final_dunning_event, :Boolean
+
       # @!attribute has_more_line_items
       #   @return [Boolean] Identifies if the invoice has more line items than are returned in `line_items`. If `has_more_line_items` is `true`, then a request needs to be made to the `list_invoice_line_items` endpoint.
       define_attribute :has_more_line_items, :Boolean

--- a/lib/recurly/resources/line_item.rb
+++ b/lib/recurly/resources/line_item.rb
@@ -130,6 +130,10 @@ module Recurly
       #   @return [Integer] This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
       define_attribute :quantity, Integer
 
+      # @!attribute quantity_decimal
+      #   @return [String] A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+      define_attribute :quantity_decimal, String
+
       # @!attribute refund
       #   @return [Boolean] Refund?
       define_attribute :refund, :Boolean
@@ -137,6 +141,10 @@ module Recurly
       # @!attribute refunded_quantity
       #   @return [Integer] For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
       define_attribute :refunded_quantity, Integer
+
+      # @!attribute refunded_quantity_decimal
+      #   @return [String] A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
+      define_attribute :refunded_quantity_decimal, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type

--- a/lib/recurly/resources/usage.rb
+++ b/lib/recurly/resources/usage.rb
@@ -7,7 +7,7 @@ module Recurly
     class Usage < Resource
 
       # @!attribute amount
-      #   @return [Float] The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+      #   @return [Float] The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
       define_attribute :amount, Float
 
       # @!attribute billed_at

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18141,6 +18141,14 @@ components:
           description: Unique ID to identify the dunning campaign used when dunning
             the invoice. For sites without multiple dunning campaigns enabled, this
             will always be the default dunning campaign.
+        dunning_events_sent:
+          type: integer
+          title: Dunning Event Sent
+          description: Number of times the event was sent.
+        final_dunning_event:
+          type: boolean
+          title: Final Dunning Event
+          description: Last communication attempt.
     InvoiceCreate:
       type: object
       properties:
@@ -18622,6 +18630,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18706,6 +18722,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18747,6 +18770,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -21667,10 +21698,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           "$ref": "#/components/schemas/UsageTypeEnum"
         tier_type:
@@ -21741,10 +21773,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time
@@ -23058,12 +23091,16 @@ components:
       - savings
     ExternalHppTypeEnum:
       type: string
-      description: Use for Adyen HPP billing info.
+      description: Use for Adyen HPP billing info. This should only be used as part
+        of a pending purchase request, when the billing info is nested inside an account
+        object.
       enum:
       - adyen
     OnlineBankingPaymentTypeEnum:
       type: string
-      description: Use for Online Banking billing info.
+      description: Use for Online Banking billing info. This should only be used as
+        part of a pending purchase request, when the billing info is nested inside
+        an account object.
       enum:
       - ideal
       - sofort


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `quantity_decimal` and `refunded_quantity_decimal` properties to `LineItem` class
- Add `quantity_decimal ` property to `LineItemRefund` class.
- Update `Usage` `amount` property description

Invoice request format has changed:
- Added `dunning_events_sent` and `final_dunning_event`