### PR TITLE
Lock the version of jruby used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }} tests
     strategy:
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, jruby]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.3]
     steps:
       - uses: actions/checkout@v3
       - name: Setup ruby


### PR DESCRIPTION
Lock down jruby to 9.3 in CI tests