### PR TITLE
Generated Latest Changes for v2021-02-25 (Taxable Address Control, RevRec)

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -1806,7 +1806,7 @@ module Recurly
     # @param custom_field_definition_id [String] Custom Field Definition ID
     # @param params [Hash] Optional query string parameters:
     #
-    # @return [Resources::CustomFieldDefinition] An custom field definition.
+    # @return [Resources::CustomFieldDefinition] A custom field definition.
     # @example
     #   begin
     #     custom_field_definition = @client.get_custom_field_definition(
@@ -1822,6 +1822,108 @@ module Recurly
     def get_custom_field_definition(custom_field_definition_id:, **options)
       path = interpolate_path("/custom_field_definitions/{custom_field_definition_id}", custom_field_definition_id: custom_field_definition_id)
       get(path, **options)
+    end
+
+    # Create a new general ledger account
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/create_general_ledger_account create_general_ledger_account api documentation}
+    #
+    # @param body [Requests::GeneralLedgerAccountCreate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::GeneralLedgerAccountCreate}
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Resources::GeneralLedgerAccount] A new general ledger account.
+    #
+    def create_general_ledger_account(body:, **options)
+      path = "/general_ledger_accounts"
+      post(path, body, Requests::GeneralLedgerAccountCreate, **options)
+    end
+
+    # List a site's general ledger accounts
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/list_general_ledger_accounts list_general_ledger_accounts api documentation}
+    #
+    # @param params [Hash] Optional query string parameters:
+    #        :ids [String] Filter results by their IDs. Up to 200 IDs can be passed at once using
+    #   commas as separators, e.g. +ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6+.
+    #
+    #   *Important notes:*
+    #
+    #   * The +ids+ parameter cannot be used with any other ordering or filtering
+    #     parameters (+limit+, +order+, +sort+, +begin_time+, +end_time+, etc)
+    #   * Invalid or unknown IDs will be ignored, so you should check that the
+    #     results correspond to your request.
+    #   * Records are returned in an arbitrary order. Since results are all
+    #     returned at once you can sort the records yourself.
+    #
+    #        :limit [Integer] Limit number of records 1-200.
+    #        :order [String] Sort order.
+    #        :sort [String] Sort field. You *really* only want to sort by +updated_at+ in ascending
+    #   order. In descending order updated records will move behind the cursor and could
+    #   prevent some records from being returned.
+    #
+    #        :account_type [String] General Ledger Account type by which to filter the response.
+    #
+    # @return [Pager<Resources::GeneralLedgerAccount>] A list of the site's general ledger accounts.
+    #
+    def list_general_ledger_accounts(**options)
+      path = "/general_ledger_accounts"
+      pager(path, **options)
+    end
+
+    # Fetch a general ledger account
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/get_general_ledger_account get_general_ledger_account api documentation}
+    #
+    # @param general_ledger_account_id [String] General Ledger Account ID
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Resources::GeneralLedgerAccount] A general ledger account.
+    #
+    def get_general_ledger_account(general_ledger_account_id:, **options)
+      path = interpolate_path("/general_ledger_accounts/{general_ledger_account_id}", general_ledger_account_id: general_ledger_account_id)
+      get(path, **options)
+    end
+
+    # Update a general ledger account
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/update_general_ledger_account update_general_ledger_account api documentation}
+    #
+    # @param general_ledger_account_id [String] General Ledger Account ID
+    # @param body [Requests::GeneralLedgerAccountUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::GeneralLedgerAccountUpdate}
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Resources::GeneralLedgerAccount] The updated general ledger account.
+    #
+    def update_general_ledger_account(general_ledger_account_id:, body:, **options)
+      path = interpolate_path("/general_ledger_accounts/{general_ledger_account_id}", general_ledger_account_id: general_ledger_account_id)
+      put(path, body, Requests::GeneralLedgerAccountUpdate, **options)
+    end
+
+    # Get a single Performance Obligation.
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligation get_performance_obligation api documentation}
+    #
+    # @param performance_obligation_id [String] Performance Obligation id.
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Resources::PerformanceObligation] A single Performance Obligation.
+    #
+    def get_performance_obligation(performance_obligation_id:, **options)
+      path = interpolate_path("/performance_obligations/{performance_obligation_id}", performance_obligation_id: performance_obligation_id)
+      get(path, **options)
+    end
+
+    # Get a site's Performance Obligations
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligations get_performance_obligations api documentation}
+    #
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Pager<Resources::PerformanceObligation>] A list of Performance Obligations.
+    #
+    def get_performance_obligations(**options)
+      path = "/performance_obligations"
+      pager(path, **options)
     end
 
     # List an invoice template's associated accounts
@@ -2301,7 +2403,7 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription get_external_subscription api documentation}
     #
-    # @param external_subscription_id [String] External subscription id
+    # @param external_subscription_id [String] External subscription ID or external_id. For ID no prefix is used e.g. +e28zov4fw0v2+. For external_id use prefix +external-id-+, e.g. +external-id-123456+.
     # @param params [Hash] Optional query string parameters:
     #
     # @return [Resources::ExternalSubscription] Settings for an external subscription.
@@ -4498,7 +4600,7 @@ module Recurly
       pager(path, **options)
     end
 
-    # Fetch an external payment_phase
+    # Fetch an external payment phase
     #
     # {https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase get_external_subscription_external_payment_phase api documentation}
     #
@@ -4506,7 +4608,7 @@ module Recurly
     # @param external_payment_phase_id [String] External payment phase ID, e.g. +a34ypb2ef9w1+.
     # @param params [Hash] Optional query string parameters:
     #
-    # @return [Resources::ExternalPaymentPhase] Details for an external payment_phase.
+    # @return [Resources::ExternalPaymentPhase] Details for an external payment phase.
     #
     def get_external_subscription_external_payment_phase(external_subscription_id:, external_payment_phase_id:, **options)
       path = interpolate_path("/external_subscriptions/{external_subscription_id}/external_payment_phases/{external_payment_phase_id}", external_subscription_id: external_subscription_id, external_payment_phase_id: external_payment_phase_id)

--- a/lib/recurly/requests/add_on_create.rb
+++ b/lib/recurly/requests/add_on_create.rb
@@ -27,7 +27,7 @@ module Recurly
       define_attribute :code, String
 
       # @!attribute currencies
-      #   @return [Array[AddOnPricing]] * If `item_code`/`item_id` is part of the request and the item has a default currency then `currencies` is optional. If the item does not have a default currency, then `currencies` is required. If `item_code`/`item_id` is not present `currencies` is required. * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `currencies` must be absent. * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
+      #   @return [Array[AddOnPricing]] * If `item_code`/`item_id` is part of the request and the item has a default currency, then `currencies` is optional. If the item does not have a default currency, then `currencies` is required. If `item_code`/`item_id` is not present `currencies` is required. * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `currencies` must be absent. * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
       define_attribute :currencies, Array, { :item_type => :AddOnPricing }
 
       # @!attribute default_quantity
@@ -39,12 +39,16 @@ module Recurly
       define_attribute :display_quantity, :Boolean
 
       # @!attribute item_code
-      #   @return [String] Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+      #   @return [String] Unique code to identify an item. Available when the `Credit Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
       define_attribute :item_code, String
 
       # @!attribute item_id
       #   @return [String] System-generated unique identifier for an item. Available when the `Credit Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
       define_attribute :item_id, String
+
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
 
       # @!attribute measured_unit_id
       #   @return [String] System-generated unique identifier for a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
@@ -66,9 +70,17 @@ module Recurly
       #   @return [Array[PercentageTiersByCurrency]] Array of objects which must have at least one set of tiers per currency and the currency code. The tier_type must be `volume` or `tiered`, if not, it must be absent. There must be one tier without an `ending_amount` value which represents the final tier. This feature is currently in development and requires approval and enablement, please contact support.
       define_attribute :percentage_tiers, Array, { :item_type => :PercentageTiersByCurrency }
 
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
       # @!attribute plan_id
       #   @return [String] Plan ID
       define_attribute :plan_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.

--- a/lib/recurly/requests/add_on_update.rb
+++ b/lib/recurly/requests/add_on_update.rb
@@ -38,6 +38,10 @@ module Recurly
       #   @return [String] Add-on ID
       define_attribute :id, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute measured_unit_id
       #   @return [String] System-generated unique identifier for a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
       define_attribute :measured_unit_id, String
@@ -55,8 +59,16 @@ module Recurly
       define_attribute :optional, :Boolean
 
       # @!attribute percentage_tiers
-      #   @return [Array[PercentageTiersByCurrency]] `percentage_tiers` is an array of objects, which must have the set of tiers per currency and the currency code. The tier_type must be `volume` or `tiered`, if not, it must be absent. There must be one tier without an `ending_amount` value which represents the final tier.  This feature is currently in development and requires approval and enablement, please contact support.
+      #   @return [Array[PercentageTiersByCurrency]] `percentage_tiers` is an array of objects, which must have the set of tiers per currency and the currency code. The tier_type must be `volume` or `tiered`, if not, it must be absent. There must be one tier without an `ending_amount` value which represents the final tier. This feature is currently in development and requires approval and enablement, please contact support.
       define_attribute :percentage_tiers, Array, { :item_type => :PercentageTiersByCurrency }
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.

--- a/lib/recurly/requests/general_ledger_account_create.rb
+++ b/lib/recurly/requests/general_ledger_account_create.rb
@@ -1,0 +1,22 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class GeneralLedgerAccountCreate < Request
+
+      # @!attribute account_type
+      #   @return [String]
+      define_attribute :account_type, String
+
+      # @!attribute code
+      #   @return [String] Unique code to identify the ledger account. Each code must start with a letter or number. The following special characters are allowed: `-_.,:`
+      define_attribute :code, String
+
+      # @!attribute description
+      #   @return [String] Optional description.
+      define_attribute :description, String
+    end
+  end
+end

--- a/lib/recurly/requests/general_ledger_account_update.rb
+++ b/lib/recurly/requests/general_ledger_account_update.rb
@@ -1,0 +1,18 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class GeneralLedgerAccountUpdate < Request
+
+      # @!attribute code
+      #   @return [String] Unique code to identify the ledger account. Each code must start with a letter or number. The following special characters are allowed: `-_.,:`
+      define_attribute :code, String
+
+      # @!attribute description
+      #   @return [String] Optional description.
+      define_attribute :description, String
+    end
+  end
+end

--- a/lib/recurly/requests/item_create.rb
+++ b/lib/recurly/requests/item_create.rb
@@ -38,9 +38,21 @@ module Recurly
       #   @return [String] Optional, stock keeping unit to link the item to other inventory systems.
       define_attribute :external_sku, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute name
       #   @return [String] This name describes your item and will appear on the invoice when it's purchased on a one time basis.
       define_attribute :name, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type

--- a/lib/recurly/requests/item_update.rb
+++ b/lib/recurly/requests/item_update.rb
@@ -38,9 +38,21 @@ module Recurly
       #   @return [String] Optional, stock keeping unit to link the item to other inventory systems.
       define_attribute :external_sku, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute name
       #   @return [String] This name describes your item and will appear on the invoice when it's purchased on a one time basis.
       define_attribute :name, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type

--- a/lib/recurly/requests/line_item_create.rb
+++ b/lib/recurly/requests/line_item_create.rb
@@ -34,6 +34,10 @@ module Recurly
       #   @return [String] Description that appears on the invoice. If `item_code`/`item_id` is part of the request then `description` must be absent.
       define_attribute :description, String
 
+      # @!attribute destination_tax_address_source
+      #   @return [String] The source of the address that will be used as the destinaion in determining taxes. Available only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax address". A value of "origin" refers to the "Business entity tax address".
+      define_attribute :destination_tax_address_source, String
+
       # @!attribute end_date
       #   @return [DateTime] If this date is provided, it indicates the end of a time range.
       define_attribute :end_date, DateTime
@@ -46,9 +50,21 @@ module Recurly
       #   @return [String] System-generated unique identifier for an item. Available when the Credit Invoices feature is enabled.
       define_attribute :item_id, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute origin
       #   @return [String] Origin `external_gift_card` is allowed if the Gift Cards feature is enabled on your site and `type` is `credit`. Set this value in order to track gift card credits from external gift cards (like InComm). It also skips billing information requirements.  Origin `prepayment` is only allowed if `type` is `charge` and `tax_exempt` is left blank or set to true.  This origin creates a charge and opposite credit on the account to be used for future invoices.
       define_attribute :origin, String
+
+      # @!attribute origin_tax_address_source
+      #   @return [String] The source of the address that will be used as the origin in determining taxes. Available only when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax address". A value of "destination" refers to the "Customer tax address".
+      define_attribute :origin_tax_address_source, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
 
       # @!attribute product_code
       #   @return [String] Optional field to track a product code or SKU for the line item. This can be used to later reporting on product purchases. For Vertex tax calculations, this field will be used as the Vertex `product` field. If `item_code`/`item_id` is part of the request then `product_code` must be absent.
@@ -57,6 +73,10 @@ module Recurly
       # @!attribute quantity
       #   @return [Integer] This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
       define_attribute :quantity, Integer
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type

--- a/lib/recurly/requests/plan_create.rb
+++ b/lib/recurly/requests/plan_create.rb
@@ -62,9 +62,17 @@ module Recurly
       #   @return [String] Unit for the plan's billing interval.
       define_attribute :interval_unit, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute name
       #   @return [String] This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
       define_attribute :name, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
 
       # @!attribute pricing_model
       #   @return [String] A fixed pricing model has the same price for each billing period. A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on a specified cadence of billing periods. The price change could be an increase or decrease.
@@ -74,6 +82,10 @@ module Recurly
       #   @return [Array[PlanRampInterval]] Ramp Intervals
       define_attribute :ramp_intervals, Array, { :item_type => :PlanRampInterval }
 
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
+
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type
       define_attribute :revenue_schedule_type, String
@@ -81,6 +93,18 @@ module Recurly
       # @!attribute setup_fee_accounting_code
       #   @return [String] Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
       define_attribute :setup_fee_accounting_code, String
+
+      # @!attribute setup_fee_liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :setup_fee_liability_gl_account_id, String
+
+      # @!attribute setup_fee_performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :setup_fee_performance_obligation_id, String
+
+      # @!attribute setup_fee_revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :setup_fee_revenue_gl_account_id, String
 
       # @!attribute setup_fee_revenue_schedule_type
       #   @return [String] Setup fee revenue schedule type

--- a/lib/recurly/requests/plan_update.rb
+++ b/lib/recurly/requests/plan_update.rb
@@ -54,13 +54,25 @@ module Recurly
       #   @return [String] Plan ID
       define_attribute :id, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute name
       #   @return [String] This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
       define_attribute :name, String
 
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
       # @!attribute ramp_intervals
       #   @return [Array[PlanRampInterval]] Ramp Intervals
       define_attribute :ramp_intervals, Array, { :item_type => :PlanRampInterval }
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type
@@ -69,6 +81,18 @@ module Recurly
       # @!attribute setup_fee_accounting_code
       #   @return [String] Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
       define_attribute :setup_fee_accounting_code, String
+
+      # @!attribute setup_fee_liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :setup_fee_liability_gl_account_id, String
+
+      # @!attribute setup_fee_performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :setup_fee_performance_obligation_id, String
+
+      # @!attribute setup_fee_revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :setup_fee_revenue_gl_account_id, String
 
       # @!attribute setup_fee_revenue_schedule_type
       #   @return [String] Setup fee revenue schedule type

--- a/lib/recurly/requests/shipping_method_create.rb
+++ b/lib/recurly/requests/shipping_method_create.rb
@@ -14,9 +14,21 @@ module Recurly
       #   @return [String] The internal name used identify the shipping method.
       define_attribute :code, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute name
       #   @return [String] The name of the shipping method displayed to customers.
       define_attribute :name, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute tax_code
       #   @return [String] Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable

--- a/lib/recurly/requests/shipping_method_update.rb
+++ b/lib/recurly/requests/shipping_method_update.rb
@@ -14,9 +14,21 @@ module Recurly
       #   @return [String] The internal name used identify the shipping method.
       define_attribute :code, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute name
       #   @return [String] The name of the shipping method displayed to customers.
       define_attribute :name, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute tax_code
       #   @return [String] Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable

--- a/lib/recurly/resources/add_on.rb
+++ b/lib/recurly/resources/add_on.rb
@@ -58,6 +58,10 @@ module Recurly
       #   @return [ItemMini] Just the important parts.
       define_attribute :item, :ItemMini
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute measured_unit_id
       #   @return [String] System-generated unique identifier for an measured unit associated with the add-on.
       define_attribute :measured_unit_id, String
@@ -78,9 +82,17 @@ module Recurly
       #   @return [Array[PercentageTiersByCurrency]] This feature is currently in development and requires approval and enablement, please contact support.
       define_attribute :percentage_tiers, Array, { :item_type => :PercentageTiersByCurrency }
 
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
       # @!attribute plan_id
       #   @return [String] Plan ID
       define_attribute :plan_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.

--- a/lib/recurly/resources/business_entity.rb
+++ b/lib/recurly/resources/business_entity.rb
@@ -14,13 +14,25 @@ module Recurly
       #   @return [DateTime] Created at
       define_attribute :created_at, DateTime
 
+      # @!attribute default_liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :default_liability_gl_account_id, String
+
       # @!attribute default_registration_number
       #   @return [String] Registration number for the customer used on the invoice.
       define_attribute :default_registration_number, String
 
+      # @!attribute default_revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :default_revenue_gl_account_id, String
+
       # @!attribute default_vat_number
       #   @return [String] VAT number for the customer used on the invoice.
       define_attribute :default_vat_number, String
+
+      # @!attribute destination_tax_address_source
+      #   @return [String] The source of the address that will be used as the destinaion in determining taxes. Available only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax address". A value of "origin" refers to the "Business entity tax address".
+      define_attribute :destination_tax_address_source, String
 
       # @!attribute id
       #   @return [String] Business entity ID
@@ -37,6 +49,10 @@ module Recurly
       # @!attribute object
       #   @return [String] Object type
       define_attribute :object, String
+
+      # @!attribute origin_tax_address_source
+      #   @return [String] The source of the address that will be used as the origin in determining taxes. Available only when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax address". A value of "destination" refers to the "Customer tax address".
+      define_attribute :origin_tax_address_source, String
 
       # @!attribute subscriber_location_countries
       #   @return [Array[String]] List of countries for which the business entity will be used.

--- a/lib/recurly/resources/external_payment_phase.rb
+++ b/lib/recurly/resources/external_payment_phase.rb
@@ -26,10 +26,6 @@ module Recurly
       #   @return [DateTime] Ends At
       define_attribute :ends_at, DateTime
 
-      # @!attribute external_subscription
-      #   @return [ExternalSubscription] Subscription from an external resource such as Apple App Store or Google Play Store.
-      define_attribute :external_subscription, :ExternalSubscription
-
       # @!attribute id
       #   @return [String] System-generated unique identifier for an external payment phase ID, e.g. `e28zov4fw0v2`.
       define_attribute :id, String

--- a/lib/recurly/resources/external_subscription.rb
+++ b/lib/recurly/resources/external_subscription.rb
@@ -38,6 +38,10 @@ module Recurly
       #   @return [String] The id of the subscription in the external systems., I.e. Apple App Store or Google Play Store.
       define_attribute :external_id, String
 
+      # @!attribute external_payment_phases
+      #   @return [Array[ExternalPaymentPhase]] The phases of the external subscription payment lifecycle.
+      define_attribute :external_payment_phases, Array, { :item_type => :ExternalPaymentPhase }
+
       # @!attribute external_product_reference
       #   @return [ExternalProductReferenceMini] External Product Reference details
       define_attribute :external_product_reference, :ExternalProductReferenceMini
@@ -45,6 +49,10 @@ module Recurly
       # @!attribute id
       #   @return [String] System-generated unique identifier for an external subscription ID, e.g. `e28zov4fw0v2`.
       define_attribute :id, String
+
+      # @!attribute imported
+      #   @return [Boolean] An indication of whether or not the external subscription was created by a historical data import.
+      define_attribute :imported, :Boolean
 
       # @!attribute in_grace_period
       #   @return [Boolean] An indication of whether or not the external subscription is in a grace period.

--- a/lib/recurly/resources/general_ledger_account.rb
+++ b/lib/recurly/resources/general_ledger_account.rb
@@ -1,0 +1,38 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class GeneralLedgerAccount < Resource
+
+      # @!attribute account_type
+      #   @return [String]
+      define_attribute :account_type, String
+
+      # @!attribute code
+      #   @return [String] Unique code to identify the ledger account. Each code must start with a letter or number. The following special characters are allowed: `-_.,:`
+      define_attribute :code, String
+
+      # @!attribute created_at
+      #   @return [DateTime] Created at
+      define_attribute :created_at, DateTime
+
+      # @!attribute description
+      #   @return [String] Optional description.
+      define_attribute :description, String
+
+      # @!attribute id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :id, String
+
+      # @!attribute object
+      #   @return [String] Object type
+      define_attribute :object, String
+
+      # @!attribute updated_at
+      #   @return [DateTime] Last updated at
+      define_attribute :updated_at, DateTime
+    end
+  end
+end

--- a/lib/recurly/resources/gift_card.rb
+++ b/lib/recurly/resources/gift_card.rb
@@ -38,9 +38,17 @@ module Recurly
       #   @return [String] Gift card ID
       define_attribute :id, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute object
       #   @return [String] Object type
       define_attribute :object, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
 
       # @!attribute product_code
       #   @return [String] The product code or SKU of the gift card product.
@@ -65,6 +73,10 @@ module Recurly
       # @!attribute redemption_invoice_id
       #   @return [String] The ID of the invoice for the gift card redemption made by the recipient.  Does not have a value until gift card is redeemed.
       define_attribute :redemption_invoice_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute unit_amount
       #   @return [Float] The amount of the gift card, which is the amount of the charge to the gifter account and the amount of credit that is applied to the recipient account upon successful redemption.

--- a/lib/recurly/resources/item.rb
+++ b/lib/recurly/resources/item.rb
@@ -50,6 +50,10 @@ module Recurly
       #   @return [String] Item ID
       define_attribute :id, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute name
       #   @return [String] This name describes your item and will appear on the invoice when it's purchased on a one time basis.
       define_attribute :name, String
@@ -57,6 +61,14 @@ module Recurly
       # @!attribute object
       #   @return [String] Object type
       define_attribute :object, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type

--- a/lib/recurly/resources/line_item.rb
+++ b/lib/recurly/resources/line_item.rb
@@ -62,6 +62,10 @@ module Recurly
       #   @return [String] Description that appears on the invoice. For subscription related items this will be filled in automatically.
       define_attribute :description, String
 
+      # @!attribute destination_tax_address_source
+      #   @return [String] The source of the address that will be used as the destinaion in determining taxes. Available only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax address". A value of "origin" refers to the "Business entity tax address".
+      define_attribute :destination_tax_address_source, String
+
       # @!attribute discount
       #   @return [Float] The discount applied to the line item.
       define_attribute :discount, Float
@@ -98,6 +102,10 @@ module Recurly
       #   @return [String] Category to describe the role of a line item on a legacy invoice: - "charges" refers to charges being billed for on this invoice. - "credits" refers to refund or proration credits. This portion of the invoice can be considered a credit memo. - "applied_credits" refers to previous credits applied to this invoice. See their original_line_item_id to determine where the credit first originated. - "carryforwards" can be ignored. They exist to consume any remaining credit balance. A new credit with the same amount will be created and placed back on the account.
       define_attribute :legacy_category, String
 
+      # @!attribute liability_gl_account_code
+      #   @return [String] Unique code to identify the ledger account. Each code must start with a letter or number. The following special characters are allowed: `-_.,:`
+      define_attribute :liability_gl_account_code, String
+
       # @!attribute object
       #   @return [String] Object type
       define_attribute :object, String
@@ -106,9 +114,17 @@ module Recurly
       #   @return [String] A credit created from an original charge will have the value of the charge's origin.
       define_attribute :origin, String
 
+      # @!attribute origin_tax_address_source
+      #   @return [String] The source of the address that will be used as the origin in determining taxes. Available only when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax address". A value of "destination" refers to the "Customer tax address".
+      define_attribute :origin_tax_address_source, String
+
       # @!attribute original_line_item_invoice_id
       #   @return [String] The invoice where the credit originated. Will only have a value if the line item is a credit created from a previous credit, or if the credit was created from a charge refund.
       define_attribute :original_line_item_invoice_id, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
 
       # @!attribute plan_code
       #   @return [String] If the line item is a charge or credit for a plan or add-on, this is the plan's code.
@@ -149,6 +165,10 @@ module Recurly
       # @!attribute refunded_quantity_decimal
       #   @return [String] A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
       define_attribute :refunded_quantity_decimal, String
+
+      # @!attribute revenue_gl_account_code
+      #   @return [String] Unique code to identify the ledger account. Each code must start with a letter or number. The following special characters are allowed: `-_.,:`
+      define_attribute :revenue_gl_account_code, String
 
       # @!attribute revenue_schedule_type
       #   @return [String] Revenue schedule type

--- a/lib/recurly/resources/performance_obligation.rb
+++ b/lib/recurly/resources/performance_obligation.rb
@@ -1,0 +1,26 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class PerformanceObligation < Resource
+
+      # @!attribute created_at
+      #   @return [DateTime] Created At
+      define_attribute :created_at, DateTime
+
+      # @!attribute id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :id, String
+
+      # @!attribute name
+      #   @return [String] Performance Obligation Name
+      define_attribute :name, String
+
+      # @!attribute updated_at
+      #   @return [DateTime] Last updated at
+      define_attribute :updated_at, DateTime
+    end
+  end
+end

--- a/lib/recurly/resources/shipping_method.rb
+++ b/lib/recurly/resources/shipping_method.rb
@@ -26,6 +26,10 @@ module Recurly
       #   @return [String] Shipping Method ID
       define_attribute :id, String
 
+      # @!attribute liability_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :liability_gl_account_id, String
+
       # @!attribute name
       #   @return [String] The name of the shipping method displayed to customers.
       define_attribute :name, String
@@ -33,6 +37,14 @@ module Recurly
       # @!attribute object
       #   @return [String] Object type
       define_attribute :object, String
+
+      # @!attribute performance_obligation_id
+      #   @return [String] The ID of a performance obligation. Performance obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :performance_obligation_id, String
+
+      # @!attribute revenue_gl_account_id
+      #   @return [String] The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+      define_attribute :revenue_gl_account_id, String
 
       # @!attribute tax_code
       #   @return [String] Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -230,6 +230,8 @@ x-tagGroups:
   - shipping_method
   - dunning_campaigns
   - business_entities
+  - general_ledger_account
+  - performance_obligations
 tags:
 - name: site
   x-displayName: Site
@@ -242,7 +244,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices features to be enabled.
+    Recurly's item catalog requires the Credit Invoices feature to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -385,6 +387,55 @@ tags:
   x-displayName: Business Entities
   description: Describes the business address that will be used for invoices and taxes
     depending on settings and subscriber location.
+- name: general_ledger_account
+  x-displayName: General Ledger Account
+  description: |
+    A general ledger account is an account of record used to sort, store
+    and summarize a company's transactions. Recurly supports the balance
+    sheet (Liability) account and income (Revenue) account to be attached
+    to business entities, plans, or at the item level.
+
+    When invoices are created, system can default to the accounts based
+    on the GL Accounts attached at the plan/item level. The accounts can
+    be defaulted from the business entity level as well.
+
+    These accounts will be used in the Revenue Recognition module to create
+    the revenue journals that can be posted into Merchant GL system.
+
+    Revenue and Liability accounts can defined in the system using this
+    API or via the General Ledger Accounting page in the Admin UI and then
+    used at the plan/item level.
+
+    Recurly allows merchants to default the accounts at the following levels:
+    - Business Entities (default)
+    - Plans
+        - Base Price
+        - Setup Fee
+        - Add-ons
+    - Items
+    - Charges
+    - Gift Cards
+    - Shipping Methods
+    - Credits
+
+    If you are interested in Recurly Revenue Recognition features, please
+    contact a Recurly customer service representative.
+- name: performance_obligations
+  x-displayName: Performance Obligations
+  description: |
+    A performance obligation is a promise to provide a distinct good or
+    service or a series of distinct goods or services as defined by the revenue standard.
+    Performance obligations are completed and revenue is recognized either at a point in
+    time or over a period of time, depending on the type of obligation.
+    - Point in time  a company has to go through the criteria and determine if a performance
+    obligation is satisfied over time. If it does not meet those criteria, then the performance
+    obligation is satisfied and revenue recognized at the point in time when control of the good
+    or service is transferred to the customer.
+    - Over a period of time  a performance obligation is satisfied and revenue is recognized over
+    time if at least one of the following are met:
+      - The customer receives and consumes the benefits of the goods or services as they are provided
+      by the entity (routine, recurring services like a cleaning service are an example of a series of
+      services that are substantially the same and have the same pattern of transfer)
 paths:
   "/sites":
     get:
@@ -6566,7 +6617,7 @@ paths:
       - "$ref": "#/components/parameters/custom_field_definition_id"
       responses:
         '200':
-          description: An custom field definition.
+          description: A custom field definition.
           content:
             application/json:
               schema:
@@ -6672,6 +6723,150 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Custom
           Field Definition: %s\", definition.Id)"
+  "/general_ledger_accounts":
+    post:
+      tags:
+      - general_ledger_account
+      operationId: create_general_ledger_account
+      summary: Create a new general ledger account
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GeneralLedgerAccountCreate"
+        required: true
+      responses:
+        '201':
+          description: A new general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+    get:
+      tags:
+      - general_ledger_account
+      operationId: list_general_ledger_accounts
+      summary: List a site's general ledger accounts
+      description: See the [Pagination Guide](/developers/guides/pagination.html)
+        to learn how to use pagination in the API and Client Libraries.
+      parameters:
+      - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/limit"
+      - "$ref": "#/components/parameters/order"
+      - "$ref": "#/components/parameters/sort_dates"
+      - "$ref": "#/components/parameters/general_ledger_account_type_enum"
+      responses:
+        '200':
+          description: A list of the site's general ledger accounts.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccountList"
+        '404':
+          description: Incorrect site ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/general_ledger_accounts/{general_ledger_account_id}":
+    get:
+      tags:
+      - general_ledger_account
+      operationId: get_general_ledger_account
+      summary: Fetch a general ledger account
+      parameters:
+      - "$ref": "#/components/parameters/general_ledger_account_id"
+      responses:
+        '200':
+          description: A general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        '404':
+          description: Incorrect site or general ledger account ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+    put:
+      tags:
+      - general_ledger_account
+      operationId: update_general_ledger_account
+      summary: Update a general ledger account
+      parameters:
+      - "$ref": "#/components/parameters/general_ledger_account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GeneralLedgerAccountUpdate"
+        required: true
+      responses:
+        '200':
+          description: The updated general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        '404':
+          description: Incorrect site or general ledger account ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/performance_obligations/{performance_obligation_id}":
+    get:
+      tags:
+      - performance_obligations
+      operationId: get_performance_obligation
+      summary: Get a single Performance Obligation.
+      parameters:
+      - "$ref": "#/components/parameters/performance_obligation_id"
+      responses:
+        '200':
+          description: A single Performance Obligation.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PerformanceObligation"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/performance_obligations":
+    get:
+      tags:
+      - performance_obligations
+      operationId: get_performance_obligations
+      summary: Get a site's Performance Obligations
+      responses:
+        '200':
+          description: A list of Performance Obligations.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PerformanceObligationList"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/invoice_templates/{invoice_template_id}/accounts":
     get:
       tags:
@@ -8034,7 +8229,7 @@ paths:
       x-code-samples: []
   "/external_subscriptions/{external_subscription_id}":
     parameters:
-    - "$ref": "#/components/parameters/external_subscription_id"
+    - "$ref": "#/components/parameters/external_subscription_id_fetch"
     get:
       tags:
       - external_subscriptions
@@ -16093,10 +16288,10 @@ paths:
       tags:
       - external_payment_phases
       operationId: get_external_subscription_external_payment_phase
-      summary: Fetch an external payment_phase
+      summary: Fetch an external payment phase
       responses:
         '200':
-          description: Details for an external payment_phase.
+          description: Details for an external payment phase.
           content:
             application/json:
               schema:
@@ -16545,6 +16740,14 @@ components:
       required: true
       schema:
         type: string
+    external_subscription_id_fetch:
+      name: external_subscription_id
+      in: path
+      description: External subscription ID or external_id. For ID no prefix is used
+        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      required: true
+      schema:
+        type: string
     external_subscription_id:
       name: external_subscription_id
       in: path
@@ -16559,6 +16762,25 @@ components:
       required: true
       schema:
         type: string
+    general_ledger_account_id:
+      name: general_ledger_account_id
+      in: path
+      description: General Ledger Account ID
+      required: true
+      schema:
+        type: string
+        title: General Ledger Account ID
+        description: |
+          The ID of a general ledger account. General ledger accounts are
+          only accessible as a part of the Recurly RevRec Standard and
+          Recurly RevRec Advanced features.
+        maxLength: 13
+    general_ledger_account_type_enum:
+      name: account_type
+      in: query
+      description: General Ledger Account type by which to filter the response.
+      schema:
+        "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
     invoice_template_id:
       name: invoice_template_id
       in: path
@@ -16604,6 +16826,19 @@ components:
       required: true
       schema:
         type: string
+    performance_obligation_id:
+      name: performance_obligation_id
+      in: path
+      description: Performance Obligation id.
+      required: true
+      schema:
+        type: string
+        title: Performance Obligation ID
+        description: |
+          The ID of a performance obligation. Performance obligations are
+          only accessible as a part of the Recurly RevRec Standard and
+          Recurly RevRec Advanced features.
+        maxLength: 13
     plan_id:
       name: plan_id
       in: path
@@ -17858,6 +18093,30 @@ components:
           description: System-generated unique identifier for an measured unit associated
             with the add-on.
           maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         accounting_code:
           type: string
           title: Accounting code
@@ -17972,7 +18231,7 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            Invoices` feature is enabled. If `item_id` and `item_code` are both present,
             `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
@@ -18031,6 +18290,30 @@ components:
           title: Plan ID
           maxLength: 13
           readOnly: true
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         accounting_code:
           type: string
           title: Accounting code
@@ -18100,7 +18383,7 @@ components:
           minItems: 1
           description: |
             * If `item_code`/`item_id` is part of the request and the item
-            has a default currency then `currencies` is optional. If the item does
+            has a default currency, then `currencies` is optional. If the item does
             not have a default currency, then `currencies` is required. If `item_code`/`item_id`
             is not present `currencies` is required.
             * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`,
@@ -18189,6 +18472,30 @@ components:
             to the `AddOn` then `accounting code` must be absent.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
           description: When this add-on is invoiced, the line item will use this revenue
@@ -18271,7 +18578,7 @@ components:
             `percentage_tiers` is an array of objects, which must have the set of tiers
             per currency and the currency code. The tier_type must be `volume` or `tiered`,
             if not, it must be absent. There must be one tier without an `ending_amount` value
-            which represents the final tier.  This feature is currently in development and
+            which represents the final tier. This feature is currently in development and
             requires approval and enablement, please contact support.
     BillingInfo:
       type: object
@@ -19210,6 +19517,171 @@ components:
             are removed from the accouts or subscriptions, will be hard deleted an
             no longer visible.
           readOnly: true
+    GeneralLedgerAccountId:
+      type: string
+      title: General Ledger Account ID
+      description: |
+        The ID of a general ledger account. General ledger accounts are
+        only accessible as a part of the Recurly RevRec Standard and
+        Recurly RevRec Advanced features.
+      maxLength: 13
+    GeneralLedgerAccountCode:
+      type: string
+      title: Accounting code for the ledger account.
+      description: |
+        Unique code to identify the ledger account. Each code must start
+        with a letter or number. The following special characters are
+        allowed: `-_.,:`
+      pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+      maxLength: 255
+    GeneralLedgerAccountDescription:
+      type: string
+      title: Description
+      description: Optional description.
+      maxLength: 255
+    GeneralLedgerAccount:
+      type: object
+      description: Full general ledger account details.
+      properties:
+        id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        object:
+          type: string
+          title: Object type
+          default: general_ledger_account
+          readOnly: true
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+        account_type:
+          "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
+        created_at:
+          type: string
+          format: date-time
+          title: Created at
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          title: Last updated at
+          readOnly: true
+    GeneralLedgerAccountList:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          description: Will always be List.
+        has_more:
+          type: boolean
+          description: Indicates there are more results on subsequent pages.
+        next:
+          type: string
+          description: Path to subsequent page of results.
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/GeneralLedgerAccount"
+    GeneralLedgerAccountCreate:
+      type: object
+      description: Create a new liability or revenue general ledger account.
+      properties:
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+        account_type:
+          "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
+    GeneralLedgerAccountUpdate:
+      type: object
+      description: Update an existing general ledger account.
+      properties:
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+    PerformanceObligationId:
+      type: string
+      title: Performance Obligation ID
+      description: |
+        The ID of a performance obligation. Performance obligations are
+        only accessible as a part of the Recurly RevRec Standard and
+        Recurly RevRec Advanced features.
+      maxLength: 13
+    PerformanceObligation:
+      type: object
+      description: Performance obligation details
+      properties:
+        id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        name:
+          title: Performance Obligation Name
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          readOnly: true
+          format: date-time
+        updated_at:
+          title: Last updated at
+          type: string
+          readOnly: true
+          format: date-time
+    PerformanceObligationList:
+      type: object
+      description: List of Performance Obligations
+      properties:
+        object:
+          title: Object type
+          type: string
+        data:
+          title: Performance Obligation
+          type: array
+          items:
+            "$ref": "#/components/schemas/PerformanceObligation"
     ItemMini:
       type: object
       title: Item mini details
@@ -19294,6 +19766,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -19378,6 +19874,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -19450,6 +19970,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -20269,6 +20813,32 @@ components:
           format: float
           title: Discount
           description: The discount applied to the line item.
+        liability_gl_account_code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        revenue_gl_account_code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         tax:
           type: number
           format: float
@@ -20310,6 +20880,10 @@ components:
           maxLength: 50
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
         proration_rate:
           type: number
           format: float
@@ -20470,6 +21044,30 @@ components:
             is part of the request then `accounting_code` must be absent.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20537,6 +21135,10 @@ components:
           format: date-time
           title: End date
           description: If this date is provided, it indicates the end of a time range.
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
       required:
       - currency
       - unit_amount
@@ -20834,6 +21436,54 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         setup_fee_revenue_schedule_type:
           title: Setup fee revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -21050,6 +21700,54 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         setup_fee_revenue_schedule_type:
           title: Setup fee revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -21508,6 +22206,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -21580,6 +22302,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
       required:
       - code
       - name
@@ -21618,6 +22364,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
     ShippingFeeCreate:
       type: object
       properties:
@@ -23980,8 +24750,6 @@ components:
         object:
           type: string
           title: Object type
-        external_subscription:
-          "$ref": "#/components/schemas/ExternalSubscription"
         started_at:
           type: string
           format: date-time
@@ -24279,6 +25047,12 @@ components:
           "$ref": "#/components/schemas/AccountMini"
         external_product_reference:
           "$ref": "#/components/schemas/ExternalProductReferenceMini"
+        external_payment_phases:
+          type: array
+          title: External payment phases
+          description: The phases of the external subscription payment lifecycle.
+          items:
+            "$ref": "#/components/schemas/ExternalPaymentPhase"
         external_id:
           type: string
           title: External Id
@@ -24351,6 +25125,12 @@ components:
           title: Test
           description: An indication of whether or not the external subscription was
             purchased in a sandbox environment.
+          default: false
+        imported:
+          type: boolean
+          title: Imported
+          description: An indication of whether or not the external subscription was
+            created by a historical data import.
           default: false
         created_at:
           type: string
@@ -24682,6 +25462,10 @@ components:
           description: Address information for the business entity that will be used
             for calculating taxes.
           "$ref": "#/components/schemas/Address"
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
         default_vat_number:
           type: string
           title: Default VAT number
@@ -24699,6 +25483,22 @@ components:
           items:
             type: string
             title: Country code
+        default_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        default_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -24797,6 +25597,30 @@ components:
           description: The delivery details for the gift card.
           readOnly: true
           "$ref": "#/components/schemas/GiftCardDelivery"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -25978,3 +26802,30 @@ components:
       type: string
       enum:
       - paid
+    GeneralLedgerAccountTypeEnum:
+      type: string
+      enum:
+      - liability
+      - revenue
+    OriginTaxAddressSourceEnum:
+      type: string
+      title: Origin tax address source
+      description: The source of the address that will be used as the origin in determining
+        taxes. Available only when the site is on an Elite plan. A value of "origin"
+        refers to the "Business entity tax address". A value of "destination" refers
+        to the "Customer tax address".
+      default: origin
+      enum:
+      - origin
+      - destination
+    DestinationTaxAddressSourceEnum:
+      type: string
+      title: Destination tax address source
+      description: The source of the address that will be used as the destinaion in
+        determining taxes. Available only when the site is on an Elite plan. A value
+        of "destination" refers to the "Customer tax address". A value of "origin"
+        refers to the "Business entity tax address".
+      default: destination
+      enum:
+      - destination
+      - origin


### PR DESCRIPTION
**Taxable Address Control**
* GET external_subscription by external-id
* Add `destination_tax_address_source` and `origin_tax_address_source` to line_item and business_entity resources

**RevRec**
*  list_general_ledger_accounts
* get_general_ledger_account by `liability_gl_account_id` or `revenue_gl_account_id`
* update_general_ledger_account by `liability_gl_account_id` or `revenue_gl_account_id`
* get_performance_obligations
* get_performance_obligation by `performance_obligation_id`
* Add `default_liability_gl_account_id` and `default_revenue_gl_account_id` to business_entity resource
* Add `liability_gl_account_id`, `revenue_gl_account_id`, and `performance_obligation_id` to the following resources
    - add_on
    - business_entity
    - gift_card
    - item
    - shipping_method
* Add `liability_gl_account_code` and `revenue_gl_account_code` to line_item resource