### PR TITLE
fix: Allow Resource to be compare to other object

### DIFF
--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -15,8 +15,8 @@ module Recurly
     end
 
     def ==(other_resource)
-      other.is_a?(Recurly::Resource) &&
-        attributes == other.attributes
+      other_resource.is_a?(Recurly::Resource) &&
+        attributes == other_resource.attributes
     end
 
     # Hide instance variables to keep from accidental logging

--- a/lib/recurly/resource.rb
+++ b/lib/recurly/resource.rb
@@ -15,7 +15,8 @@ module Recurly
     end
 
     def ==(other_resource)
-      self.attributes == other_resource.attributes
+      other.is_a?(Recurly::Resource) &&
+        attributes == other.attributes
     end
 
     # Hide instance variables to keep from accidental logging


### PR DESCRIPTION
# Problem

The `Recurly::Resource` does not allow to compare to another object that does not respond to the `attributes` method.

