### PR TITLE
Generated Latest Changes for v2021-02-25 (gateway_attributes on PaymentMethod)

### DIFF
--- a/lib/recurly/requests/billing_info_create.rb
+++ b/lib/recurly/requests/billing_info_create.rb
@@ -54,6 +54,10 @@ module Recurly
       #   @return [String] Fraud Session ID
       define_attribute :fraud_session_id, String
 
+      # @!attribute gateway_attributes
+      #   @return [GatewayAttributes] Additional attributes to send to the gateway.
+      define_attribute :gateway_attributes, :GatewayAttributes
+
       # @!attribute gateway_code
       #   @return [String] An identifier for a specific payment gateway. Must be used in conjunction with `gateway_token`.
       define_attribute :gateway_code, String

--- a/lib/recurly/requests/gateway_attributes.rb
+++ b/lib/recurly/requests/gateway_attributes.rb
@@ -1,0 +1,14 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class GatewayAttributes < Request
+
+      # @!attribute account_reference
+      #   @return [String] Used by Adyen gateways. The Shopper Reference value used when the external token was created. Must be used in conjunction with gateway_token and gateway_code.
+      define_attribute :account_reference, String
+    end
+  end
+end

--- a/lib/recurly/resources/gateway_attributes.rb
+++ b/lib/recurly/resources/gateway_attributes.rb
@@ -1,0 +1,14 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class GatewayAttributes < Resource
+
+      # @!attribute account_reference
+      #   @return [String] Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+      define_attribute :account_reference, String
+    end
+  end
+end

--- a/lib/recurly/resources/payment_method.rb
+++ b/lib/recurly/resources/payment_method.rb
@@ -34,6 +34,10 @@ module Recurly
       #   @return [String] Credit card number's first six digits.
       define_attribute :first_six, String
 
+      # @!attribute gateway_attributes
+      #   @return [GatewayAttributes] Gateway specific attributes associated with this PaymentMethod
+      define_attribute :gateway_attributes, :GatewayAttributes
+
       # @!attribute gateway_code
       #   @return [String] An identifier for a specific payment gateway.
       define_attribute :gateway_code, String

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17853,6 +17853,17 @@ components:
           title: An identifier for a specific payment gateway. Must be used in conjunction
             with `gateway_token`.
           maxLength: 12
+        gateway_attributes:
+          type: object
+          description: Additional attributes to send to the gateway.
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created. Must be used in conjunction with
+                gateway_token and gateway_code.
+              maxLength: 264
         amazon_billing_agreement_id:
           type: string
           title: Amazon billing agreement ID
@@ -23606,6 +23617,16 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+        gateway_attributes:
+          type: object
+          description: Gateway specific attributes associated with this PaymentMethod
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created.
+              maxLength: 264
         billing_agreement_id:
           type: string
           description: Billing Agreement identifier. Only present for Amazon or Paypal


### PR DESCRIPTION
Add new property to `BillingInfoCreate` and `PaymentMethod`

- Added `gateway_attributes` property
- `gateway_attributes` allows an `account_reference` value to be be submitted. This field must be passed in with a `gateway_code` and `gateway_token`
- `gateway_attributes` is returned in response if present