### PR TITLE
Add used_tax_service to Invoice response

### DIFF
--- a/lib/recurly/invoice.rb
+++ b/lib/recurly/invoice.rb
@@ -117,6 +117,7 @@ module Recurly
       billing_info_uuid
       dunning_campaign_id
       refundable_total_in_cents
+      used_tax_service
     )
     alias to_param invoice_number_with_prefix
 

--- a/spec/fixtures/invoices/show-200-taxed.xml
+++ b/spec/fixtures/invoices/show-200-taxed.xml
@@ -60,6 +60,7 @@ Content-Type: application/xml; charset=utf-8
       <tax_in_cents type="integer">20</tax_in_cents>
     </tax_detail>
   </tax_details>
+  <used_tax_service type="boolean">true</used_tax_service>
   <!-- /Vertex -->
   <line_items>
     <adjustment href="https://api.recurly.com/v2/adjustments/charge" type="charge">

--- a/spec/recurly/invoice_spec.rb
+++ b/spec/recurly/invoice_spec.rb
@@ -64,6 +64,10 @@ describe Invoice do
         invoice.tax_type.must_equal 'usst'
       end
 
+      it 'used_tax_service is true' do
+        invoice.used_tax_service.must_equal true
+      end
+
       it 'has a vertex fields' do
         invoice.refund_tax_date.must_equal DateTime.new(2017, 04, 30)
         invoice.refund_geo_code.must_equal 'ABC123'


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `<used_tax_service>`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.