### PR TITLE
chore: Adding base64 to gemspec to accommodate removal in 3.4.0

### DIFF
--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   # spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "base64", "~> 0.2.0"
+
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
The `base64` package is no longer included as a default gem in Ruby 3.4.0:
```
warning: base64 was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
```
