### PR TITLE
Added decline code to transaction error

### DIFF
--- a/lib/recurly/transaction/errors.rb
+++ b/lib/recurly/transaction/errors.rb
@@ -48,6 +48,10 @@ module Recurly
         xml.text '/errors/transaction_error/gateway_error_code'
       end
 
+      def decline_code
+        xml.text '/errors/transaction_error/decline_code'
+      end
+
       private
 
       def update_transaction transaction

--- a/spec/fixtures/transaction_error.xml
+++ b/spec/fixtures/transaction_error.xml
@@ -9,6 +9,7 @@ Content-Type: application/xml; charset=utf-8
     <customer_message lang="en-US">Your card number is not valid. Please update your card number.</customer_message>
     <merchant_advice lang="en-US">The credit card number is not valid. The customer needs to try a different number.</merchant_advice>
     <gateway_error_code>123</gateway_error_code>
+    <decline_code>invalid_number</decline_code>
   </transaction_error>
   <error field="transaction.account.billing_info.credit_card_number" symbol="invalid" lang="en-US">is not valid</error>
   <transaction href="https://api.recurly.com/v2/transactions/abcdef1234567890">

--- a/spec/recurly/transaction_spec.rb
+++ b/spec/recurly/transaction_spec.rb
@@ -44,6 +44,7 @@ describe Transaction do
       transaction.account.billing_info.errors[:credit_card_number].wont_be_nil
       error.transaction_error_code.must_equal 'invalid_card_number'
       error.gateway_error_code.must_equal "123"
+      error.decline_code.must_equal 'invalid_number'
       error.transaction.must_equal transaction
       transaction.persisted?.must_equal true
     end


### PR DESCRIPTION
This PR adds decline_code field to the transaction error response. This will be populated when a transactions are declined from the issuer.