### PR TITLE
Generated Latest Changes for v2021-02-25 (Multiple Business Entities)

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -4470,6 +4470,33 @@ module Recurly
       pager(path, **options)
     end
 
+    # Fetch a business entity
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/get_business_entity get_business_entity api documentation}
+    #
+    # @param business_entity_id [String] Business Entity ID. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-entity1+.
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Resources::BusinessEntity] Business entity details
+    #
+    def get_business_entity(business_entity_id:, **options)
+      path = interpolate_path("/business_entities/{business_entity_id}", business_entity_id: business_entity_id)
+      get(path, **options)
+    end
+
+    # List business entities
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/list_business_entities list_business_entities api documentation}
+    #
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Pager<Resources::BusinessEntity>] List of all business entities on your site.
+    #
+    def list_business_entities(**options)
+      path = "/business_entities"
+      pager(path, **options)
+    end
+
     # List gift cards
     #
     # {https://developers.recurly.com/api/v2021-02-25#operation/list_gift_cards list_gift_cards api documentation}
@@ -4538,6 +4565,50 @@ module Recurly
     def redeem_gift_card(redemption_code:, body:, **options)
       path = interpolate_path("/gift_cards/{redemption_code}/redeem", redemption_code: redemption_code)
       post(path, body, Requests::GiftCardRedeem, **options)
+    end
+
+    # List a business entity's invoices
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/list_business_entity_invoices list_business_entity_invoices api documentation}
+    #
+    # @param business_entity_id [String] Business Entity ID. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-entity1+.
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
+    #
+    #   *Important notes:*
+    #
+    #   * The +ids+ parameter cannot be used with any other ordering or filtering
+    #     parameters (+limit+, +order+, +sort+, +begin_time+, +end_time+, etc)
+    #   * Invalid or unknown IDs will be ignored, so you should check that the
+    #     results correspond to your request.
+    #   * Records are returned in an arbitrary order. Since results are all
+    #     returned at once you can sort the records yourself.
+    #
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #   order. In descending order updated records will move behind the cursor and could
+    #   prevent some records from being returned.
+    #
+    #        :begin_time [DateTime] Inclusively filter by begin_time when +sort=created_at+ or +sort=updated_at+.
+    #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
+    #
+    #        :end_time [DateTime] Inclusively filter by end_time when +sort=created_at+ or +sort=updated_at+.
+    #   *Note:* this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
+    #
+    #        :type [String] Filter by type when:
+    #   - +type=charge+, only charge invoices will be returned.
+    #   - +type=credit+, only credit invoices will be returned.
+    #   - +type=non-legacy+, only charge and credit invoices will be returned.
+    #   - +type=legacy+, only legacy invoices will be returned.
+    #
+    #
+    # @return [Pager<Resources::Invoice>] A list of the business entity's invoices.
+    #
+    def list_business_entity_invoices(business_entity_id:, **options)
+      path = interpolate_path("/business_entities/{business_entity_id}/invoices", business_entity_id: business_entity_id)
+      pager(path, **options)
     end
   end
 end

--- a/lib/recurly/requests/account_create.rb
+++ b/lib/recurly/requests/account_create.rb
@@ -66,6 +66,10 @@ module Recurly
       #   @return [String]
       define_attribute :last_name, String
 
+      # @!attribute override_business_entity_id
+      #   @return [String] Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.
+      define_attribute :override_business_entity_id, String
+
       # @!attribute parent_account_code
       #   @return [String] The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
       define_attribute :parent_account_code, String

--- a/lib/recurly/requests/account_purchase.rb
+++ b/lib/recurly/requests/account_purchase.rb
@@ -66,6 +66,10 @@ module Recurly
       #   @return [String]
       define_attribute :last_name, String
 
+      # @!attribute override_business_entity_id
+      #   @return [String] Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.
+      define_attribute :override_business_entity_id, String
+
       # @!attribute parent_account_code
       #   @return [String] The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
       define_attribute :parent_account_code, String

--- a/lib/recurly/requests/account_update.rb
+++ b/lib/recurly/requests/account_update.rb
@@ -54,6 +54,10 @@ module Recurly
       #   @return [String]
       define_attribute :last_name, String
 
+      # @!attribute override_business_entity_id
+      #   @return [String] Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.
+      define_attribute :override_business_entity_id, String
+
       # @!attribute parent_account_code
       #   @return [String] The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
       define_attribute :parent_account_code, String

--- a/lib/recurly/resources/account.rb
+++ b/lib/recurly/resources/account.rb
@@ -106,6 +106,10 @@ module Recurly
       #   @return [String] Object type
       define_attribute :object, String
 
+      # @!attribute override_business_entity_id
+      #   @return [String] Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.
+      define_attribute :override_business_entity_id, String
+
       # @!attribute parent_account_id
       #   @return [String] The UUID of the parent account associated with this account.
       define_attribute :parent_account_id, String

--- a/lib/recurly/resources/business_entity.rb
+++ b/lib/recurly/resources/business_entity.rb
@@ -1,0 +1,54 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class BusinessEntity < Resource
+
+      # @!attribute code
+      #   @return [String] The entity code of the business entity.
+      define_attribute :code, String
+
+      # @!attribute created_at
+      #   @return [DateTime] Created at
+      define_attribute :created_at, DateTime
+
+      # @!attribute default_registration_number
+      #   @return [String] Registration number for the customer used on the invoice.
+      define_attribute :default_registration_number, String
+
+      # @!attribute default_vat_number
+      #   @return [String] VAT number for the customer used on the invoice.
+      define_attribute :default_vat_number, String
+
+      # @!attribute id
+      #   @return [String] Business entity ID
+      define_attribute :id, String
+
+      # @!attribute invoice_display_address
+      #   @return [Address] Address information for the business entity that will appear on the invoice.
+      define_attribute :invoice_display_address, :Address
+
+      # @!attribute name
+      #   @return [String] This name describes your business entity and will appear on the invoice.
+      define_attribute :name, String
+
+      # @!attribute object
+      #   @return [String] Object type
+      define_attribute :object, String
+
+      # @!attribute subscriber_location_countries
+      #   @return [Array[String]] List of countries for which the business entity will be used.
+      define_attribute :subscriber_location_countries, Array, { :item_type => String }
+
+      # @!attribute tax_address
+      #   @return [Address] Address information for the business entity that will be used for calculating taxes.
+      define_attribute :tax_address, :Address
+
+      # @!attribute updated_at
+      #   @return [DateTime] Last updated at
+      define_attribute :updated_at, DateTime
+    end
+  end
+end

--- a/lib/recurly/resources/invoice.rb
+++ b/lib/recurly/resources/invoice.rb
@@ -22,6 +22,10 @@ module Recurly
       #   @return [String] The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
       define_attribute :billing_info_id, String
 
+      # @!attribute business_entity_id
+      #   @return [String] Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.
+      define_attribute :business_entity_id, String
+
       # @!attribute closed_at
       #   @return [DateTime] Date invoice was marked paid or failed.
       define_attribute :closed_at, DateTime

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -228,6 +228,7 @@ x-tagGroups:
   - custom_field_definition
   - shipping_method
   - dunning_campaigns
+  - business_entities
 tags:
 - name: site
   x-displayName: Site
@@ -374,6 +375,10 @@ tags:
   description: An account from an external resource that is not managed by the Recurly
     platform and instead is managed by third-party platforms like Apple App Store
     and Google Play Store.
+- name: business_entities
+  x-displayName: Business Entities
+  description: Describes the business address that will be used for invoices and taxes
+    depending on settings and subscriber location.
 paths:
   "/sites":
     get:
@@ -15974,6 +15979,60 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/business_entities/{business_entity_id}":
+    parameters:
+    - "$ref": "#/components/parameters/business_entity_id"
+    get:
+      tags:
+      - business_entities
+      operationId: get_business_entity
+      summary: Fetch a business entity
+      responses:
+        '200':
+          description: Business entity details
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BusinessEntity"
+        '404':
+          description: Incorrect site or business entity ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/business_entities":
+    get:
+      tags:
+      - business_entities
+      operationId: list_business_entities
+      summary: List business entities
+      responses:
+        '200':
+          description: List of all business entities on your site.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BusinessEntityList"
+        '404':
+          description: Incorrect site.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/gift_cards":
     get:
       tags:
@@ -16143,6 +16202,49 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/business_entities/{business_entity_id}/invoices":
+    get:
+      tags:
+      - invoice
+      operationId: list_business_entity_invoices
+      summary: List a business entity's invoices
+      description: See the [Pagination Guide](/developers/guides/pagination.html)
+        to learn how to use pagination in the API and Client Libraries.
+      parameters:
+      - "$ref": "#/components/parameters/business_entity_id"
+      - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/limit"
+      - "$ref": "#/components/parameters/order"
+      - "$ref": "#/components/parameters/sort_dates"
+      - "$ref": "#/components/parameters/filter_begin_time"
+      - "$ref": "#/components/parameters/filter_end_time"
+      - "$ref": "#/components/parameters/filter_invoice_type"
+      responses:
+        '200':
+          description: A list of the business entity's invoices.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InvoiceList"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site or business entity ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
 servers:
 - url: https://v3.recurly.com
 - url: https://v3.eu.recurly.com
@@ -16177,6 +16279,14 @@ components:
       in: path
       description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
         feature.
+      required: true
+      schema:
+        type: string
+    business_entity_id:
+      name: business_entity_id
+      in: path
+      description: Business Entity ID. For ID no prefix is used e.g. `e28zov4fw0v2`.
+        For code use prefix `code-`, e.g. `code-entity1`.
       required: true
       schema:
         type: string
@@ -17101,6 +17211,11 @@ components:
             merchant has an integration for the Vertex tax provider, this optional
             value will be sent in any tax calculation requests for the account.
           maxLength: 30
+        override_business_entity_id:
+          type: string
+          title: Override Business Entity ID
+          description: Unique ID to identify the business entity assigned to the account.
+            Available when the `Multiple Business Entities` feature is enabled.
         parent_account_code:
           type: string
           maxLength: 50
@@ -17169,6 +17284,11 @@ components:
             The customer will also use this email address to log into your hosted
             account management pages. This value does not need to be unique.
           maxLength: 255
+        override_business_entity_id:
+          type: string
+          title: Override Business Entity ID
+          description: Unique ID to identify the business entity assigned to the account.
+            Available when the `Multiple Business Entities` feature is enabled.
         preferred_locale:
           description: Used to determine the language and locale of emails sent on
             behalf of the merchant to the customer.
@@ -19358,6 +19478,11 @@ components:
           type: boolean
           title: Final Dunning Event
           description: Last communication attempt.
+        business_entity_id:
+          type: string
+          title: Business Entity ID
+          description: Unique ID to identify the business entity assigned to the invoice.
+            Available when the `Multiple Business Entities` feature is enabled.
     InvoiceCreate:
       type: object
       properties:
@@ -23939,6 +24064,84 @@ components:
           type: string
           description: Username of the associated payment method. Currently only associated
             with Venmo.
+    BusinessEntityList:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          description: Will always be List.
+        has_more:
+          type: boolean
+          description: Indicates there are more results on subsequent pages.
+        next:
+          type: string
+          description: Path to subsequent page of results.
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/BusinessEntity"
+    BusinessEntity:
+      type: object
+      description: Business entity details
+      properties:
+        id:
+          title: Business entity ID
+          type: string
+          maxLength: 13
+          readOnly: true
+        object:
+          title: Object type
+          type: string
+          readOnly: true
+        code:
+          title: Business entity code
+          type: string
+          maxLength: 50
+          description: The entity code of the business entity.
+        name:
+          type: string
+          title: Name
+          description: This name describes your business entity and will appear on
+            the invoice.
+          maxLength: 255
+        invoice_display_address:
+          title: Invoice display address
+          description: Address information for the business entity that will appear
+            on the invoice.
+          "$ref": "#/components/schemas/Address"
+        tax_address:
+          title: Tax address
+          description: Address information for the business entity that will be used
+            for calculating taxes.
+          "$ref": "#/components/schemas/Address"
+        default_vat_number:
+          type: string
+          title: Default VAT number
+          description: VAT number for the customer used on the invoice.
+          maxLength: 20
+        default_registration_number:
+          type: string
+          title: Default registration number
+          description: Registration number for the customer used on the invoice.
+          maxLength: 30
+        subscriber_location_countries:
+          type: array
+          title: Subscriber location countries
+          description: List of countries for which the business entity will be used.
+          items:
+            type: string
+            title: Country code
+        created_at:
+          type: string
+          format: date-time
+          title: Created at
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          title: Last updated at
+          readOnly: true
     GiftCardList:
       type: object
       properties:


### PR DESCRIPTION
Adds support for Multiple Business Entities:
  - Adds operations for Multiple Business Entities:
    - `get_business_entity`
    - `list_business_entities`
    - `list_business_entity_invoices`
  - Adds `override_business_entity_id` to the `Account` resource and as params for the following requests:
    - `AccountCreate`
    - `AccountUpdate`
    - `AccountPurchase`
  - Adds `business_entity_id` to the `Invoice` resource