### PR TITLE
Add tax_service_opt_out attribute to GiftCard model and corresponding tests

### DIFF
--- a/lib/recurly/gift_card.rb
+++ b/lib/recurly/gift_card.rb
@@ -36,6 +36,7 @@ module Recurly
       gifter_account_code
       recipient_account_code
       invoice_number
+      tax_service_opt_out
     ) + RevRec::PRODUCT_ATTRIBUTES
     alias to_param id
 

--- a/spec/recurly/gift_card_spec.rb
+++ b/spec/recurly/gift_card_spec.rb
@@ -200,5 +200,17 @@ describe GiftCard do
         actual_xml.must_equal expected_xml
       end
     end
+
+    describe "with tax_service_opt_out" do
+      let(:gift_card) {
+        Recurly::GiftCard.new(
+          tax_service_opt_out: true
+        )
+      }
+
+      it "should render a gift card payload with tax_service_opt_out" do
+        gift_card.to_xml.must_include "<tax_service_opt_out>true</tax_service_opt_out>"
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request adds support for the `tax_service_opt_out` attribute to the `GiftCard` resource. It also introduces a corresponding test to ensure the attribute is correctly included in the XML payload.

Gift card model update:

* Added the `tax_service_opt_out` attribute to the `GiftCard` resource, allowing users to specify whether to opt out of tax service for a gift card.

Testing improvements:

* Added a test case in `gift_card_spec.rb` to verify that the `tax_service_opt_out` attribute is properly rendered in the XML payload.