### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/requests/payment_gateway_references.rb
+++ b/lib/recurly/requests/payment_gateway_references.rb
@@ -7,11 +7,11 @@ module Recurly
     class PaymentGatewayReferences < Request
 
       # @!attribute reference_type
-      #   @return [String] The type of reference token. Required if token is passed in for Stripe Gateway.
+      #   @return [String] The type of reference token. Required if token is passed in for Stripe Gateway or Ebanx UPI.
       define_attribute :reference_type, String
 
       # @!attribute token
-      #   @return [String] Reference value used when the external token was created. If Stripe gateway is used, this value will need to be accompanied by its reference_type.
+      #   @return [String] Reference value used when the external token was created. If a Stripe gateway or Ebanx gateway is used, this value will need to be accompanied by its reference_type.
       define_attribute :token, String
     end
   end

--- a/lib/recurly/requests/subscription_create.rb
+++ b/lib/recurly/requests/subscription_create.rb
@@ -111,7 +111,7 @@ module Recurly
       define_attribute :shipping, :SubscriptionShippingCreate
 
       # @!attribute starts_at
-      #   @return [DateTime] If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
+      #   @return [DateTime] If set, the subscription will begin on this specified date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
       define_attribute :starts_at, DateTime
 
       # @!attribute tax_inclusive

--- a/lib/recurly/requests/subscription_purchase.rb
+++ b/lib/recurly/requests/subscription_purchase.rb
@@ -55,7 +55,7 @@ module Recurly
       define_attribute :shipping, :SubscriptionShippingPurchase
 
       # @!attribute starts_at
-      #   @return [DateTime] If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
+      #   @return [DateTime] If set, the subscription will begin on this specified date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
       define_attribute :starts_at, DateTime
 
       # @!attribute tax_inclusive

--- a/lib/recurly/resources/payment_gateway_references.rb
+++ b/lib/recurly/resources/payment_gateway_references.rb
@@ -7,11 +7,11 @@ module Recurly
     class PaymentGatewayReferences < Resource
 
       # @!attribute reference_type
-      #   @return [String] The type of reference token. Required if token is passed in for Stripe Gateway.
+      #   @return [String] The type of reference token. Required if token is passed in for Stripe Gateway or Ebanx UPI.
       define_attribute :reference_type, String
 
       # @!attribute token
-      #   @return [String] Reference value used when the external token was created. If Stripe gateway is used, this value will need to be accompanied by its reference_type.
+      #   @return [String] Reference value used when the external token was created. If a Stripe gateway or Ebanx gateway is used, this value will need to be accompanied by its reference_type.
       define_attribute :token, String
     end
   end

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21322,8 +21322,8 @@ components:
           type: string
           title: Token
           description: Reference value used when the external token was created. If
-            Stripe gateway is used, this value will need to be accompanied by its
-            reference_type.
+            a Stripe gateway or Ebanx gateway is used, this value will need to be
+            accompanied by its reference_type.
         reference_type:
           type: string
           title: Reference Type
@@ -23682,7 +23682,7 @@ components:
           type: string
           format: date-time
           title: Start date
-          description: If set, the subscription will begin in the future on this date.
+          description: If set, the subscription will begin on this specified date.
             The subscription will apply the setup fee and trial period, unless the
             plan has no trial.
         next_bill_date:
@@ -23855,7 +23855,7 @@ components:
           type: string
           format: date-time
           title: Start date
-          description: If set, the subscription will begin in the future on this date.
+          description: If set, the subscription will begin on this specified date.
             The subscription will apply the setup fee and trial period, unless the
             plan has no trial.
         next_bill_date:
@@ -26564,11 +26564,12 @@ components:
     PaymentGatewayReferencesEnum:
       type: string
       description: The type of reference token. Required if token is passed in for
-        Stripe Gateway.
+        Stripe Gateway or Ebanx UPI.
       enum:
       - stripe_confirmation_token
       - stripe_customer
       - stripe_payment_method
+      - upi_vpa
     GatewayTransactionTypeEnum:
       type: string
       enum:


### PR DESCRIPTION
- Adding the new `upi_vpa` payment gateway reference type
- Updated starts_at description to allow backdating subscriptions.