### PR TITLE
V2 add support for Apply Credit Balance to existing invoice feature

### DIFF
--- a/lib/recurly/account_balance.rb
+++ b/lib/recurly/account_balance.rb
@@ -12,6 +12,7 @@ module Recurly
       past_due
       balance_in_cents
       processing_prepayment_balance_in_cents
+      available_credit_balance_in_cents
     )
 
     # This object does not represent a model on the server side

--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -177,6 +177,16 @@ module Recurly
       true
     end
 
+    # Applies the open credit balance on the account to the invoice balance.
+    #
+    # @return [true, false] +true+ when successful, +false+ when unable to
+    #   (e.g., the invoice is no longer collectible).
+    def apply_credit_balance
+      return false unless link? :apply_credit_balance
+      reload follow_link :apply_credit_balance
+      true
+    end
+
     # Posts an offline payment on this invoice
     #
     # @return [Transaction]

--- a/spec/fixtures/account_balance/show-200.xml
+++ b/spec/fixtures/account_balance/show-200.xml
@@ -13,4 +13,8 @@ Content-Type: application/xml; charset=utf-8
     <USD type="integer">-3000</USD>
     <EUR type="integer">0</EUR>
   </processing_prepayment_balance_in_cents>
+  <available_credit_balance_in_cents>
+    <USD type="integer">-3000</USD>
+    <EUR type="integer">0</EUR>
+  </available_credit_balance_in_cents>
 </account_balance>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -302,6 +302,9 @@ XML
         processing_prepayment_balance = account_balance.processing_prepayment_balance_in_cents
         processing_prepayment_balance[:USD].must_equal(-3000)
         processing_prepayment_balance[:EUR].must_equal(0)
+        available_credit_balance = account_balance.available_credit_balance_in_cents
+        available_credit_balance[:USD].must_equal(-3000)
+        available_credit_balance[:EUR].must_equal(0)
       end
     end
 

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -234,6 +234,15 @@ describe Invoice do
     end
   end
 
+  describe "#apply_credit_balance" do
+    it "must call /apply_credit_balance" do
+      stub_api_request :get, 'invoices/1000', 'invoices/show-200'
+      stub_api_request :put, 'invoices/created-invoice/apply_credit_balance', 'invoices/show-200-updated'
+      invoice = Invoice.find(1000)
+      invoice.apply_credit_balance
+    end
+  end
+
   describe "#save" do
     it "must update an invoice" do
       stub_api_request :get, 'invoices/1000', 'invoices/show-200'


### PR DESCRIPTION
Add new `available_credit_balance_in_cents` attribute to `AccountBalance`. The `available_credit_balance_in_cents` attribute is a similar format to the `balance_in_cents` attribute and contains the total of open balances for credit invoices in each currency. This value is useful when trying to determine if the customer's account has any available credit that can be applied to an existing collectible invoice on the account.

Add new `apply_credit_balance` method to `Invoice`. This action will be available for collectible charge invoices. If the account has available credit it will be applied to pay down the balance on the invoice.