### PR TITLE
Generated Latest Changes for v2021-02-25 (add UUID to external subscriptions)

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -2403,7 +2403,7 @@ module Recurly
     #
     # {https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription get_external_subscription api documentation}
     #
-    # @param external_subscription_id [String] External subscription ID or external_id. For ID no prefix is used e.g. +e28zov4fw0v2+. For external_id use prefix +external-id-+, e.g. +external-id-123456+.
+    # @param external_subscription_id [String] External subscription ID, external_id or uuid. For ID no prefix is used e.g. +e28zov4fw0v2+. For external_id use prefix +external-id-+, e.g. +external-id-123456+ and for uuid use prefix +uuid-+ e.g. +uuid-7293239bae62777d8c1ae044a9843633+.
     # @param params [Hash] Optional query string parameters:
     #
     # @return [Resources::ExternalSubscription] Settings for an external subscription.

--- a/lib/recurly/resources/external_subscription.rb
+++ b/lib/recurly/resources/external_subscription.rb
@@ -89,6 +89,10 @@ module Recurly
       # @!attribute updated_at
       #   @return [DateTime] When the external subscription was updated in Recurly.
       define_attribute :updated_at, DateTime
+
+      # @!attribute uuid
+      #   @return [String] Universally Unique Identifier created automatically.
+      define_attribute :uuid, String
     end
   end
 end

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16743,8 +16743,9 @@ components:
     external_subscription_id_fetch:
       name: external_subscription_id
       in: path
-      description: External subscription ID or external_id. For ID no prefix is used
-        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      description: External subscription ID, external_id or uuid. For ID no prefix
+        is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g.
+        `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
       required: true
       schema:
         type: string
@@ -25100,6 +25101,10 @@ components:
           title: External Id
           description: The id of the subscription in the external systems., I.e. Apple
             App Store or Google Play Store.
+        uuid:
+          type: string
+          title: Uuid
+          description: Universally Unique Identifier created automatically.
         last_purchased:
           type: string
           format: date-time


### PR DESCRIPTION
We are giving the ability to fetch external subscriptions by uuid v3 v2021-02-25

Get `/external_subscriptions/uuid-<uuid_code>` replace <uuid_code> for specific uuid value