### PR TITLE
Update client library to support custom fields

### DIFF
--- a/lib/recurly/plan.rb
+++ b/lib/recurly/plan.rb
@@ -10,6 +10,9 @@ module Recurly
     # @return [[PlanRampInterval], nil]
     has_many :ramp_intervals, class_name: :PlanRampInterval
 
+    # @return [[CustomField], []]
+    has_many :custom_fields, class_name: :CustomField, readonly: false
+
     define_attribute_methods %w(
       plan_code
       name
@@ -44,6 +47,7 @@ module Recurly
       avalara_transaction_type
       avalara_service_type
       dunning_campaign_id
+      custom_fields
       created_at
       updated_at
     )

--- a/spec/fixtures/plans/show-200.xml
+++ b/spec/fixtures/plans/show-200.xml
@@ -32,4 +32,10 @@ Content-Type: application/xml; charset=utf-8
   <setup_fee_in_cents>
     <USD type="integer">0</USD>
   </setup_fee_in_cents>
+  <custom_fields type="array">
+    <custom_field>
+      <name>color</name>
+      <value>Red</value>
+    </custom_field>
+  </custom_fields>
 </plan>

--- a/spec/recurly/plan_spec.rb
+++ b/spec/recurly/plan_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe Plan do
   let(:plan) {
     Plan.new(
-      :plan_code                 => "gold",
-      :name                      => "The Gold Plan",
+      :plan_code                 => 'gold',
+      :name                      => 'The Gold Plan',
       :unit_amount_in_cents      => 79_00,
-      :description               => "The Gold Plan is for folks who love gold.",
-      :accounting_code           => "gold_plan_acc_code",
-      :setup_fee_accounting_code => "setup_fee_ac",
+      :description               => 'The Gold Plan is for folks who love gold.',
+      :accounting_code           => 'gold_plan_acc_code',
+      :setup_fee_accounting_code => 'setup_fee_ac',
       :setup_fee_in_cents        => 60_00,
       :plan_interval_length      => 1,
       :plan_interval_unit        => 'months',
@@ -17,37 +17,89 @@ describe Plan do
       :revenue_schedule_type     => 'evenly',
       :avalara_transaction_type  => 600,
       :avalara_service_type      => 3,
+      :custom_fields             => [{ :name => 'color', value: 'Red' }]
     )
   }
 
   describe 'when pricing_model is fixed' do
+    let(:expected_xml) do
+      <<~XML.gsub('  ', '').chomp
+        <plan>\
+          <accounting_code>gold_plan_acc_code</accounting_code>\
+          <avalara_service_type>3</avalara_service_type>\
+          <avalara_transaction_type>600</avalara_transaction_type>\
+          <custom_fields>\
+            <custom_field>\
+              <name>color</name>\
+              <value>Red</value>\
+            </custom_field>\
+          </custom_fields>\
+          <description>The Gold Plan is for folks who love gold.</description>\
+          <name>The Gold Plan</name>\
+          <plan_code>gold</plan_code>\
+          <plan_interval_length>1</plan_interval_length>\
+          <plan_interval_unit>months</plan_interval_unit>\
+          <pricing_model>fixed</pricing_model>\
+          <revenue_schedule_type>evenly</revenue_schedule_type>\
+          <setup_fee_accounting_code>setup_fee_ac</setup_fee_accounting_code>\
+          <setup_fee_in_cents>\
+            <USD>6000</USD>\
+          </setup_fee_in_cents>\
+          <tax_exempt>false</tax_exempt>\
+          <unit_amount_in_cents>\
+            <USD>7900</USD>\
+          </unit_amount_in_cents>\
+        </plan>
+      XML
+    end
     it 'must serialize' do
-      plan.to_xml.must_equal <<XML.chomp
-<plan>\
-<accounting_code>gold_plan_acc_code</accounting_code>\
-<avalara_service_type>3</avalara_service_type>\
-<avalara_transaction_type>600</avalara_transaction_type>\
-<description>The Gold Plan is for folks who love gold.</description>\
-<name>The Gold Plan</name>\
-<plan_code>gold</plan_code>\
-<plan_interval_length>1</plan_interval_length>\
-<plan_interval_unit>months</plan_interval_unit>\
-<pricing_model>fixed</pricing_model>\
-<revenue_schedule_type>evenly</revenue_schedule_type>\
-<setup_fee_accounting_code>setup_fee_ac</setup_fee_accounting_code>\
-<setup_fee_in_cents>\
-<USD>6000</USD>\
-</setup_fee_in_cents>\
-<tax_exempt>false</tax_exempt>\
-<unit_amount_in_cents>\
-<USD>7900</USD>\
-</unit_amount_in_cents>\
-</plan>
-XML
+      plan.to_xml.must_equal expected_xml
     end
   end
 
   describe 'when pricing_model is ramp' do
+    let(:expected_xml) do
+      <<~XML.gsub('  ', '').chomp
+        <plan>\
+          <accounting_code>gold_plan_acc_code</accounting_code>\
+          <avalara_service_type>3</avalara_service_type>\
+          <avalara_transaction_type>600</avalara_transaction_type>\
+          <custom_fields>\
+            <custom_field>\
+              <name>color</name>\
+              <value>Red</value>\
+            </custom_field>\
+          </custom_fields>\
+          <description>The Gold Plan is for folks who love gold.</description>\
+          <name>The Gold Plan</name>\
+          <plan_code>gold</plan_code>\
+          <plan_interval_length>1</plan_interval_length>\
+          <plan_interval_unit>months</plan_interval_unit>\
+          <pricing_model>ramp</pricing_model>\
+          <ramp_intervals>\
+            <ramp_interval>\
+              <starting_billing_cycle>1</starting_billing_cycle>\
+              <unit_amount_in_cents>\
+                <USD>1000</USD>\
+              </unit_amount_in_cents>\
+            </ramp_interval>\
+            <ramp_interval>\
+              <starting_billing_cycle>2</starting_billing_cycle>\
+              <unit_amount_in_cents>\
+                <USD>2000</USD>\
+              </unit_amount_in_cents>\
+            </ramp_interval>\
+          </ramp_intervals>\
+          <revenue_schedule_type>evenly</revenue_schedule_type>\
+          <setup_fee_accounting_code>setup_fee_ac</setup_fee_accounting_code>\
+          <setup_fee_in_cents>\
+            <USD>6000</USD>\
+          </setup_fee_in_cents>\
+          <tax_exempt>false</tax_exempt>\
+        </plan>
+      XML
+    end
+
     before do
       plan.pricing_model = 'ramp'
       plan.unit_amount_in_cents = nil
@@ -68,53 +120,43 @@ XML
     end
 
     it 'must serialize' do
-      plan.to_xml.must_equal <<XML.chomp
-<plan>\
-<accounting_code>gold_plan_acc_code</accounting_code>\
-<avalara_service_type>3</avalara_service_type>\
-<avalara_transaction_type>600</avalara_transaction_type>\
-<description>The Gold Plan is for folks who love gold.</description>\
-<name>The Gold Plan</name>\
-<plan_code>gold</plan_code>\
-<plan_interval_length>1</plan_interval_length>\
-<plan_interval_unit>months</plan_interval_unit>\
-<pricing_model>ramp</pricing_model>\
-<ramp_intervals>\
-<ramp_interval><starting_billing_cycle>1</starting_billing_cycle><unit_amount_in_cents><USD>1000</USD></unit_amount_in_cents></ramp_interval>\
-<ramp_interval><starting_billing_cycle>2</starting_billing_cycle><unit_amount_in_cents><USD>2000</USD></unit_amount_in_cents></ramp_interval>\
-</ramp_intervals>\
-<revenue_schedule_type>evenly</revenue_schedule_type>\
-<setup_fee_accounting_code>setup_fee_ac</setup_fee_accounting_code>\
-<setup_fee_in_cents>\
-<USD>6000</USD>\
-</setup_fee_in_cents>\
-<tax_exempt>false</tax_exempt>\
-</plan>
-XML
+      plan.to_xml.must_equal expected_xml
     end
   end
 
-  describe ".find" do
-    it "must return a plan when available" do
-      stub_api_request(
-        :get, 'plans/gold', 'plans/show-200'
-      )
+  describe '.find' do
+    before do
+      stub_api_request(:get, 'plans/gold', 'plans/show-200')
+    end
+
+    it 'returns a plan when available' do
       plan = Plan.find 'gold'
+
       plan.must_be_instance_of Plan
+      plan.plan_code.must_equal('gold')
+    end
+
+    it 'returns plan with the custom fields' do
+      plan = Plan.find 'gold'
+
+      plan.custom_fields[0].name.must_equal('color')
+      plan.custom_fields[0].value.must_equal('Red')
     end
   end
 
-  describe ".save!" do
-    it "must raise an Invalid error when currency is not enabled on the site" do
+  describe '.save!' do
+    before do
       stub_api_request :get, 'plans/gold', 'plans/show-200'
       stub_api_request :put, 'plans/gold', 'plans/show-422'
+    end
 
+    it 'must raise an Invalid error when currency is not enabled on the site' do
       plan = Plan.find 'gold'
       plan.unit_amount_in_cents['BRL'] = 329_00
       proc{plan.save!}.must_raise Resource::Invalid
 
-      plan.errors['unit_amount_in_cents'].must_equal ["is invalid"]
-      plan.errors['setup_fee_in_cents'].must_equal ["is invalid"]
+      plan.errors['unit_amount_in_cents'].must_equal ['is invalid']
+      plan.errors['setup_fee_in_cents'].must_equal ['is invalid']
     end
   end
 end


### PR DESCRIPTION
This PR aims to add custom fields to `Plan`.

Sample code request for the listing:
```ruby
Recurly::Plan.find_each do |plan|
  puts "Plan: #{plan.inspect}"
end
```

Sample code request for the getting:
```ruby
plan = Recurly::Plan.find(<PLAN_CODE>)
puts "Plan: ", plan
```