### PR TITLE
Added custom fields to adjustments

### DIFF
--- a/lib/recurly/adjustment.rb
+++ b/lib/recurly/adjustment.rb
@@ -26,7 +26,10 @@ module Recurly
     # @return [ShippingAddress, nil]
     has_one :shipping_address, class_name: :ShippingAddress, readonly: false
 
-    define_attribute_methods %w(
+    # @return [[CustomField], []]
+    has_many :custom_fields, class_name: :CustomField, readonly: false
+
+    define_attribute_methods %w[
       uuid
       state
       description
@@ -65,7 +68,7 @@ module Recurly
       avalara_transaction_type
       avalara_service_type
       refundable_total_in_cents
-    )
+    ]
     alias to_param uuid
 
     # @return ["charge", "credit", nil] The type of adjustment.
@@ -79,6 +82,14 @@ module Recurly
     # @see Resource#initialize
     def initialize(attributes = {})
       super({ :currency => Recurly.default_currency }.merge attributes)
+    end
+
+    def changed_attributes
+      attrs = super
+      if custom_fields.any?(&:changed?)
+        attrs['custom_fields'] = custom_fields.select(&:changed?)
+      end
+      attrs
     end
 
     # Adjustments are only writeable through an {Account} instance.

--- a/spec/fixtures/adjustments/show-200.xml
+++ b/spec/fixtures/adjustments/show-200.xml
@@ -52,4 +52,10 @@ Content-Type: application/xml; charset=utf-8
   <start_date type="datetime">2011-04-30T07:00:00Z</start_date>
   <end_date type="datetime">2011-04-30T07:00:00Z</end_date>
   <created_at type="datetime">2011-08-31T03:30:00Z</created_at>
+  <custom_fields>
+    <custom_field>
+      <name>field1</name>
+      <value>priceless</value>
+    </custom_field>
+  </custom_fields>
 </adjustment>

--- a/spec/recurly/adjustment_spec.rb
+++ b/spec/recurly/adjustment_spec.rb
@@ -52,6 +52,8 @@ describe Adjustment do
 
       stub_api_request(:get, 'adjustments/abcdef1234567890', 'adjustments/show-200')
       adjustment.credit_adjustments.must_be_instance_of Resource::Pager
+      adjustment.custom_fields.first.name.must_equal 'field1'
+      adjustment.custom_fields.first.value.must_equal 'priceless'
     end
 
     it 'must return tax info when the site has it enabled' do

--- a/spec/recurly/purchase_spec.rb
+++ b/spec/recurly/purchase_spec.rb
@@ -10,7 +10,13 @@ describe Purchase do
         {
           product_code: 'product_code',
           unit_amount_in_cents: 1_000,
-          quantity: 1
+          quantity: 1,
+          custom_fields: [
+            {
+              name: 'field1',
+              value: 'priceless'
+            }
+          ]
         }
       ],
       subscriptions: [
@@ -81,6 +87,13 @@ describe Purchase do
     it 'should raise a Transaction::Error error when transaction fails' do
       stub_api_request(:post, 'purchases', 'purchases/invoice-declined-422')
       proc { Purchase.invoice!(purchase) }.must_raise Transaction::DeclinedError
+    end
+
+    it 'should return custom fields for an adjustment on a purchase that has custom fields' do
+      stub_api_request(:post, 'purchases', 'purchases/invoice-422')
+
+      purchase.adjustments.first.custom_fields.first.name.must_equal 'field1'
+      purchase.adjustments.first.custom_fields.first.value.must_equal 'priceless'
     end
   end
 


### PR DESCRIPTION
Custom fields are now supported on adjustments!

Usage:

```
Recurly::Purchase.new({
    currency: 'USD',
    collection_method: :manual,
    account: {
      account_code: account_code
    },
    adjustments: [
      {
        unit_amount_in_cents: 50_00,
        custom_fields: [
          {
            name: 'field1',
            value: 'priceless'
          }
        ]
      }
    ],
  }.merge(attributes))
```

