### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/resources/invoice.rb
+++ b/lib/recurly/resources/invoice.rb
@@ -114,6 +114,10 @@ module Recurly
       #   @return [String] On refund invoices, this value will exist and show the invoice ID of the purchase invoice the refund was created from. This field is only populated for sites without the [Only Bill What Changed](https://docs.recurly.com/docs/only-bill-what-changed) feature enabled. Sites with Only Bill What Changed enabled should use the [related_invoices endpoint](https://recurly.com/developers/api/v2021-02-25/index.html#operation/list_related_invoices) to see purchase invoices refunded by this invoice.
       define_attribute :previous_invoice_id, String
 
+      # @!attribute reference_only_currency_conversion
+      #   @return [ReferenceOnlyCurrencyConversion] Reference Only Currency Conversion
+      define_attribute :reference_only_currency_conversion, :ReferenceOnlyCurrencyConversion
+
       # @!attribute refundable_amount
       #   @return [Float] The refundable amount on a charge invoice. It will be null for all other invoices.
       define_attribute :refundable_amount, Float

--- a/lib/recurly/resources/reference_only_currency_conversion.rb
+++ b/lib/recurly/resources/reference_only_currency_conversion.rb
@@ -1,0 +1,22 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class ReferenceOnlyCurrencyConversion < Resource
+
+      # @!attribute currency
+      #   @return [String] 3-letter ISO 4217 currency code.
+      define_attribute :currency, String
+
+      # @!attribute subtotal_in_cents
+      #   @return [Float] The subtotal converted to the currency.
+      define_attribute :subtotal_in_cents, Float
+
+      # @!attribute tax_in_cents
+      #   @return [Float] The tax converted to the currency.
+      define_attribute :tax_in_cents, Float
+    end
+  end
+end

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -20276,6 +20276,8 @@ components:
           format: float
           title: Tax
           description: The total tax on this invoice.
+        reference_only_currency_conversion:
+          "$ref": "#/components/schemas/ReferenceOnlyCurrencyConversion"
         total:
           type: number
           format: float
@@ -22289,6 +22291,25 @@ components:
           title: Updated at
           format: date-time
           readOnly: true
+    ReferenceOnlyCurrencyConversion:
+      type: object
+      title: Reference Only Currency Conversion
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        subtotal_in_cents:
+          type: number
+          format: float
+          title: Subtotal In Cents
+          description: The subtotal converted to the currency.
+        tax_in_cents:
+          type: number
+          format: float
+          title: Tax In Cents
+          description: The tax converted to the currency.
     ShippingAddressCreate:
       type: object
       properties:


### PR DESCRIPTION
This PR adds `reference_only_currency_conversion` values to Invoice responses.

```json
  "reference_only_currency_conversion": {
    "currency": "str",
    "subtotal_in_cents": 0,
    "tax_in_cents": 0
  },
  ```