### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/requests/plan_create.rb
+++ b/lib/recurly/requests/plan_create.rb
@@ -133,6 +133,10 @@ module Recurly
       # @!attribute trial_unit
       #   @return [String] Units for the plan's trial period.
       define_attribute :trial_unit, String
+
+      # @!attribute vertex_transaction_type
+      #   @return [String] Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
+      define_attribute :vertex_transaction_type, String
     end
   end
 end

--- a/lib/recurly/requests/plan_update.rb
+++ b/lib/recurly/requests/plan_update.rb
@@ -121,6 +121,10 @@ module Recurly
       # @!attribute trial_unit
       #   @return [String] Units for the plan's trial period.
       define_attribute :trial_unit, String
+
+      # @!attribute vertex_transaction_type
+      #   @return [String] Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
+      define_attribute :vertex_transaction_type, String
     end
   end
 end

--- a/lib/recurly/resources/plan.rb
+++ b/lib/recurly/resources/plan.rb
@@ -129,6 +129,10 @@ module Recurly
       # @!attribute updated_at
       #   @return [DateTime] Last updated at
       define_attribute :updated_at, DateTime
+
+      # @!attribute vertex_transaction_type
+      #   @return [String] Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
+      define_attribute :vertex_transaction_type, String
     end
   end
 end

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21353,6 +21353,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21568,6 +21573,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21832,6 +21842,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing


### PR DESCRIPTION
This PR adds the ability to send a plan's `vertex_transaction_type` to vertex. 
 ```
vertex_transaction_type:
  type: string
  title: Vertex Transaction Type
  description: Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
```