### PR TITLE
Add pull_request trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
-on: [push]
-concurrency: 
-  group: ${{ github.ref }}
+on:
+  push:
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add `pull_request` to the CI workflow trigger alongside `push`, so pull requests (including from forks) get CI runs that maintainers can approve directly from the PR's checks tab.
- Scope the concurrency group by workflow name to avoid any cross-event collisions now that two event types feed the same workflow.

## Why
Previously CI only ran on `push`, so PRs opened from forks had no workflow run to approve — the workaround was pushing the fork's commit to a local branch on this repo just to trigger CI. `pull_request` runs use the fork's code in an isolated context with no secrets, so this is safe to enable directly.

## Test plan
- [ ] Confirm CI runs automatically on this PR
- [ ] Confirm a repo admin still sees an approval gate for outside-contributor PRs if "Fork pull request workflows require approval" is enabled in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)