### PR TITLE
Generated Latest Changes for v2021-02-25 (used_tax_service on Invoice)

### DIFF
--- a/lib/recurly/resources/invoice.rb
+++ b/lib/recurly/resources/invoice.rb
@@ -154,6 +154,10 @@ module Recurly
       #   @return [DateTime] Last updated at
       define_attribute :updated_at, DateTime
 
+      # @!attribute used_tax_service
+      #   @return [Boolean] Will be `true` when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
+      define_attribute :used_tax_service, :Boolean
+
       # @!attribute uuid
       #   @return [String] Invoice UUID
       define_attribute :uuid, String

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19032,6 +19032,13 @@ components:
           description: The outstanding balance remaining on this invoice.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        used_tax_service:
+          type: boolean
+          title: Used Tax Service?
+          description: Will be `true` when the invoice had a successful response from
+            the tax service and `false` when the invoice was not sent to tax service
+            due to a lack of address or enabled jurisdiction or was processed without
+            tax due to a non-blocking error returned from the tax service.
         vat_number:
           type: string
           title: VAT number
@@ -24043,7 +24050,9 @@ components:
       - es-MX
       - es-US
       - fi-FI
+      - fr-BE
       - fr-CA
+      - fr-CH
       - fr-FR
       - hi-IN
       - it-IT


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `used_tax_service`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.