### PR TITLE
Relax base64 dependency to allow 0.3.x

### DIFF
--- a/recurly.gemspec
+++ b/recurly.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   # spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "base64", "~> 0.2.0"
+  spec.add_dependency "base64", ">= 0.2", "< 0.4"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3.3"


### PR DESCRIPTION
## Summary

Relaxes the `base64` runtime dependency from `~> 0.2.0` to `>= 0.2, < 0.4`.

## Motivation

The exact `~> 0.2.0` pin (added in #920 to accommodate the gem's removal from the Ruby 3.4 stdlib) makes this client uninstallable alongside gems that require `base64 ~> 0.3.0` — for example `travel_time >= 0.8.0`. Bundler cannot resolve a bundle containing both:

```
Because recurly >= 4.59.0 depends on base64 ~> 0.2.0
  and travel_time >= 0.8.0 depends on base64 ~> 0.3.0,
  recurly >= 4.59.0 is incompatible with travel_time >= 0.8.0.
```

## Safety

- The client's only use of the gem is a single `Base64.encode64` call for the Basic auth header in `lib/recurly/client.rb`, whose behavior is unchanged in base64 0.3.x.
- The full test suite passes against base64 0.3.0: 920 examples, 0 failures.
- The same relaxation was made by fog-aws (`>= 0.2, < 0.4`) for the same reason.