### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -2734,7 +2734,6 @@ module Recurly
     #
     # @param invoice_id [String] Invoice ID or number. For ID no prefix is used e.g. +e28zov4fw0v2+. For number use prefix +number-+, e.g. +number-1000+. For number with prefix or country code, use +number-+ and +prefix+, e.g. +number-TEST-FR1001+
     # @param params [Hash] Optional query string parameters:
-    #        :site_id [String] Site ID or subdomain. For ID no prefix is used e.g. +e28zov4fw0v2+. For subdomain use prefix +subdomain-+, e.g. +subdomain-recurly+.
     #
     # @return [Resources::Invoice] The updated invoice.
     # @example

--- a/lib/recurly/requests/address.rb
+++ b/lib/recurly/requests/address.rb
@@ -15,7 +15,7 @@ module Recurly
       define_attribute :country, String
 
       # @!attribute geo_code
-      #   @return [String] Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+      #   @return [String] Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
       define_attribute :geo_code, String
 
       # @!attribute phone

--- a/lib/recurly/requests/coupon_create.rb
+++ b/lib/recurly/requests/coupon_create.rb
@@ -87,11 +87,11 @@ module Recurly
       define_attribute :redemption_resource, String
 
       # @!attribute temporal_amount
-      #   @return [Integer] If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+      #   @return [Integer] If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.
       define_attribute :temporal_amount, Integer
 
       # @!attribute temporal_unit
-      #   @return [String] If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+      #   @return [String] If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
       define_attribute :temporal_unit, String
 
       # @!attribute unique_code_template

--- a/lib/recurly/requests/custom_field.rb
+++ b/lib/recurly/requests/custom_field.rb
@@ -10,6 +10,14 @@ module Recurly
       #   @return [String] Fields must be created in the UI before values can be assigned to them.
       define_attribute :name, String
 
+      # @!attribute source_record_id
+      #   @return [String] The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.
+      define_attribute :source_record_id, String
+
+      # @!attribute source_record_type
+      #   @return [String] The type of record this custom field was automatically copied from. Only present when the field was copied from another record.
+      define_attribute :source_record_type, String
+
       # @!attribute value
       #   @return [String] Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
       define_attribute :value, String

--- a/lib/recurly/requests/invoice_address.rb
+++ b/lib/recurly/requests/invoice_address.rb
@@ -23,7 +23,7 @@ module Recurly
       define_attribute :first_name, String
 
       # @!attribute geo_code
-      #   @return [String] Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+      #   @return [String] Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
       define_attribute :geo_code, String
 
       # @!attribute last_name

--- a/lib/recurly/requests/shipping_address_create.rb
+++ b/lib/recurly/requests/shipping_address_create.rb
@@ -27,7 +27,7 @@ module Recurly
       define_attribute :first_name, String
 
       # @!attribute geo_code
-      #   @return [String] Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+      #   @return [String] Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
       define_attribute :geo_code, String
 
       # @!attribute last_name

--- a/lib/recurly/requests/shipping_address_update.rb
+++ b/lib/recurly/requests/shipping_address_update.rb
@@ -27,7 +27,7 @@ module Recurly
       define_attribute :first_name, String
 
       # @!attribute geo_code
-      #   @return [String] Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+      #   @return [String] Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
       define_attribute :geo_code, String
 
       # @!attribute id

--- a/lib/recurly/resources/address.rb
+++ b/lib/recurly/resources/address.rb
@@ -15,7 +15,7 @@ module Recurly
       define_attribute :country, String
 
       # @!attribute geo_code
-      #   @return [String] Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+      #   @return [String] Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
       define_attribute :geo_code, String
 
       # @!attribute phone

--- a/lib/recurly/resources/address_with_name.rb
+++ b/lib/recurly/resources/address_with_name.rb
@@ -19,7 +19,7 @@ module Recurly
       define_attribute :first_name, String
 
       # @!attribute geo_code
-      #   @return [String] Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+      #   @return [String] Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
       define_attribute :geo_code, String
 
       # @!attribute last_name

--- a/lib/recurly/resources/coupon.rb
+++ b/lib/recurly/resources/coupon.rb
@@ -99,11 +99,11 @@ module Recurly
       define_attribute :state, String
 
       # @!attribute temporal_amount
-      #   @return [Integer] If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+      #   @return [Integer] If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.
       define_attribute :temporal_amount, Integer
 
       # @!attribute temporal_unit
-      #   @return [String] If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+      #   @return [String] If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
       define_attribute :temporal_unit, String
 
       # @!attribute unique_code_template

--- a/lib/recurly/resources/custom_field.rb
+++ b/lib/recurly/resources/custom_field.rb
@@ -10,6 +10,14 @@ module Recurly
       #   @return [String] Fields must be created in the UI before values can be assigned to them.
       define_attribute :name, String
 
+      # @!attribute source_record_id
+      #   @return [String] The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.
+      define_attribute :source_record_id, String
+
+      # @!attribute source_record_type
+      #   @return [String] The type of record this custom field was automatically copied from. Only present when the field was copied from another record.
+      define_attribute :source_record_type, String
+
       # @!attribute value
       #   @return [String] Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
       define_attribute :value, String

--- a/lib/recurly/resources/invoice.rb
+++ b/lib/recurly/resources/invoice.rb
@@ -46,6 +46,10 @@ module Recurly
       #   @return [String] 3-letter ISO 4217 currency code.
       define_attribute :currency, String
 
+      # @!attribute custom_fields
+      #   @return [Array[CustomField]] A list of custom fields that were on the account at the time of invoice creation and were marked to be displayed on invoices. Read-only; cannot be set directly on the invoice.
+      define_attribute :custom_fields, Array, { :item_type => :CustomField }
+
       # @!attribute customer_notes
       #   @return [String] This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes.
       define_attribute :customer_notes, String

--- a/lib/recurly/resources/invoice_address.rb
+++ b/lib/recurly/resources/invoice_address.rb
@@ -23,7 +23,7 @@ module Recurly
       define_attribute :first_name, String
 
       # @!attribute geo_code
-      #   @return [String] Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+      #   @return [String] Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
       define_attribute :geo_code, String
 
       # @!attribute last_name

--- a/lib/recurly/resources/shipping_address.rb
+++ b/lib/recurly/resources/shipping_address.rb
@@ -35,7 +35,7 @@ module Recurly
       define_attribute :first_name, String
 
       # @!attribute geo_code
-      #   @return [String] Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+      #   @return [String] Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
       define_attribute :geo_code, String
 
       # @!attribute id

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -200,14 +200,12 @@ x-tagGroups:
   - usage
   - automated_exports
   - gift_cards
-- name: App Management
+- name: Invoices and Payments
   tags:
-  - external_subscriptions
-  - external_invoices
-  - external_products
-  - external_accounts
-  - external_product_references
-  - external_payment_phases
+  - invoice
+  - line_item
+  - credit_payment
+  - transaction
 - name: Products and Promotions
   tags:
   - item
@@ -218,12 +216,6 @@ x-tagGroups:
   - coupon_redemption
   - unique_coupon_code
   - price_segment
-- name: Invoices and Payments
-  tags:
-  - invoice
-  - line_item
-  - credit_payment
-  - transaction
 - name: Configuration
   tags:
   - site
@@ -233,6 +225,14 @@ x-tagGroups:
   - business_entities
   - general_ledger_account
   - performance_obligations
+- name: App Management
+  tags:
+  - external_subscriptions
+  - external_invoices
+  - external_products
+  - external_accounts
+  - external_product_references
+  - external_payment_phases
 tags:
 - name: site
   x-displayName: Site
@@ -9245,7 +9245,6 @@ paths:
       description: Apply credit payment to the outstanding balance on an existing
         charge invoice from an account’s available balance from existing credit invoices.
       parameters:
-      - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/invoice_id"
       responses:
         '200':
@@ -18621,7 +18620,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     AddressWithName:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19642,12 +19641,14 @@ components:
           title: Temporal amount
           description: If `duration` is "temporal" than `temporal_amount` is an integer
             which is multiplied by `temporal_unit` to define the duration that the
-            coupon will be applied to invoices for.
+            coupon will be applied to invoices for. When `temporal_unit` is "billing_period",
+            this is the number of complete billing cycles.
         temporal_unit:
           title: Temporal unit
           description: If `duration` is "temporal" than `temporal_unit` is multiplied
             by `temporal_amount` to define the duration that the coupon will be applied
-            to invoices for.
+            to invoices for. Use "billing_period" to apply the coupon for a fixed
+            number of billing cycles. Requires `redemption_resource=subscription`.
           "$ref": "#/components/schemas/TemporalUnitEnum"
         free_trial_unit:
           title: Free trial unit
@@ -19833,12 +19834,14 @@ components:
             title: Temporal amount
             description: If `duration` is "temporal" than `temporal_amount` is an
               integer which is multiplied by `temporal_unit` to define the duration
-              that the coupon will be applied to invoices for.
+              that the coupon will be applied to invoices for. When `temporal_unit`
+              is "billing_period", this is the number of complete billing cycles.
           temporal_unit:
             title: Temporal unit
             description: If `duration` is "temporal" than `temporal_unit` is multiplied
               by `temporal_amount` to define the duration that the coupon will be
-              applied to invoices for.
+              applied to invoices for. Use "billing_period" to apply the coupon for
+              a fixed number of billing cycles. Requires `redemption_resource=subscription`.
             "$ref": "#/components/schemas/TemporalUnitEnum"
           coupon_type:
             title: Coupon type
@@ -20195,6 +20198,19 @@ components:
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
           maxLength: 255
+        source_record_type:
+          type: string
+          title: Source record type
+          description: The type of record this custom field was automatically copied
+            from. Only present when the field was copied from another record.
+          readOnly: true
+          "$ref": "#/components/schemas/SourceRecordTypeEnum"
+        source_record_id:
+          type: string
+          title: Source record ID
+          description: The UUID of the record this custom field was automatically
+            copied from. Only present when the field was copied from another record.
+          readOnly: true
       required:
       - name
       - value
@@ -20204,6 +20220,15 @@ components:
       description: The custom fields will only be altered when they are included in
         a request. Sending an empty array will not remove any existing values. To
         remove a field send the name with a null or empty value.
+      items:
+        "$ref": "#/components/schemas/CustomField"
+    InvoiceCustomFields:
+      type: array
+      title: Custom fields
+      description: A list of custom fields that were on the account at the time of
+        invoice creation and were marked to be displayed on invoices. Read-only; cannot
+        be set directly on the invoice.
+      readOnly: true
       items:
         "$ref": "#/components/schemas/CustomField"
     CustomFieldDefinition:
@@ -21084,6 +21109,8 @@ components:
           title: Business Entity ID
           description: Unique ID to identify the business entity assigned to the invoice.
             Available when the `Multiple Business Entities` feature is enabled.
+        custom_fields:
+          "$ref": "#/components/schemas/InvoiceCustomFields"
     InvoiceCreate:
       type: object
       properties:
@@ -22735,7 +22762,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         created_at:
           type: string
           title: Created at
@@ -22823,7 +22850,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         country:
           type: string
           maxLength: 50
@@ -23154,7 +23181,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     Site:
       type: object
       properties:
@@ -27196,11 +27223,16 @@ components:
       - temporal
     TemporalUnitEnum:
       type: string
+      description: The temporal unit for the coupon's duration. Used with temporal_amount
+        to define how long the coupon applies. When temporal_unit is billing_period,
+        the coupon applies for temporal_amount complete billing cycles rather than
+        a fixed calendar duration. billing_period requires redemption_resource=subscription.
       enum:
       - day
       - month
       - week
       - year
+      - billing_period
     FreeTrialUnitEnum:
       type: string
       enum:
@@ -28104,3 +28136,11 @@ components:
       enum:
       - customer
       - merchant
+    SourceRecordTypeEnum:
+      type: string
+      description: The type of record a custom field was automatically copied from.
+      enum:
+      - account
+      - plan
+      - product
+      - subscription


### PR DESCRIPTION
This PR includes the latest generated changes for the `v2021-02-25` API version.

**New fields**
- `CustomField` now exposes `source_record_id` and `source_record_type` (read-only) — populated when a custom field was automatically copied from another record.
- `Invoice` now exposes `custom_fields` (read-only) — the list of custom fields that were on the account at invoice creation time and were marked for display on invoices.

**New enum values**
- `TemporalUnit`: added `billing_period` — use with `temporal_amount` to apply a coupon for a fixed number of billing cycles (requires `redemption_resource=subscription`).
- `SourceRecordType` (new enum): `account`, `plan`, `product`, `subscription`.

**Documentation clarifications**
- `Coupon` / `CouponCreate`: clarified `temporal_amount` and `temporal_unit` descriptions to document `billing_period` behavior.
- `Address`, `AddressWithName`, `InvoiceAddress`, `ShippingAddress`: updated `geo_code` description — now reads "Only returned when Vertex or Avalara for Communications is enabled" (previously referenced Sling Vertex only).