### PR TITLE
Add an option to override keep_alive_timeout

### DIFF
--- a/lib/recurly/client.rb
+++ b/lib/recurly/client.rb
@@ -61,7 +61,7 @@ module Recurly
     # @param ca_file [String] The CA bundle to use when connecting to the API. Defaults to "data/ca-certificates.crt"
     # @param api_key [String] The private API key
     # @param logger [Logger] A logger to use. Defaults to creating a new STDOUT logger with level WARN.
-    def initialize(region: REGION, base_url: API_HOSTS[:us], ca_file: CA_FILE, api_key:, logger: nil)
+    def initialize(region: REGION, base_url: API_HOSTS[:us], ca_file: CA_FILE, api_key:, logger: nil, keep_alive_timeout: 600)
       raise ArgumentError, "'api_key' must be set to a non-nil value" if api_key.nil?
 
       raise ArgumentError, "Invalid region type. Expected one of: #{API_HOSTS.keys.join(", ")}" if !API_HOSTS.key?(region)
@@ -69,7 +69,7 @@ module Recurly
       base_url = API_HOSTS[region] if base_url == API_HOSTS[:us] && API_HOSTS.key?(region)
 
       set_api_key(api_key)
-      set_connection_options(base_url, ca_file)
+      set_connection_options(base_url, ca_file, keep_alive_timeout)
 
       if logger.nil?
         @logger = Logger.new(STDOUT).tap do |l|
@@ -172,7 +172,7 @@ module Recurly
     end
 
     def run_request(request, options = {})
-      self.class.connection_pool.with_connection(uri: @base_uri, ca_file: @ca_file) do |http|
+      self.class.connection_pool.with_connection(uri: @base_uri, keep_alive_timeout: @keep_alive_timeout, ca_file: @ca_file) do |http|
         set_http_options(http, options)
 
         retries = 0
@@ -353,9 +353,10 @@ module Recurly
       @api_key = api_key.to_s
     end
 
-    def set_connection_options(base_url, ca_file)
+    def set_connection_options(base_url, ca_file, keep_alive_timeout)
       @base_uri = URI.parse(base_url)
       @ca_file = ca_file
+      @keep_alive_timeout = keep_alive_timeout
     end
 
     def build_url(path, options)

--- a/lib/recurly/connection_pool.rb
+++ b/lib/recurly/connection_pool.rb
@@ -9,14 +9,14 @@ module Recurly
       @pool = Hash.new { |h, k| h[k] = [] }
     end
 
-    def with_connection(uri:, ca_file: nil)
+    def with_connection(uri:, keep_alive_timeout:, ca_file: nil)
       http = nil
       @mutex.synchronize do
         http = @pool[[uri.host, uri.port]].pop
       end
 
       # create connection if the pool was empty
-      http ||= init_http_connection(uri, ca_file)
+      http ||= init_http_connection(uri, keep_alive_timeout, ca_file)
 
       response = yield http
 
@@ -29,12 +29,12 @@ module Recurly
       response
     end
 
-    def init_http_connection(uri, ca_file)
+    def init_http_connection(uri, keep_alive_timeout, ca_file)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == "https"
       http.ca_file = ca_file
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-      http.keep_alive_timeout = 600
+      http.keep_alive_timeout = keep_alive_timeout
 
       http
     end

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 RSpec.describe Recurly::Client do
   subject(:client) { Recurly::Client.new(**client_options) }
   let(:client_options) { { api_key: api_key } }
+  let(:keep_alive_timeout) { 600 }
   let(:subdomain) { "test" }
   let(:api_key) { "recurly-good" }
   let(:resp_headers) do
@@ -18,7 +19,7 @@ RSpec.describe Recurly::Client do
     }
   end
   let(:net_http) {
-    Recurly::ConnectionPool.new.init_http_connection(URI.parse(Recurly::Client::API_HOSTS[:us]), Recurly::Client::CA_FILE)
+    Recurly::ConnectionPool.new.init_http_connection(URI.parse(Recurly::Client::API_HOSTS[:us]), keep_alive_timeout, Recurly::Client::CA_FILE)
   }
   let(:connection_pool) {
     pool = double("ConnectionPool")
@@ -64,6 +65,20 @@ RSpec.describe Recurly::Client do
         expect {
           Recurly::Client.new(**client_options.merge(region: :none))
         }.to raise_error(ArgumentError, "Invalid region type. Expected one of: #{Recurly::Client::API_HOSTS.keys.join(", ")}")
+      end
+    end
+
+    describe "using a custom keep alive timeout" do
+      let(:keep_alive_timeout) { 10 }
+
+      it "should use a custom base url in EU" do
+        client = Recurly::Client.new(**client_options.merge(region: :eu, keep_alive_timeout:))
+        expect(client.instance_variable_get(:@keep_alive_timeout)).to eq(10)
+      end
+
+      it "should use a custom base url in US" do
+        client = Recurly::Client.new(**client_options.merge(keep_alive_timeout:))
+        expect(client.instance_variable_get(:@keep_alive_timeout)).to eq(10)
       end
     end
   end

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Recurly::Client do
       let(:keep_alive_timeout) { 10 }
 
       it "should use a custom base url in EU" do
-        client = Recurly::Client.new(**client_options.merge(region: :eu, keep_alive_timeout:))
+        client = Recurly::Client.new(**client_options.merge(region: :eu, keep_alive_timeout: keep_alive_timeout))
         expect(client.instance_variable_get(:@keep_alive_timeout)).to eq(10)
       end
 

--- a/spec/recurly/client_spec.rb
+++ b/spec/recurly/client_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Recurly::Client do
       end
 
       it "should use a custom base url in US" do
-        client = Recurly::Client.new(**client_options.merge(keep_alive_timeout:))
+        client = Recurly::Client.new(**client_options.merge(keep_alive_timeout: keep_alive_timeout))
         expect(client.instance_variable_get(:@keep_alive_timeout)).to eq(10)
       end
     end


### PR DESCRIPTION
In order to try and resolve Recurly::Errors::SSLError: SSL_read error - mentioned in this issue - https://github.com/recurly/recurly-client-ruby/issues/893 I would like to have the option to receive the keep alive timeout as a configuration