### PR TITLE
Generated Latest Changes for v2021-02-25 (Proration Settings)

### DIFF
--- a/lib/recurly/requests/proration_settings.rb
+++ b/lib/recurly/requests/proration_settings.rb
@@ -1,0 +1,18 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class ProrationSettings < Request
+
+      # @!attribute charge
+      #   @return [String] Determines how the amount charged is determined for this change
+      define_attribute :charge, String
+
+      # @!attribute credit
+      #   @return [String] Determines how the amount credited is determined for this change
+      define_attribute :credit, String
+    end
+  end
+end

--- a/lib/recurly/requests/subscription_change_create.rb
+++ b/lib/recurly/requests/subscription_change_create.rb
@@ -46,6 +46,10 @@ module Recurly
       #   @return [String] For manual invoicing, this identifies the PO number associated with the subscription.
       define_attribute :po_number, String
 
+      # @!attribute proration_settings
+      #   @return [ProrationSettings] Allows you to control how any resulting charges and credits will be calculated and prorated.
+      define_attribute :proration_settings, :ProrationSettings
+
       # @!attribute quantity
       #   @return [Integer] Optionally override the default quantity of 1.
       define_attribute :quantity, Integer

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21253,6 +21253,34 @@ components:
           description: |
             The percentage taken of the monetary amount of usage tracked.
             This can be up to 4 decimal places represented as a string.
+    ProrationSettings:
+      type: object
+      title: Proration Settings
+      description: Allows you to control how any resulting charges and credits will
+        be calculated and prorated.
+      properties:
+        charge:
+          "$ref": "#/components/schemas/ProrationSettingsChargeEnum"
+        credit:
+          "$ref": "#/components/schemas/ProrationSettingsCreditEnum"
+    ProrationSettingsChargeEnum:
+      type: string
+      title: Charge
+      description: Determines how the amount charged is determined for this change
+      default: prorated_amount
+      enum:
+      - full_amount
+      - prorated_amount
+      - none
+    ProrationSettingsCreditEnum:
+      type: string
+      title: Credit
+      description: Determines how the amount credited is determined for this change
+      default: prorated_amount
+      enum:
+      - full_amount
+      - prorated_amount
+      - none
     Settings:
       type: object
       properties:
@@ -22476,6 +22504,8 @@ components:
           description: The new set of ramp intervals for the subscription.
           items:
             "$ref": "#/components/schemas/SubscriptionRampInterval"
+        proration_settings:
+          "$ref": "#/components/schemas/ProrationSettings"
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription


### PR DESCRIPTION
Adds support for passing `proration_settings` to the following endpoints:

- POST /subscriptions/:id/change
- POST /subscriptions/:id/change/preview