### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -248,6 +248,20 @@ module Recurly
       delete(path, **options)
     end
 
+    # Redact an account (GDPR Right to Erasure)
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/redact_account redact_account api documentation}
+    #
+    # @param account_id [String] Account ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-bob+.
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Resources::Account] Account has been accepted for redaction and will be processed asynchronously.
+    #
+    def redact_account(account_id:, **options)
+      path = interpolate_path("/accounts/{account_id}/redact", account_id: account_id)
+      put(path, **options)
+    end
+
     # Fetch an account's acquisition data
     #
     # {https://developers.recurly.com/api/v2021-02-25#operation/get_account_acquisition get_account_acquisition api documentation}
@@ -1743,6 +1757,21 @@ module Recurly
     def generate_unique_coupon_codes(coupon_id:, body:, **options)
       path = interpolate_path("/coupons/{coupon_id}/generate", coupon_id: coupon_id)
       post(path, body, Requests::CouponBulkCreate, **options)
+    end
+
+    # Generate unique coupon codes synchronously
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/generate_unique_coupon_codes_sync generate_unique_coupon_codes_sync api documentation}
+    #
+    # @param coupon_id [String] Coupon ID or code. For ID no prefix is used e.g. +e28zov4fw0v2+. For code use prefix +code-+, e.g. +code-10off+.
+    # @param body [Requests::CouponBulkCreateSync] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::CouponBulkCreateSync}
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Resources::UniqueCouponCodeGenerationResponse] The newly generated unique coupon codes.
+    #
+    def generate_unique_coupon_codes_sync(coupon_id:, body:, **options)
+      path = interpolate_path("/coupons/{coupon_id}/generate_sync", coupon_id: coupon_id)
+      post(path, body, Requests::CouponBulkCreateSync, **options)
     end
 
     # Restore an inactive coupon

--- a/lib/recurly/requests/coupon_bulk_create_sync.rb
+++ b/lib/recurly/requests/coupon_bulk_create_sync.rb
@@ -1,0 +1,14 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class CouponBulkCreateSync < Request
+
+      # @!attribute number_of_unique_codes
+      #   @return [Integer] The quantity of unique coupon codes to generate. A bulk coupon can have up to 100,000 unique codes (or your site's configured limit).
+      define_attribute :number_of_unique_codes, Integer
+    end
+  end
+end

--- a/lib/recurly/resources/unique_coupon_code_generation_response.rb
+++ b/lib/recurly/resources/unique_coupon_code_generation_response.rb
@@ -1,0 +1,18 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class UniqueCouponCodeGenerationResponse < Resource
+
+      # @!attribute object
+      #   @return [String] Object type
+      define_attribute :object, String
+
+      # @!attribute unique_coupon_codes
+      #   @return [Array[UniqueCouponCode]] An array containing the newly generated unique coupon codes.
+      define_attribute :unique_coupon_codes, Array, { :item_type => :UniqueCouponCode }
+    end
+  end
+end

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1404,6 +1404,45 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Deactivated
           Account: %s\", account.Id)"
+  "/accounts/{account_id}/redact":
+    parameters:
+    - "$ref": "#/components/parameters/account_id"
+    put:
+      tags:
+      - account
+      operationId: redact_account
+      summary: Redact an account (GDPR Right to Erasure)
+      description: Permanently and irreversibly removes all personally identifiable
+        information (PII) from an account to fulfill a data subject's right to erasure
+        under GDPR and similar privacy regulations (e.g. CCPA). This includes billing
+        information, shipping addresses, and transaction details such as names, email
+        addresses, and payment card data. The underlying account and transaction records
+        are retained for financial and audit purposes, but all personal data fields
+        are cleared. The account must have no active subscriptions, uninvoiced charges,
+        or partially paid invoices before it can be redacted. Redaction is processed
+        asynchronously and cannot be undone.
+      responses:
+        '200':
+          description: Account has been accepted for redaction and will be processed
+            asynchronously.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Account"
+        '422':
+          description: Account cannot be redacted. Common reasons include active subscriptions,
+            uninvoiced charges, or partially paid invoices.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/accounts/{account_id}/acquisition":
     parameters:
     - "$ref": "#/components/parameters/account_id"
@@ -6494,6 +6533,55 @@ paths:
                 "$ref": "#/components/schemas/Error"
         '404':
           description: Incorrect site or coupon ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/coupons/{coupon_id}/generate_sync":
+    post:
+      tags:
+      - unique_coupon_code
+      operationId: generate_unique_coupon_codes_sync
+      summary: Generate unique coupon codes synchronously
+      description: Generates up to 200 unique coupon codes for a bulk coupon and returns
+        them directly in the response. For larger batches, use the asynchronous generate
+        endpoint instead.
+      parameters:
+      - "$ref": "#/components/parameters/coupon_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/CouponBulkCreateSync"
+        required: true
+      responses:
+        '200':
+          description: The newly generated unique coupon codes.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UniqueCouponCodeGenerationResponse"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site or coupon ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: Unprocessable entity.
           content:
             application/json:
               schema:
@@ -19841,6 +19929,18 @@ components:
           description: The quantity of unique coupon codes to generate. A bulk coupon
             can have up to 100,000 unique codes (or your site's configured limit).
           minimum: 1
+    CouponBulkCreateSync:
+      type: object
+      properties:
+        number_of_unique_codes:
+          type: integer
+          title: Number of unique codes
+          description: The quantity of unique coupon codes to generate. A bulk coupon
+            can have up to 100,000 unique codes (or your site's configured limit).
+          minimum: 1
+          maximum: 200
+      required:
+      - number_of_unique_codes
     CouponMini:
       type: object
       properties:
@@ -25251,7 +25351,20 @@ components:
                   transactions where fraud checks have already been performed on the
                   initial transaction. Note that not all gateways support this feature.
                   For Stripe, this skips Radar fraud rules; for Adyen, this skips
-                  Risk checks.
+              skip_recurly_fraud:
+                type: boolean
+                title: Skip Recurly Fraud
+                description: When set to `true`, skips Recurly's fraud detection checks
+                  for this transaction, including Kount and IP-based fraud screening.
+                  Does not affect gateway-level fraud checks. Use `skip_all_fraud`
+                  to skip all fraud checks.
+              skip_all_fraud:
+                type: boolean
+                title: Skip All Fraud
+                description: When set to `true`, skips all fraud checks for this transaction,
+                  including both gateway-level fraud checks and Recurly's fraud detection
+                  services. This is useful for trusted transactions where fraud screening
+                  is not required.
         customer_notes:
           type: string
           title: Customer notes
@@ -25839,6 +25952,20 @@ components:
           type: string
           format: date-time
           description: When the external product was updated in Recurly.
+    UniqueCouponCodeGenerationResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          readOnly: true
+        unique_coupon_codes:
+          type: array
+          title: Unique coupon codes
+          description: An array containing the newly generated unique coupon codes.
+          maxItems: 200
+          items:
+            "$ref": "#/components/schemas/UniqueCouponCode"
     ExternalSubscription:
       type: object
       description: Subscription from an external resource such as Apple App Store


### PR DESCRIPTION
This PR shows the following endpoints are supported
`/coupons/{coupon_id}/generate_sync`
`/accounts/{account_id}/redact`