### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/resources/tax_detail.rb
+++ b/lib/recurly/resources/tax_detail.rb
@@ -6,12 +6,24 @@ module Recurly
   module Resources
     class TaxDetail < Resource
 
+      # @!attribute billable
+      #   @return [Boolean] Whether or not the line item is taxable. Only populated for a single LineItem fetch when Avalara for Communications is enabled.
+      define_attribute :billable, :Boolean
+
+      # @!attribute level
+      #   @return [String] Provides the jurisdiction level for the Communications tax applied. Example values include city, state and federal. Present only when Avalara for Communications is enabled.
+      define_attribute :level, String
+
+      # @!attribute name
+      #   @return [String] Provides the name of the Communications tax applied. Present only when Avalara for Communications is enabled.
+      define_attribute :name, String
+
       # @!attribute rate
       #   @return [Float] Provides the tax rate for the region.
       define_attribute :rate, Float
 
       # @!attribute region
-      #   @return [String] Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code.
+      #   @return [String] Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code. Not present when Avalara for Communications is enabled.
       define_attribute :region, String
 
       # @!attribute tax
@@ -19,7 +31,7 @@ module Recurly
       define_attribute :tax, Float
 
       # @!attribute type
-      #   @return [String] Provides the tax type for the region. For Canadian Sales Tax, this will be GST, HST, QST or PST.
+      #   @return [String] Provides the tax type for the region or type of Comminications tax when Avalara for Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
       define_attribute :type, String
     end
   end

--- a/lib/recurly/resources/tax_info.rb
+++ b/lib/recurly/resources/tax_info.rb
@@ -7,19 +7,19 @@ module Recurly
     class TaxInfo < Resource
 
       # @!attribute rate
-      #   @return [Float] Rate
+      #   @return [Float] The combined tax rate. Not present when Avalara for Communications is enabled.
       define_attribute :rate, Float
 
       # @!attribute region
-      #   @return [String] Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST.
+      #   @return [String] Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST. Not present when Avalara for Communications is enabled.
       define_attribute :region, String
 
       # @!attribute tax_details
-      #   @return [Array[TaxDetail]] Provides additional tax details for Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItem.
+      #   @return [Array[TaxDetail]] Provides additional tax details for Communications taxes when Avalara for Communications is enabled or Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItemList. Only populated for a single LineItem fetch when Avalara for Communications is enabled.
       define_attribute :tax_details, Array, { :item_type => :TaxDetail }
 
       # @!attribute type
-      #   @return [String] Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.
+      #   @return [String] Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries. Not present when Avalara for Communications is enabled.
       define_attribute :type, String
     end
   end

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -22347,23 +22347,29 @@ components:
           description: Provides the tax type as "vat" for EU VAT, "usst" for U.S.
             Sales Tax, or the 2 letter country code for country level tax types like
             Canada, Australia, New Zealand, Israel, and all non-EU European countries.
+            Not present when Avalara for Communications is enabled.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For U.S. Sales
             Tax, this will be the 2 letter state code. For EU VAT this will be the
             2 letter country code. For all country level tax types, this will display
-            the regional tax, like VAT, GST, or PST.
+            the regional tax, like VAT, GST, or PST. Not present when Avalara for
+            Communications is enabled.
         rate:
           type: number
           format: float
           title: Rate
+          description: The combined tax rate. Not present when Avalara for Communications
+            is enabled.
         tax_details:
           type: array
-          description: Provides additional tax details for Canadian Sales Tax when
-            there is tax applied at both the country and province levels. This will
-            only be populated for the Invoice response when fetching a single invoice
-            and not for the InvoiceList or LineItem.
+          description: Provides additional tax details for Communications taxes when
+            Avalara for Communications is enabled or Canadian Sales Tax when there
+            is tax applied at both the country and province levels. This will only
+            be populated for the Invoice response when fetching a single invoice and
+            not for the InvoiceList or LineItemList. Only populated for a single LineItem
+            fetch when Avalara for Communications is enabled.
           items:
             "$ref": "#/components/schemas/TaxDetail"
     TaxDetail:
@@ -22373,13 +22379,15 @@ components:
         type:
           type: string
           title: Type
-          description: Provides the tax type for the region. For Canadian Sales Tax,
+          description: Provides the tax type for the region or type of Comminications
+            tax when Avalara for Communications is enabled. For Canadian Sales Tax,
             this will be GST, HST, QST or PST.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For Canadian
             Sales Tax, this will be either the 2 letter province code or country code.
+            Not present when Avalara for Communications is enabled.
         rate:
           type: number
           format: float
@@ -22390,6 +22398,22 @@ components:
           format: float
           title: Tax
           description: The total tax applied for this tax type.
+        name:
+          type: string
+          title: Name
+          description: Provides the name of the Communications tax applied. Present
+            only when Avalara for Communications is enabled.
+        level:
+          type: string
+          title: Level
+          description: Provides the jurisdiction level for the Communications tax
+            applied. Example values include city, state and federal. Present only
+            when Avalara for Communications is enabled.
+        billable:
+          type: boolean
+          title: Billable
+          description: Whether or not the line item is taxable. Only populated for
+            a single LineItem fetch when Avalara for Communications is enabled.
     Transaction:
       type: object
       properties:


### PR DESCRIPTION
LineItem response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`
  * `billable`

Invoice response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`