### PR TITLE
Add `preferred_time_zone` to Account

### DIFF
--- a/lib/recurly/account.rb
+++ b/lib/recurly/account.rb
@@ -103,6 +103,7 @@ module Recurly
       has_past_due_invoice
       has_paused_subscription
       preferred_locale
+      preferred_time_zone
       transaction_type
       dunning_campaign_id
       invoice_template_uuid

--- a/spec/fixtures/accounts/hierarchy/show-children-200.xml
+++ b/spec/fixtures/accounts/hierarchy/show-children-200.xml
@@ -23,6 +23,7 @@ Content-Type: application/xml; charset=utf-8
     <company_name nil="nil"></company_name>
     <vat_number nil="nil"></vat_number>
     <preferred_locale nil="nil"></preferred_locale>
+    <preferred_time_zone nil="nil"></preferred_time_zone>
     <address>
       <address1 nil="nil"></address1>
       <address2 nil="nil"></address2>

--- a/spec/fixtures/accounts/hierarchy/show-parent-200.xml
+++ b/spec/fixtures/accounts/hierarchy/show-parent-200.xml
@@ -22,6 +22,7 @@ Content-Type: application/xml; charset=utf-8
   <company_name nil="nil"></company_name>
   <vat_number nil="nil"></vat_number>
   <preferred_locale nil="nil"></preferred_locale>
+  <preferred_time_zone nil="nil"></preferred_time_zone>
   <address>
     <address1 nil="nil"></address1>
     <address2 nil="nil"></address2>

--- a/spec/fixtures/accounts/show-200.xml
+++ b/spec/fixtures/accounts/show-200.xml
@@ -46,6 +46,7 @@ Content-Type: application/xml; charset=utf-8
   <has_canceled_subscription type="boolean">false</has_canceled_subscription>
   <has_past_due_invoice type="boolean">false</has_past_due_invoice>
   <preferred_locale>fr-FR</preferred_locale>
+  <preferred_time_zone>America/Los_Angeles</preferred_time_zone>
   <custom_fields type="array">
     <custom_field>
       <name>acct_field</name>

--- a/spec/recurly/account_spec.rb
+++ b/spec/recurly/account_spec.rb
@@ -111,6 +111,7 @@ describe Account do
       account.has_future_subscription.must_equal false
       account.has_past_due_invoice.must_equal false
       account.preferred_locale.must_equal 'fr-FR'
+      account.preferred_time_zone.must_equal 'America/Los_Angeles'
     end
 
     it 'must return an account with tax state' do


### PR DESCRIPTION
Adds `Account#preferred_time_zone` as a string attribute for API version 2.29 which is used to determine the time zone of emails sent on behalf of the merchant to the customer.