### PR TITLE
Add Client#update_dunning_campaign for retry settings

### DIFF
--- a/lib/recurly/client/operations.rb
+++ b/lib/recurly/client/operations.rb
@@ -4752,6 +4752,21 @@ module Recurly
       get(path, **options)
     end
 
+    # Update a dunning campaign's retry settings
+    #
+    # {https://developers.recurly.com/api/v2021-02-25#operation/update_dunning_campaign update_dunning_campaign api documentation}
+    #
+    # @param dunning_campaign_id [String] Dunning Campaign ID, e.g. +e28zov4fw0v2+.
+    # @param body [Requests::DunningCampaignUpdate] The Hash representing the JSON request to send to the server. It should conform to the schema of {Requests::DunningCampaignUpdate}
+    # @param params [Hash] Optional query string parameters:
+    #
+    # @return [Resources::DunningCampaign] Updated dunning campaign.
+    #
+    def update_dunning_campaign(dunning_campaign_id:, body:, **options)
+      path = interpolate_path("/dunning_campaigns/{dunning_campaign_id}", dunning_campaign_id: dunning_campaign_id)
+      put(path, body, Requests::DunningCampaignUpdate, **options)
+    end
+
     # Assign a dunning campaign to multiple plans
     #
     # {https://developers.recurly.com/api/v2021-02-25#operation/put_dunning_campaign_bulk_update put_dunning_campaign_bulk_update api documentation}

--- a/lib/recurly/requests/dunning_campaign_update.rb
+++ b/lib/recurly/requests/dunning_campaign_update.rb
@@ -1,0 +1,14 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class DunningCampaignUpdate < Request
+
+      # @!attribute retry_settings
+      #   @return [DunningRetrySettings] Retry phase configuration for a dunning campaign's automatic collection cycle. Partial updates are supported — only the keys provided are changed; all other retry settings are inherited from the prior version.
+      define_attribute :retry_settings, :DunningRetrySettings
+    end
+  end
+end

--- a/lib/recurly/requests/dunning_retry_settings.rb
+++ b/lib/recurly/requests/dunning_retry_settings.rb
@@ -1,0 +1,26 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Requests
+    class DunningRetrySettings < Request
+
+      # @!attribute double_tap
+      #   @return [Boolean] Whether to enable double-tap retries at the start of the window. Absence or null means off.
+      define_attribute :double_tap, :Boolean
+
+      # @!attribute front_load_days
+      #   @return [Integer] Number of days to front-load retries at the beginning of the window. Absence, null, or 0 means off.
+      define_attribute :front_load_days, Integer
+
+      # @!attribute max_attempts
+      #   @return [Integer] Total number of retry attempts across the dunning window. Defaults to 20.
+      define_attribute :max_attempts, Integer
+
+      # @!attribute max_retries
+      #   @return [Integer] Maximum number of decline retries before the invoice is failed. Defaults to 10.
+      define_attribute :max_retries, Integer
+    end
+  end
+end

--- a/lib/recurly/resources/dunning_cycle.rb
+++ b/lib/recurly/resources/dunning_cycle.rb
@@ -30,6 +30,10 @@ module Recurly
       #   @return [Array[DunningInterval]] Dunning intervals.
       define_attribute :intervals, Array, { :item_type => :DunningInterval }
 
+      # @!attribute retry_settings
+      #   @return [DunningRetrySettings] Retry phase configuration for a dunning campaign's automatic collection cycle.
+      define_attribute :retry_settings, :DunningRetrySettings
+
       # @!attribute send_immediately_on_hard_decline
       #   @return [Boolean] Whether or not to send an extra email immediately to customers whose initial payment attempt fails with either a hard decline or invalid billing info.
       define_attribute :send_immediately_on_hard_decline, :Boolean

--- a/lib/recurly/resources/dunning_retry_settings.rb
+++ b/lib/recurly/resources/dunning_retry_settings.rb
@@ -1,0 +1,26 @@
+# This file is automatically created by Recurly's OpenAPI generation process
+# and thus any edits you make by hand will be lost. If you wish to make a
+# change to this file, please create a Github issue explaining the changes you
+# need and we will usher them to the appropriate places.
+module Recurly
+  module Resources
+    class DunningRetrySettings < Resource
+
+      # @!attribute double_tap
+      #   @return [Boolean] Whether to enable double-tap retries at the start of the window. Absence or null means off.
+      define_attribute :double_tap, :Boolean
+
+      # @!attribute front_load_days
+      #   @return [Integer] Number of days to front-load retries at the beginning of the window. Absence, null, or 0 means off.
+      define_attribute :front_load_days, Integer
+
+      # @!attribute max_attempts
+      #   @return [Integer] Total number of retry attempts across the dunning window. Defaults to 20.
+      define_attribute :max_attempts, Integer
+
+      # @!attribute max_retries
+      #   @return [Integer] Maximum number of decline retries before the invoice is failed. Defaults to 10.
+      define_attribute :max_retries, Integer
+    end
+  end
+end

--- a/lib/recurly/version.rb
+++ b/lib/recurly/version.rb
@@ -1,3 +1,3 @@
 module Recurly
-  VERSION = "4.80.0"
+  VERSION = "4.80.1"
 end


### PR DESCRIPTION
Adds the operation, DunningCampaignUpdate/DunningRetrySettings request and resource classes, and DunningCycle#retry_settings, so the gem supports the new PUT /dunning_campaigns/{id} retry_settings endpoint. 