### PR TITLE
Fixed usage of Minitest

### DIFF
--- a/spec/recurly/api/errors_spec.rb
+++ b/spec/recurly/api/errors_spec.rb
@@ -13,7 +13,7 @@ describe Recurly::API::ResponseError do
     end
 
     describe "when response assigned" do
-      let(:response) { MiniTest::Mock.new }
+      let(:response) { Minitest::Mock.new }
       let(:error) { Recurly::API::ResponseError.new nil, response }
 
       describe "when xml already cached" do


### PR DESCRIPTION
Fixes issue where `MiniTest` (now seemingly deprecated) vs. `Minitest` was being referenced in a spec