### PR TITLE
Update client library to support `CustomFieldDefinition`

### DIFF
--- a/lib/recurly.rb
+++ b/lib/recurly.rb
@@ -56,6 +56,7 @@ module Recurly
   require 'recurly/percentage_tier'
   require 'recurly/currency_percentage_tier'
   require 'recurly/sub_add_on_percentage_tier'
+  require 'recurly/custom_field_definition'
 
   @subdomain = nil
 

--- a/lib/recurly/custom_field_definition.rb
+++ b/lib/recurly/custom_field_definition.rb
@@ -1,0 +1,14 @@
+module Recurly
+  class CustomFieldDefinition < Resource
+    define_attribute_methods %w(
+      id
+      related_type
+      name
+      user_access
+      display_name
+      tooltip
+      created_at
+      updated_at
+    )
+  end
+end

--- a/spec/fixtures/custom_field_definition/index-200-filtered.xml
+++ b/spec/fixtures/custom_field_definition/index-200-filtered.xml
@@ -1,0 +1,28 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<custom_field_definitions type="array">
+    <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3725082729815285135">
+        <id>3725082729815285135</id>
+        <related_type>plan</related_type>
+        <name>size</name>
+        <user_access>writable</user_access>
+        <display_name>SIZE</display_name>
+        <tooltip></tooltip>
+        <created_at type="datetime">2023-01-27T15:14:25Z</created_at>
+        <updated_at type="datetime">2023-01-27T15:14:25Z</updated_at>
+        <deleted_at nil="nil"></deleted_at>
+    </custom_field_definition>
+    <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3725071998026640908">
+        <id>3725071998026640908</id>
+        <related_type>plan</related_type>
+        <name>color</name>
+        <user_access>writable</user_access>
+        <display_name>COLOR</display_name>
+        <tooltip></tooltip>
+        <created_at type="datetime">2023-01-27T14:53:06Z</created_at>
+        <updated_at type="datetime">2023-01-27T14:53:06Z</updated_at>
+        <deleted_at nil="nil"></deleted_at>
+    </custom_field_definition>
+</custom_field_definitions>

--- a/spec/fixtures/custom_field_definition/index-200.xml
+++ b/spec/fixtures/custom_field_definition/index-200.xml
@@ -1,0 +1,28 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<custom_field_definitions type="array">
+    <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3725082729815285135">
+        <id>3725082729815285135</id>
+        <related_type>item</related_type>
+        <name>size</name>
+        <user_access>writable</user_access>
+        <display_name>SIZE</display_name>
+        <tooltip></tooltip>
+        <created_at type="datetime">2023-01-27T15:14:25Z</created_at>
+        <updated_at type="datetime">2023-01-27T15:14:25Z</updated_at>
+        <deleted_at nil="nil"></deleted_at>
+    </custom_field_definition>
+    <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3725071998026640908">
+        <id>3725071998026640908</id>
+        <related_type>plan</related_type>
+        <name>color</name>
+        <user_access>writable</user_access>
+        <display_name>COLOR</display_name>
+        <tooltip></tooltip>
+        <created_at type="datetime">2023-01-27T14:53:06Z</created_at>
+        <updated_at type="datetime">2023-01-27T14:53:06Z</updated_at>
+        <deleted_at nil="nil"></deleted_at>
+    </custom_field_definition>
+</custom_field_definitions>

--- a/spec/fixtures/custom_field_definition/show-200.xml
+++ b/spec/fixtures/custom_field_definition/show-200.xml
@@ -1,0 +1,15 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3722298505492673710">
+  <id>3722298505492673710</id>
+  <related_type>plan</related_type>
+  <name>package</name>
+  <user_access>writable</user_access>
+  <display_name>Package</display_name>
+  <tooltip>Value can be 'Basic' or 'Premium'</tooltip>
+  <created_at type="datetime">2023-01-23T19:02:40Z</created_at>
+  <updated_at type="datetime">2023-01-23T19:02:47Z</updated_at>
+  <deleted_at nil="nil"></deleted_at>
+</custom_field_definition>

--- a/spec/recurly/custom_field_definition_spec.rb
+++ b/spec/recurly/custom_field_definition_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe CustomFieldDefinition do
+  describe ".find" do
+    before do
+      stub_api_request(
+        :get, "custom_field_definitions/3722298505492673710", "custom_field_definition/show-200"
+      )
+    end
+
+    it "returns a custom field definition" do
+      definition = CustomFieldDefinition.find("3722298505492673710")
+
+      definition.must_be_instance_of(CustomFieldDefinition)
+      definition.id.must_equal("3722298505492673710")
+      definition.related_type.must_equal("plan")
+      definition.name.must_equal("package")
+      definition.user_access.must_equal("writable")
+      definition.display_name.must_equal("Package")
+      definition.tooltip.must_equal("Value can be 'Basic' or 'Premium'")
+      definition.created_at.must_equal(DateTime.new(2023, 1, 23, 19, 2, 40))
+      definition.updated_at.must_equal(DateTime.new(2023, 1, 23, 19, 2, 47))
+    end
+  end
+
+  describe ".all" do
+    before do
+      stub_api_request(
+        :get, "custom_field_definitions", "custom_field_definition/index-200"
+      )
+    end
+
+    it "returns a list of custom field definitions" do
+      definitions = CustomFieldDefinition.all
+
+      definitions.must_be_instance_of(Array)
+      definitions.count.must_equal(2)
+      definitions.first.related_type.must_equal("item")
+      definitions.last.related_type.must_equal("plan")
+    end
+  end
+
+  describe "when the request is filtered by 'related_type'" do
+    before do
+      stub_api_request(
+        :get, "custom_field_definitions?related_type=plan", "custom_field_definition/index-200-filtered"
+      )
+    end
+
+    it "returns a list of the filtered results" do
+      definitions = CustomFieldDefinition.all(related_type: "plan")
+
+      definitions.must_be_instance_of(Array)
+      definitions.count.must_equal(2)
+      definitions.first.related_type.must_equal("plan")
+      definitions.last.related_type.must_equal("plan")
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to:
* Adds `CustomFieldDefinition` model
* Adds `GET v2/custom_field_definitions` endpoint to this client library
* Adds `GET v2/custom_field_definitions/:custom_field_definition_id` endpoint to this client library
* Adds `GET v2/custom_field_definitions?related_type=plan` endpoint to this client library

Sample code request for the listing:
```ruby
Recurly::CustomFieldDefinition.find_each do |definition|
  puts "Custom Field Definition: #{definition}"
end
```

Sample code request for the getting:
```ruby
definition = Recurly::CustomFieldDefinition.find(<DEFINITION_ID>)
puts "Custom Field Definition: ", definition
```

Sample code request for the filtered listing:
```ruby
Recurly::CustomFieldDefinition.all(related_type: <RELATED_TYPE>).each do |definition|
   puts "Custom Field Definition: #{definition}"
end
```